### PR TITLE
Fix unittests failing in Kubernete 1.18

### DIFF
--- a/workloads/paas_wl/paas_wl/cnative/specs/resource.py
+++ b/workloads/paas_wl/paas_wl/cnative/specs/resource.py
@@ -107,7 +107,7 @@ def deploy_networking(env: ModuleEnv) -> None:
         crd.DomainGroupMapping(client).create_or_update(
             mapping.metadata.name,
             namespace=engine_app.namespace,
-            body=mapping.dict(),
+            body=mapping.to_deployable(),
             update_method='patch',
             content_type='application/merge-patch+json',
         )

--- a/workloads/paas_wl/paas_wl/cnative/specs/v1alpha1/bk_app.py
+++ b/workloads/paas_wl/paas_wl/cnative/specs/v1alpha1/bk_app.py
@@ -145,4 +145,6 @@ class BkAppResource(BaseModel):
 
     def to_deployable(self) -> Dict:
         """Return the deployable manifest, some fields are excluded."""
-        return self.dict(exclude={"status"})
+        # Set `exclude_none` to remove all fields whose value is `None` because
+        # entries such as `"hooks": null` is not processable in Kubernetes 1.18.
+        return self.dict(exclude_none=True, exclude={"status"})

--- a/workloads/paas_wl/paas_wl/cnative/specs/v1alpha1/domain_group_mapping.py
+++ b/workloads/paas_wl/paas_wl/cnative/specs/v1alpha1/domain_group_mapping.py
@@ -17,7 +17,7 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 """Resource Definition of `DomainGroupMapping` kind"""
-from typing import List, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 from pydantic import BaseModel, validator
 
@@ -81,3 +81,7 @@ class DomainGroupMapping(BaseModel):
         if v != ApiVersion.V1ALPHA1:
             raise ValueError(f'{v} is not valid, use {ApiVersion.V1ALPHA1}')
         return v
+
+    def to_deployable(self) -> Dict:
+        """Return the deployable manifest, none fields are excluded."""
+        return self.dict(exclude_none=True)


### PR DESCRIPTION
Fix unittests failing in Kubernete 1.18 by removing null fields in CRD when being applid to cluster. 