### PR TITLE
enhance: 将应用描述文件解析失败的信息暴露给用户

### DIFF
--- a/apiserver/paasng/paasng/engine/deploy/building.py
+++ b/apiserver/paasng/paasng/engine/deploy/building.py
@@ -43,7 +43,7 @@ from paasng.engine.deploy.preparations import (
 )
 from paasng.engine.models.phases import DeployPhaseTypes
 from paasng.engine.signals import post_phase_end, pre_appenv_build, pre_phase_start
-from paasng.extensions.declarative.exceptions import ControllerError
+from paasng.extensions.declarative.exceptions import ControllerError, DescriptionValidationError
 from paasng.extensions.declarative.handlers import AppDescriptionHandler
 from paasng.platform.applications.constants import AppFeatureFlag
 from paasng.platform.modules.models.module import Module
@@ -65,13 +65,14 @@ class ApplicationBuilder(DeployStep):
             self.handle_app_description()
         except FileNotFoundError:
             logger.debug("App description file not defined, do not process.")
+        except DescriptionValidationError as e:
+            self.stream.write_message(Style.Error(_("应用描述文件解析异常: {}").format(e.message)))
+            logger.exception("Exception while parsing app description file, skip.")
         except ControllerError as e:
             self.stream.write_message(Style.Error(e.message))
             logger.exception("Exception while processing app description file, skip.")
         except Exception:
-            self.stream.write_message(
-                Style.Error("An exception occurred while processing the app_desc.yaml file, please check.")
-            )
+            self.stream.write_message(Style.Error(_("处理应用描述文件时出现异常, 请检查应用描述文件")))
             logger.exception("Exception while processing app description file, skip.")
 
         # TODO: 改造提示信息&错误信息都需要入库

--- a/apiserver/paasng/paasng/engine/deploy/image.py
+++ b/apiserver/paasng/paasng/engine/deploy/image.py
@@ -29,7 +29,7 @@ from paasng.engine.deploy.pre_release import ApplicationPreReleaseExecutor
 from paasng.engine.deploy.preparations import get_app_description_handler, get_processes
 from paasng.engine.models import DeployPhaseTypes
 from paasng.engine.signals import post_phase_end, pre_phase_start
-from paasng.extensions.declarative.exceptions import ControllerError
+from paasng.extensions.declarative.exceptions import ControllerError, DescriptionValidationError
 from paasng.extensions.declarative.handlers import AppDescriptionHandler
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,9 @@ class ImageReleaseMgr(DeployStep):
             self.handle_app_description()
         except FileNotFoundError:
             logger.debug("App description file not defined, do not process.")
+        except DescriptionValidationError as e:
+            self.stream.write_message(Style.Error(_("应用描述文件解析异常: {}").format(e.message)))
+            logger.exception("Exception while parsing app description file, skip.")
         except ControllerError as e:
             self.stream.write_message(Style.Error(e.message))
             logger.exception("Exception while processing app description file, skip.")


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/app/paasng/extensions/declarative/handlers.py", line 147, in handle_deployment
    controller.perform_action(self.get_deploy_desc(deployment.app_environment.module.name))
  File "/app/paasng/extensions/declarative/handlers.py", line 121, in get_deploy_desc
    raise DescriptionValidationError({"module": _('内容不能为空')})
```

例如, 以上异常会打印  `应用描述文件解析异常: module: 内容不能为空`