### PR TITLE
重构生成默认子路径/子域名相关代码，消除重复的算法逻辑

### DIFF
--- a/apiserver/paasng/paasng/engine/controller/models.py
+++ b/apiserver/paasng/paasng/engine/controller/models.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+from itertools import chain
 from operator import attrgetter
 from typing import List
 
@@ -56,6 +57,17 @@ class IngressConfig:
     def __attrs_post_init__(self):
         self.app_root_domains = sorted(self.app_root_domains, key=attrgetter("reserved"))
         self.sub_path_domains = sorted(self.sub_path_domains, key=attrgetter("reserved"))
+
+    def find_https_enabled(self, host: str) -> bool:
+        """Find "https-enabled" status by looping over all configured domains,
+        return false if no matched domains can be found by given host.
+
+        :param host: Any valid host name
+        """
+        for d in chain(self.app_root_domains, self.sub_path_domains):
+            if d.name == host:
+                return d.https_enabled
+        return False
 
     @property
     def default_root_domain(self) -> Domain:

--- a/apiserver/paasng/paasng/engine/controller/models.py
+++ b/apiserver/paasng/paasng/engine/controller/models.py
@@ -16,9 +16,8 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-from itertools import chain
 from operator import attrgetter
-from typing import List
+from typing import List, Optional
 
 from attrs import Factory, asdict, define
 
@@ -58,16 +57,25 @@ class IngressConfig:
         self.app_root_domains = sorted(self.app_root_domains, key=attrgetter("reserved"))
         self.sub_path_domains = sorted(self.sub_path_domains, key=attrgetter("reserved"))
 
-    def find_https_enabled(self, host: str) -> bool:
-        """Find "https-enabled" status by looping over all configured domains,
-        return false if no matched domains can be found by given host.
+    def find_subdomain_domain(self, host: str) -> Optional[Domain]:
+        """Find domain object in configured sub-domains by given host.
 
         :param host: Any valid host name
         """
-        for d in chain(self.app_root_domains, self.sub_path_domains):
+        for d in self.app_root_domains:
             if d.name == host:
-                return d.https_enabled
-        return False
+                return d
+        return None
+
+    def find_subpath_domain(self, host: str) -> Optional[Domain]:
+        """Find domain object in configured sub-path domains by given host.
+
+        :param host: Any valid host name
+        """
+        for d in self.sub_path_domains:
+            if d.name == host:
+                return d
+        return None
 
     @property
     def default_root_domain(self) -> Domain:

--- a/apiserver/paasng/paasng/publish/entrance/domains.py
+++ b/apiserver/paasng/paasng/publish/entrance/domains.py
@@ -22,11 +22,11 @@ from typing import Dict, List, NamedTuple, Optional
 
 from blue_krill.data_types.enum import EnumField, StructuredEnum
 
+from paasng.engine.constants import AppEnvName
 from paasng.engine.controller.cluster import get_engine_app_cluster
 from paasng.engine.controller.models import Domain as DomainCfg
 from paasng.engine.controller.models import IngressConfig, PortMap
 from paasng.platform.applications.models import ModuleEnvironment
-from paasng.engine.constants import AppEnvName
 from paasng.publish.entrance.utils import URL, to_dns_safe
 
 
@@ -137,7 +137,8 @@ class ModuleEnvDomains:
             return None
 
         # Make a virtual domain config and use it to get the domain object
-        cfg = DomainCfg(name=host, https_enabled=self.ingress_config.find_https_enabled(host))
+        d = self.ingress_config.find_subdomain_domain(host)
+        cfg = DomainCfg(name=host, https_enabled=d.https_enabled if d else False)
         domain = self.allocator.get_highest_priority(
             cfg, self.env.module.name, self.env.environment, self.env.module.is_default
         )

--- a/apiserver/paasng/paasng/publish/entrance/domains.py
+++ b/apiserver/paasng/paasng/publish/entrance/domains.py
@@ -23,9 +23,13 @@ from typing import Dict, List, NamedTuple, Optional
 from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 from paasng.engine.controller.cluster import get_engine_app_cluster
+from paasng.engine.controller.models import Domain as DomainCfg
 from paasng.engine.controller.models import IngressConfig, PortMap
+from paasng.platform.applications.constants import AppEnvironment
 from paasng.platform.applications.models import ModuleEnvironment
 from paasng.publish.entrance.utils import URL, to_dns_safe
+
+PROD_ENV_NAME = AppEnvironment.PRODUCTION.value
 
 
 class DomainPriorityType(int, StructuredEnum):
@@ -88,137 +92,138 @@ def get_preallocated_domain(
     if not ingress_config.app_root_domains:
         return None
 
-    safe_app_code = to_dns_safe(app_code)
+    allocator = SubDomainAllocator(app_code, ingress_config.port_map)
+    domain_cfg = ingress_config.default_root_domain
     if not module_name:
         return PreDomains(
-            stag=Domain(
-                host=ModuleEnvDomains.make_host(ingress_config.default_root_domain.name, 'stag', safe_app_code),
-                https_enabled=ingress_config.default_root_domain.https_enabled,
-                type=DomainPriorityType.WITHOUT_MODULE,
-                port_map=ingress_config.port_map,
-            ),
-            prod=Domain(
-                host=ModuleEnvDomains.make_host(ingress_config.default_root_domain.name, safe_app_code),
-                https_enabled=ingress_config.default_root_domain.https_enabled,
-                type=DomainPriorityType.ONLY_CODE,
-                port_map=ingress_config.port_map,
-            ),
+            stag=allocator.for_default_module(domain_cfg, 'stag'),
+            prod=allocator.for_default_module_prod_env(domain_cfg),
         )
     else:
-        safe_module_name = to_dns_safe(module_name)
         return PreDomains(
-            stag=Domain(
-                host=ModuleEnvDomains.make_host(
-                    ingress_config.default_root_domain.name, 'stag', safe_module_name, safe_app_code
-                ),
-                https_enabled=ingress_config.default_root_domain.https_enabled,
-                type=DomainPriorityType.STABLE,
-                port_map=ingress_config.port_map,
-            ),
-            prod=Domain(
-                host=ModuleEnvDomains.make_host(
-                    ingress_config.default_root_domain.name, 'prod', safe_module_name, safe_app_code
-                ),
-                https_enabled=ingress_config.default_root_domain.https_enabled,
-                type=DomainPriorityType.STABLE,
-                port_map=ingress_config.port_map,
-            ),
+            stag=allocator.for_universal(domain_cfg, module_name, 'stag'),
+            prod=allocator.for_universal(domain_cfg, module_name, 'prod'),
         )
 
 
 class ModuleEnvDomains:
     """managing domains for module environment"""
 
-    DOT_SEP = '-dot-'
-
     def __init__(self, env: ModuleEnvironment):
         self.env = env
         self.application = env.module.application
-        self.engine_app = env.engine_app
-
-        self.part_env = to_dns_safe(env.environment)
-        self.part_module = to_dns_safe(env.module.name)
-        self.part_code = to_dns_safe(self.application.code)
-
-        ingress_config = self.get_ingress_config()
-        self.root_domains = ingress_config.app_root_domains
-        self.port_map = ingress_config.port_map
+        self.ingress_config = self.get_ingress_config()
+        self.allocator = SubDomainAllocator(self.application.code, self.ingress_config.port_map)
 
     def get_ingress_config(self) -> IngressConfig:
         """Get ingress config from cluster info"""
-        cluster = get_engine_app_cluster(self.application.region, self.engine_app.name)
+        cluster = get_engine_app_cluster(self.application.region, self.env.engine_app.name)
         return cluster.ingress_config
 
     def all(self) -> List[Domain]:
         """Get all assigned domains for current env"""
-        if not self.root_domains:
+        root_domains = self.ingress_config.app_root_domains
+        if not root_domains:
             return []
 
-        domains = [*self.make_stable()]
-        if self.env.module.is_default:
-            domains.extend(self.make_without_module())
-
-            # Assign a shortest domain for "prod" environment of "default" module
-            if self.env.environment == 'prod':
-                domains.extend(self.make_only_code())
-
-        return domains
-
-    def make_stable(self) -> List[Domain]:
-        """Make all stable domain."""
-        return [
-            Domain(
-                host=self.make_host(domain.name, self.part_env, self.part_module, self.part_code),
-                type=DomainPriorityType.STABLE,
-                https_enabled=domain.https_enabled,
-                port_map=self.port_map,
-            )
-            for domain in self.root_domains
-        ]
-
-    def make_without_module(self) -> List[Domain]:
-        """Make all domain for default module."""
-        return [
-            Domain(
-                host=self.make_host(domain.name, self.part_env, self.part_code),
-                type=DomainPriorityType.WITHOUT_MODULE,
-                https_enabled=domain.https_enabled,
-                port_map=self.port_map,
-            )
-            for domain in self.root_domains
-        ]
-
-    def make_only_code(self) -> List[Domain]:
-        """Make all domain for default module prod env."""
-        return [
-            Domain(
-                host=self.make_host(domain.name, self.part_code),
-                type=DomainPriorityType.ONLY_CODE,
-                https_enabled=domain.https_enabled,
-                port_map=self.port_map,
-            )
-            for domain in self.root_domains
-        ]
+        return self.allocator.list_available(
+            root_domains, self.env.module.name, self.env.environment, self.env.module.is_default
+        )
 
     def make_user_preferred_one(self) -> Optional[Domain]:
-        """Make the domain with user prefer root domain"""
-        preferred = self.env.module.user_preferred_root_domain
-        if not preferred:
+        """Make a domain object with user prefer root domain, return None if no preferred
+        value was set.
+        """
+        host = self.env.module.user_preferred_root_domain
+        if not host:
             return None
 
-        parts = [self.part_env, self.part_module, self.part_code]
-        if self.env.module.is_default:
-            parts = [self.part_env, self.part_code]
-            if self.env.environment == "prod":
-                parts = [self.part_code]
+        # Make a virtual domain config and use it to get the domain object
+        cfg = DomainCfg(name=host, https_enabled=self.ingress_config.find_https_enabled(host))
+        domain = self.allocator.get_highest_priority(
+            cfg, self.env.module.name, self.env.environment, self.env.module.is_default
+        )
+        # Modify the domain type manually
+        domain.type = DomainPriorityType.USER_PREFERRED
+        return domain
+
+
+class SubDomainAllocator:
+    """Allocate domain objects
+
+    :param port_map: The PortMap config
+    """
+
+    DOT_SEP = '-dot-'
+
+    def __init__(self, app_code: str, port_map: PortMap):
+        self.app_code = app_code
+        self.port_map = port_map
+
+    def list_available(
+        self, domain_cfgs: List[DomainCfg], module_name: str, env_name: str, is_default: bool
+    ) -> List[Domain]:
+        """Get all available domain objects, the result was sorted by `DomainPriorityType`
+
+        :param domain_cfgs: A list of domain configs
+        :param module: Name of module
+        :param env_name: Name of environment, "stag" or "prod"
+        :param is_default: Whether current module is "default" module
+        """
+        domains = [self.for_universal(c, module_name, env_name) for c in domain_cfgs]
+        if is_default:
+            domains.extend([self.for_default_module(c, env_name) for c in domain_cfgs])
+            if env_name == PROD_ENV_NAME:
+                domains.extend([self.for_default_module_prod_env(c) for c in domain_cfgs])
+        return domains
+
+    def get_highest_priority(self, domain_cfg: DomainCfg, module_name: str, env_name: str, is_default: bool) -> Domain:
+        """Get the default Domain object for given environment, it will return
+        the object with the highest priority, see `DomainPriorityType` for more
+        details.
+        """
+        domains = self.list_available([domain_cfg], module_name, env_name, is_default)
+        return domains[-1]
+
+    def for_universal(self, domain_cfg: DomainCfg, module_name: str, env_name: str) -> Domain:
+        """Return a Domain object whose host depends on app_code, module and
+        environment name, suitable for all environments.
+
+        :param domain_cfg: Domain config object, usually defined in ingress config
+        :param module: Name of module
+        :param env_name: Name of environment, "stag" or "prod"
+        """
         return Domain(
-            host=self.make_host(preferred, *parts),
-            type=DomainPriorityType.USER_PREFERRED,
-            https_enabled=any(domain.name == preferred and domain.https_enabled for domain in self.root_domains),
+            host=self._make_host(domain_cfg.name, env_name, module_name, self.app_code),
+            type=DomainPriorityType.STABLE,
+            https_enabled=domain_cfg.https_enabled,
+            port_map=self.port_map,
+        )
+
+    def for_default_module(self, domain_cfg: DomainCfg, env_name: str) -> Domain:
+        """Return a Domain object whose host depends on app_code and environment name,
+        always bound to default module.
+        """
+        return Domain(
+            host=self._make_host(domain_cfg.name, env_name, self.app_code),
+            type=DomainPriorityType.WITHOUT_MODULE,
+            https_enabled=domain_cfg.https_enabled,
+            port_map=self.port_map,
+        )
+
+    def for_default_module_prod_env(self, domain_cfg: DomainCfg) -> Domain:
+        """Return a Domain object whose host depends on app_code only, always bound
+        to main module's prod environment.
+        """
+        return Domain(
+            host=self._make_host(domain_cfg.name, self.app_code),
+            type=DomainPriorityType.ONLY_CODE,
+            https_enabled=domain_cfg.https_enabled,
             port_map=self.port_map,
         )
 
     @classmethod
-    def make_host(cls, root_domain: str, *parts):
+    def _make_host(cls, root_domain: str, *parts: str):
         """Make a host name"""
-        return (cls.DOT_SEP.join(parts) + '.' + root_domain).lower()
+        safe_parts = [to_dns_safe(s) for s in parts]
+        return (cls.DOT_SEP.join(safe_parts) + '.' + root_domain).lower()

--- a/apiserver/paasng/paasng/publish/entrance/exposer.py
+++ b/apiserver/paasng/paasng/publish/entrance/exposer.py
@@ -421,11 +421,11 @@ def get_preallocated_address(
         cluster = helper.get_default_cluster()
 
     ingress_config = cluster.ingress_config
-    pre_subpathes = get_preallocated_path(app_code, ingress_config, module_name=module_name)
-    if pre_subpathes:
+    pre_subpaths = get_preallocated_path(app_code, ingress_config, module_name=module_name)
+    if pre_subpaths:
         return PreAddresses(
-            stag=pre_subpathes.stag.as_url().as_address(),
-            prod=pre_subpathes.prod.as_url().as_address(),
+            stag=pre_subpaths.stag.as_url().as_address(),
+            prod=pre_subpaths.prod.as_url().as_address(),
         )
 
     pre_subdomains = get_preallocated_domain(app_code, ingress_config, module_name=module_name)

--- a/apiserver/paasng/paasng/publish/entrance/subpaths.py
+++ b/apiserver/paasng/paasng/publish/entrance/subpaths.py
@@ -25,7 +25,7 @@ from django.conf import settings
 
 from paasng.engine.constants import AppEnvName
 from paasng.engine.controller.cluster import get_engine_app_cluster
-from paasng.engine.controller.models import IngressConfig, PortMap
+from paasng.engine.controller.models import IngressConfig, PortMap, Domain as DomainCfg
 from paasng.platform.applications.models import ModuleEnvironment
 from paasng.publish.entrance.utils import URL, to_dns_safe
 
@@ -93,73 +93,39 @@ def get_preallocated_path(
     if not ingress_config.sub_path_domains:
         return None
 
-    safe_app_code = to_dns_safe(app_code)
+    allocator = SubPathAllocator(app_code, ingress_config.port_map)
+    domain_cfg = ingress_config.default_sub_path_domain
     if not module_name:
         # No module name was given, return shorten address which pointed to application's "default" module
         # automatically.
         return PreSubpaths(
-            stag=Subpath(
-                subpath=ModuleEnvSubpaths.make_subpath('stag', safe_app_code),
-                host=ingress_config.default_sub_path_domain.name,
-                https_enabled=ingress_config.default_sub_path_domain.https_enabled,
-                type=SubpathPriorityType.WITHOUT_MODULE,
-                port_map=ingress_config.port_map,
-            ),
-            prod=Subpath(
-                subpath=f'/{safe_app_code}/',
-                host=ingress_config.default_sub_path_domain.name,
-                https_enabled=ingress_config.default_sub_path_domain.https_enabled,
-                type=SubpathPriorityType.ONLY_CODE,
-                port_map=ingress_config.port_map,
-            ),
+            stag=allocator.for_default_module(domain_cfg, 'stag'),
+            prod=allocator.for_default_module_prod_env(domain_cfg),
         )
     else:
         # Generate address which always include module name
-        safe_module_name = to_dns_safe(module_name)
         return PreSubpaths(
-            stag=Subpath(
-                subpath=ModuleEnvSubpaths.make_subpath('stag', safe_module_name, safe_app_code),
-                host=ingress_config.default_sub_path_domain.name,
-                https_enabled=ingress_config.default_sub_path_domain.https_enabled,
-                type=SubpathPriorityType.STABLE,
-                port_map=ingress_config.port_map,
-            ),
-            prod=Subpath(
-                subpath=ModuleEnvSubpaths.make_subpath('prod', safe_module_name, safe_app_code),
-                host=ingress_config.default_sub_path_domain.name,
-                https_enabled=ingress_config.default_sub_path_domain.https_enabled,
-                type=SubpathPriorityType.STABLE,
-                port_map=ingress_config.port_map,
-            ),
+            stag=allocator.for_universal(domain_cfg, module_name, 'stag'),
+            prod=allocator.for_universal(domain_cfg, module_name, 'prod'),
         )
 
 
 class ModuleEnvSubpaths:
     """managing subpaths for module environment"""
 
-    # Reserved word of application code, safe for concatenating address
-    sep = '--'
-
     def __init__(self, env: ModuleEnvironment):
         self.env = env
         self.application = env.module.application
-        self.engine_app = env.engine_app
-
-        self.part_env = to_dns_safe(env.environment)
-        self.part_module = to_dns_safe(env.module.name)
-        self.part_code = to_dns_safe(self.application.code)
-
-        ingress_config = self.get_ingress_config()
-        self.sub_path_domains = ingress_config.sub_path_domains
-        self.port_map = ingress_config.port_map
+        self.ingress_config = self.get_ingress_config()
+        self.allocator = SubPathAllocator(self.application.code, self.ingress_config.port_map)
 
     def get_ingress_config(self) -> IngressConfig:
         """Get ingress config from cluster info"""
-        cluster = get_engine_app_cluster(self.application.region, self.engine_app.name)
+        cluster = get_engine_app_cluster(self.application.region, self.env.engine_app.name)
         return cluster.ingress_config
 
     def get_shortest(self) -> Optional[Subpath]:
-        """Get the shorted subpath object"""
+        """Get the shortest subpath object"""
         subpaths = self.all()
         if not subpaths:
             return None
@@ -167,90 +133,36 @@ class ModuleEnvSubpaths:
 
     def all(self) -> List[Subpath]:
         """Get all assigned subpaths for current env"""
-        if not self.sub_path_domains:
+        sub_path_domains = self.ingress_config.sub_path_domains
+        if not sub_path_domains:
             return []
 
-        # TODO: Add legacy subpath
-        subpaths = [*self.make_stable()]
-        if self.env.module.is_default:
-            subpaths.extend(self.make_without_module())
-
-            # Assign a shortest domain for "prod" environment of "default" module
-            if self.env.environment == AppEnvName.PROD:
-                subpaths.extend(self.make_only_code())
-
-        return subpaths
-
-    def make_stable(self) -> List[Subpath]:
-        """Make all stable subpath."""
-        subpaths = [
-            self.make_subpath(self.part_env, self.part_module, self.part_code),
-        ]
-        if settings.USE_LEGACY_SUB_PATH_PATTERN:
-            subpaths.append(get_legacy_compatible_path(self.env))
-        results = []
-        for domain in self.sub_path_domains:
-            for subpath in subpaths:
-                results.append(
-                    Subpath(
-                        subpath=subpath,
-                        host=domain.name,
-                        type=SubpathPriorityType.STABLE,
-                        https_enabled=domain.https_enabled,
-                        port_map=self.port_map,
-                    )
-                )
-        return results
-
-    def make_without_module(self) -> List[Subpath]:
-        """Make all subpath for default module."""
-        return [
-            Subpath(
-                subpath=self.make_subpath(self.part_env, self.part_code),
-                host=domain.name,
-                type=SubpathPriorityType.WITHOUT_MODULE,
-                https_enabled=domain.https_enabled,
-                port_map=self.port_map,
-            )
-            for domain in self.sub_path_domains
-        ]
-
-    def make_only_code(self) -> List[Subpath]:
-        """Make all subpath for default module prod env."""
-        return [
-            Subpath(
-                subpath=self.make_subpath(self.part_code),
-                host=domain.name,
-                type=SubpathPriorityType.ONLY_CODE,
-                https_enabled=domain.https_enabled,
-                port_map=self.port_map,
-            )
-            for domain in self.sub_path_domains
-        ]
-
-    def make_user_preferred_one(self) -> Optional[Subpath]:
-        """Make the subpath with user prefer root domain"""
-        preferred = self.env.module.user_preferred_root_domain
-        if not preferred:
-            return None
-
-        parts = [self.part_env, self.part_module, self.part_code]
-        if self.env.module.is_default:
-            parts = [self.part_env, self.part_code]
-            if self.env.environment == "prod":
-                parts = [self.part_code]
-        return Subpath(
-            subpath=self.make_subpath(*parts),
-            host=preferred,
-            type=SubpathPriorityType.USER_PREFERRED,
-            https_enabled=any(domain.name == preferred and domain.https_enabled for domain in self.sub_path_domains),
-            port_map=self.port_map,
+        items = self.allocator.list_available(
+            sub_path_domains, self.env.module.name, self.env.environment, self.env.module.is_default
         )
 
-    @classmethod
-    def make_subpath(cls, *parts):
-        """Make a subpath"""
-        return '/{}/'.format(cls.sep.join(parts).lower())
+        # Add legacy subpaths if configured
+        if settings.USE_LEGACY_SUB_PATH_PATTERN:
+            legacy_path = get_legacy_compatible_path(self.env)
+            items.extend([self.allocator.make_stable_obj(c, legacy_path) for c in sub_path_domains])
+            # Sort items because legacy subpath obj has low priority type
+            items.sort(key=Subpath.sort_by_type)
+        return items
+
+    def make_user_preferred_one(self) -> Optional[Subpath]:
+        """Make the subpath with user preferred root domain"""
+        host = self.env.module.user_preferred_root_domain
+        if not host:
+            return None
+
+        # Make a virtual domain config, use it to get the domain object
+        cfg = DomainCfg(name=host, https_enabled=self.ingress_config.find_https_enabled(host))
+        p = self.allocator.get_highest_priority(
+            cfg, self.env.module.name, self.env.environment, self.env.module.is_default
+        )
+        # Modify the subpath type manually
+        p.type = SubpathPriorityType.USER_PREFERRED
+        return p
 
 
 def get_legacy_compatible_path(env: ModuleEnvironment) -> str:
@@ -260,3 +172,90 @@ def get_legacy_compatible_path(env: ModuleEnvironment) -> str:
     """
     name = env.engine_app.name
     return f'/{env.module.region}-{name}/'
+
+
+class SubPathAllocator:
+    """Allocate subpath objects
+
+    :param port_map: The PortMap config
+    """
+
+    # Reserved word of application code, safe for concatenating address
+    sep = '--'
+
+    def __init__(self, app_code: str, port_map: PortMap):
+        self.app_code = app_code
+        self.port_map = port_map
+
+    def list_available(
+        self, domain_cfgs: List[DomainCfg], module_name: str, env_name: str, is_default: bool
+    ) -> List[Subpath]:
+        """Get all available subpath objects, the result was sorted by type,
+        see `SubpathPriorityType` for more details
+
+        :param domain_cfgs: A list of domain configs
+        :param module: Name of module
+        :param env_name: Name of environment, "stag" or "prod"
+        :param is_default: Whether current module is "default" module
+        """
+        subpaths = [self.for_universal(c, module_name, env_name) for c in domain_cfgs]
+        if is_default:
+            subpaths.extend([self.for_default_module(c, env_name) for c in domain_cfgs])
+            if env_name == AppEnvName.PROD.value:
+                subpaths.extend([self.for_default_module_prod_env(c) for c in domain_cfgs])
+        return subpaths
+
+    def get_highest_priority(
+        self, domain_cfg: DomainCfg, module_name: str, env_name: str, is_default: bool
+    ) -> Subpath:
+        """Get the subpath object for given environment, it will return the object
+        with the highest priority, see `SubpathPriorityType` for more details.
+        """
+        subpaths = self.list_available([domain_cfg], module_name, env_name, is_default)
+        return subpaths[-1]
+
+    def for_universal(self, domain_cfg: DomainCfg, module_name: str, env_name: str) -> Subpath:
+        """Return subpath object whose value depends on app_code, module and
+        environment name, suitable for all environments.
+        """
+        return self.make_stable_obj(domain_cfg, self._make_subpath(env_name, module_name, self.app_code))
+
+    def for_default_module(self, domain_cfg: DomainCfg, env_name: str) -> Subpath:
+        """Return subpath object whose value depends on app_code and environment name,
+        always bound to default module.
+        """
+        return Subpath(
+            subpath=self._make_subpath(env_name, self.app_code),
+            host=domain_cfg.name,
+            type=SubpathPriorityType.WITHOUT_MODULE,
+            https_enabled=domain_cfg.https_enabled,
+            port_map=self.port_map,
+        )
+
+    def for_default_module_prod_env(self, domain_cfg: DomainCfg) -> Subpath:
+        """Return subpath object whose value depends on app_code only, always bound
+        to the default module's prod environment.
+        """
+        return Subpath(
+            subpath=self._make_subpath(self.app_code),
+            host=domain_cfg.name,
+            type=SubpathPriorityType.ONLY_CODE,
+            https_enabled=domain_cfg.https_enabled,
+            port_map=self.port_map,
+        )
+
+    def make_stable_obj(self, domain_cfg: DomainCfg, subpath: str) -> Subpath:
+        """Make a subpath object with "STABLE" type."""
+        return Subpath(
+            subpath=subpath,
+            host=domain_cfg.name,
+            type=SubpathPriorityType.STABLE,
+            https_enabled=domain_cfg.https_enabled,
+            port_map=self.port_map,
+        )
+
+    @classmethod
+    def _make_subpath(cls, *parts: str) -> str:
+        """Make a subpath"""
+        safe_parts = [to_dns_safe(p) for p in parts]
+        return '/{}/'.format(cls.sep.join(safe_parts).lower())

--- a/apiserver/paasng/paasng/publish/entrance/subpaths.py
+++ b/apiserver/paasng/paasng/publish/entrance/subpaths.py
@@ -25,7 +25,8 @@ from django.conf import settings
 
 from paasng.engine.constants import AppEnvName
 from paasng.engine.controller.cluster import get_engine_app_cluster
-from paasng.engine.controller.models import IngressConfig, PortMap, Domain as DomainCfg
+from paasng.engine.controller.models import Domain as DomainCfg
+from paasng.engine.controller.models import IngressConfig, PortMap
 from paasng.platform.applications.models import ModuleEnvironment
 from paasng.publish.entrance.utils import URL, to_dns_safe
 
@@ -156,7 +157,8 @@ class ModuleEnvSubpaths:
             return None
 
         # Make a virtual domain config, use it to get the domain object
-        cfg = DomainCfg(name=host, https_enabled=self.ingress_config.find_https_enabled(host))
+        d = self.ingress_config.find_subpath_domain(host)
+        cfg = DomainCfg(name=host, https_enabled=d.https_enabled if d else False)
         p = self.allocator.get_highest_priority(
             cfg, self.env.module.name, self.env.environment, self.env.module.is_default
         )

--- a/apiserver/paasng/tests/engine/controller/test_models.py
+++ b/apiserver/paasng/tests/engine/controller/test_models.py
@@ -1,23 +1,29 @@
 import cattr
-import pytest
 
 from paasng.engine.controller.models import IngressConfig
 
 
-@pytest.mark.parametrize(
-    'host,ret',
-    [
-        ('foo-1.example.com', False),
-        ('foo-2.example.com', True),
-        ('bar.example.com', False),
-    ],
-)
-def test_find_https_enabled(host, ret):
+def test_find_subdomain_domain():
     ing_cfg = cattr.structure(
         {
-            'app_root_domains': [{"name": 'foo-1.example.com', 'https_enabled': False}],
-            'sub_path_domains': [{"name": 'foo-2.example.com', 'https_enabled': True}],
+            'app_root_domains': [{"name": 'foo-1.example.com', 'https_enabled': True}],
         },
         IngressConfig,
     )
-    assert ing_cfg.find_https_enabled(host) is ret
+    d = ing_cfg.find_subdomain_domain('foo-1.example.com')
+    assert d is not None
+    assert d.https_enabled is True
+    assert ing_cfg.find_subdomain_domain('foo-2.example.com') is None
+
+
+def test_find_subpath_domain():
+    ing_cfg = cattr.structure(
+        {
+            'sub_path_domains': [{"name": 'foo-1.example.com', 'https_enabled': True}],
+        },
+        IngressConfig,
+    )
+    d = ing_cfg.find_subpath_domain('foo-1.example.com')
+    assert d is not None
+    assert d.https_enabled is True
+    assert ing_cfg.find_subpath_domain('bar.example.com') is None

--- a/apiserver/paasng/tests/engine/controller/test_models.py
+++ b/apiserver/paasng/tests/engine/controller/test_models.py
@@ -1,0 +1,23 @@
+import cattr
+import pytest
+
+from paasng.engine.controller.models import IngressConfig
+
+
+@pytest.mark.parametrize(
+    'host,ret',
+    [
+        ('foo-1.example.com', False),
+        ('foo-2.example.com', True),
+        ('bar.example.com', False),
+    ],
+)
+def test_find_https_enabled(host, ret):
+    ing_cfg = cattr.structure(
+        {
+            'app_root_domains': [{"name": 'foo-1.example.com', 'https_enabled': False}],
+            'sub_path_domains': [{"name": 'foo-2.example.com', 'https_enabled': True}],
+        },
+        IngressConfig,
+    )
+    assert ing_cfg.find_https_enabled(host) is ret

--- a/apiserver/paasng/tests/publish/entrance/test_domains.py
+++ b/apiserver/paasng/tests/publish/entrance/test_domains.py
@@ -21,8 +21,15 @@ to the current version of the project delivered to anyone in the future.
 import cattr
 import pytest
 
-from paasng.engine.controller.models import IngressConfig
-from paasng.publish.entrance.domains import get_preallocated_domain
+from paasng.engine.controller.models import Domain as DomainCfg
+from paasng.engine.controller.models import IngressConfig, PortMap
+from paasng.publish.entrance.domains import (
+    DomainPriorityType,
+    ModuleEnvDomains,
+    SubDomainAllocator,
+    get_preallocated_domain,
+)
+from tests.utils.mocks.engine import replace_cluster_service
 
 pytestmark = pytest.mark.django_db
 
@@ -78,3 +85,143 @@ class TestGetPreallocatedDomain:
         assert domain
         assert domain.stag.as_url().as_address() == 'http://stag-dot-api-dot-test-code.example.com'
         assert domain.prod.as_url().as_address() == 'http://prod-dot-api-dot-test-code.example.com'
+
+
+@pytest.fixture()
+def bk_app(bk_app):
+    bk_app.code = 'some-app-o'
+    bk_app.name = "some-app-o"
+    bk_app.save()
+    return bk_app
+
+
+@pytest.fixture(autouse=True)
+def setup_cluster():
+    """Replace cluster info in module level"""
+    with replace_cluster_service(
+        ingress_config={
+            'app_root_domains': [{"name": 'bar-1.example.com'}],
+        }
+    ):
+        yield
+
+
+class TestModuleEnvDomains:
+    def test_prod_default(self, bk_prod_env, bk_module):
+        domains = ModuleEnvDomains(bk_prod_env).all()
+        assert [d.host for d in domains] == [
+            'prod-dot-default-dot-some-app-o.bar-1.example.com',
+            'prod-dot-some-app-o.bar-1.example.com',
+            'some-app-o.bar-1.example.com',
+        ]
+
+    def test_stag_default(self, bk_stag_env):
+        domains = ModuleEnvDomains(bk_stag_env).all()
+        assert [d.host for d in domains] == [
+            'stag-dot-default-dot-some-app-o.bar-1.example.com',
+            'stag-dot-some-app-o.bar-1.example.com',
+        ]
+
+    def test_stag_non_default(self, bk_module, bk_stag_env):
+        bk_module.is_default = False
+        bk_module.save()
+
+        domains = ModuleEnvDomains(bk_stag_env).all()
+        assert [d.host for d in domains] == [
+            'stag-dot-default-dot-some-app-o.bar-1.example.com',
+        ]
+
+    @pytest.mark.parametrize("https_enabled, expected_scheme", ((True, "https"), (False, "http")))
+    def test_enable_https_by_default(self, https_enabled, expected_scheme, bk_stag_env):
+        with replace_cluster_service(
+            ingress_config={'app_root_domains': [{'name': 'example.com', 'https_enabled': https_enabled}]}
+        ):
+            domains = ModuleEnvDomains(bk_stag_env).all()
+            assert domains[0].https_enabled == https_enabled
+            assert domains[0].as_url().protocol == expected_scheme
+
+
+class TestModuleEnvDomainsCodeWithUnderscore:
+    @pytest.fixture()
+    def bk_app(self, bk_app):
+        bk_app.code = 'some_app'
+        bk_app.save()
+        return bk_app
+
+    def test_prod_default(self, bk_app, bk_module):
+        env = bk_module.envs.get(environment='prod')
+        domains = ModuleEnvDomains(env).all()
+        assert [d.host for d in domains] == [
+            'prod-dot-default-dot-some--app.bar-1.example.com',
+            'prod-dot-some--app.bar-1.example.com',
+            'some--app.bar-1.example.com',
+        ]
+
+
+class TestMakeUserPreferredOne:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        with replace_cluster_service(
+            ingress_config={
+                'app_root_domains': [
+                    {"name": 'bar-1.example.com'},
+                    {"name": 'bar-2.example.com', 'https_enabled': True},
+                ],
+            }
+        ):
+            yield
+
+    @pytest.mark.parametrize(
+        'host,https_enabled',
+        [
+            ('bar-1.example.com', False),
+            ('bar-2.example.com', True),
+        ],
+    )
+    def test_https_enabled(self, bk_prod_env, host, https_enabled):
+        bk_prod_env.module.user_preferred_root_domain = host
+        bk_prod_env.module.save()
+
+        d = ModuleEnvDomains(bk_prod_env).make_user_preferred_one()
+        assert d is not None
+        assert d.host == f'some-app-o.{host}'
+        assert d.https_enabled is https_enabled
+        assert d.type == DomainPriorityType.USER_PREFERRED
+
+
+class TestSubDomainAllocator:
+    @pytest.fixture
+    def allocator(self) -> SubDomainAllocator:
+        return SubDomainAllocator('some-app', PortMap())
+
+    @pytest.fixture
+    def domain_cfg(self) -> DomainCfg:
+        return DomainCfg(name='example.com', https_enabled=True)
+
+    def test_list_available_universal(self, bk_app, allocator, domain_cfg):
+        domains = allocator.list_available([domain_cfg], 'm1', 'stag', is_default=False)
+        assert [d.host for d in domains] == ['stag-dot-m1-dot-some-app.example.com']
+
+    def test_list_available_default(self, bk_app, allocator, domain_cfg):
+        domains = allocator.list_available([domain_cfg], 'm1', 'prod', is_default=True)
+        assert [d.host for d in domains] == [
+            'prod-dot-m1-dot-some-app.example.com',
+            'prod-dot-some-app.example.com',
+            'some-app.example.com',
+        ]
+
+    def test_get_highest_priority_universal(self, bk_app, allocator, domain_cfg):
+        domain = allocator.get_highest_priority(domain_cfg, 'm1', 'stag', is_default=False)
+        assert domain.host == 'stag-dot-m1-dot-some-app.example.com'
+        assert domain.type == DomainPriorityType.STABLE
+        assert domain.https_enabled is True
+
+    def test_get_highest_priority_default(self, bk_app, allocator, domain_cfg):
+        domain = allocator.get_highest_priority(domain_cfg, 'm1', 'stag', is_default=True)
+        assert domain.host == 'stag-dot-some-app.example.com'
+        assert domain.type == DomainPriorityType.WITHOUT_MODULE
+
+    def test_get_highest_priority_default_prod(self, allocator, domain_cfg):
+        domain = allocator.get_highest_priority(domain_cfg, 'm1', 'prod', is_default=True)
+        assert domain.host == 'some-app.example.com'
+        assert domain.type == DomainPriorityType.ONLY_CODE

--- a/workloads/paas_wl/paas_wl/cnative/specs/addresses.py
+++ b/workloads/paas_wl/paas_wl/cnative/specs/addresses.py
@@ -56,7 +56,7 @@ def save_addresses(env: ModuleEnv) -> Set[EngineApp]:
     subdomains and subpaths.
 
     :return: Affected engine apps, "affected" means the app's domains or
-    paths were updated during this save operation.
+        paths were updated during this save operation.
     """
     engine_app = EngineApp.objects.get_by_env(env)
     addresses = get_plat_client().get_addresses(env.application.code, env.environment)


### PR DESCRIPTION
- 增加 `*Allocator` 类型，汇聚子路径和子域名生成逻辑，消除重复
- 增加 `make_user_preferred_one` 相关的单元测试代码