### PR TITLE
bugfix: 修复增强服务环境变量不支持 int 类型的问题

### DIFF
--- a/apiserver/paasng/paasng/plat_admin/system/serializers.py
+++ b/apiserver/paasng/paasng/plat_admin/system/serializers.py
@@ -113,3 +113,7 @@ class ModuleEnvBasicSLZ(serializers.ModelSerializer):
     class Meta:
         model = ModuleEnvironment
         fields = ['id', 'environment', 'module_id', 'engine_app_id', 'is_offlined']
+
+
+class AddonCredentialsSLZ(serializers.Serializer):
+    credentials = serializers.DictField(child=serializers.CharField())

--- a/apiserver/paasng/paasng/plat_admin/system/views.py
+++ b/apiserver/paasng/paasng/plat_admin/system/views.py
@@ -41,6 +41,7 @@ from paasng.plat_admin.system.applications import (
     query_uni_apps_by_username,
 )
 from paasng.plat_admin.system.serializers import (
+    AddonCredentialsSLZ,
     AppBasicSLZ,
     ContactInfo,
     ModuleBasicSLZ,
@@ -137,7 +138,7 @@ class SysAddonsAPIViewSet(ApplicationCodeInPathMixin, viewsets.ViewSet):
         credentials = mixed_service_mgr.get_env_vars(engine_app=engine_app, service=svc)
         if not credentials:
             raise error_codes.CANNOT_READ_INSTANCE_INFO.f(_("无法获取到有效的配置信息."))
-        return Response(data={"credentials": credentials})
+        return Response(data=AddonCredentialsSLZ({"credentials": credentials}).data)
 
     @swagger_auto_schema(tags=["SYSTEMAPI"])
     @site_perm_required(SiteAction.SYSAPI_READ_SERVICES)

--- a/operator/hack/boilerplate.go.txt
+++ b/operator/hack/boilerplate.go.txt
@@ -1,10 +1,11 @@
 /*
  * TencentBlueKing is pleased to support the open source community by making
  * 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+ * Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
  * Licensed under the MIT License (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *
- * 	http://opensource.org/licenses/MIT
+ *	http://opensource.org/licenses/MIT
  *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,

--- a/operator/pkg/controllers/resources/configuration.go
+++ b/operator/pkg/controllers/resources/configuration.go
@@ -76,7 +76,7 @@ func retrieveAddonEnvVar(bkapp *v1alpha1.BkApp) []corev1.EnvVar {
 			continue
 		}
 		for key, value := range instance.Credentials {
-			envs = append(envs, corev1.EnvVar{Name: key, Value: value})
+			envs = append(envs, corev1.EnvVar{Name: key, Value: value.String()})
 		}
 	}
 	return envs

--- a/operator/pkg/platform/external/addons.go
+++ b/operator/pkg/platform/external/addons.go
@@ -23,12 +23,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // AddonInstance define the structure return from QueryAddonInstance API
 type AddonInstance struct {
 	// Credentials contains the EnvVar offered by the AddonInstance
-	Credentials map[string]string `json:"credentials"`
+	Credentials map[string]intstr.IntOrString `json:"credentials"`
 }
 
 // QueryAddonInstance 调用 bkpaas 对应的接口, 查询应用的增强服务实例

--- a/operator/pkg/platform/external/addons_test.go
+++ b/operator/pkg/platform/external/addons_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var _ = Describe("TestClient", func() {
@@ -43,20 +44,34 @@ var _ = Describe("TestClient", func() {
 			}
 			Expect(instance).To(Equal(expectedInstance))
 		},
-		Entry("addon found and get 1 extra envs", func(req *http.Request) *http.Response {
+		Entry("addon found and get 1 extra envs(string)", func(req *http.Request) *http.Response {
 			return &http.Response{
 				StatusCode: 200,
 				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"credentials": {"FAKE_FOO": "FOO"}}`)),
 				Header:     make(http.Header),
 			}
-		}, AddonInstance{Credentials: map[string]string{"FAKE_FOO": "FOO"}}, nil),
+		}, AddonInstance{Credentials: map[string]intstr.IntOrString{"FAKE_FOO": intstr.Parse("FOO")}}, nil),
+		Entry("addon found and get 1 extra envs(int)", func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"credentials": {"FAKE_FOO": 1}}`)),
+				Header:     make(http.Header),
+			}
+		}, AddonInstance{Credentials: map[string]intstr.IntOrString{"FAKE_FOO": intstr.FromInt(1)}}, nil),
+		Entry("addon found and get 1 extra envs(string-int)", func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"credentials": {"FAKE_FOO": "1"}}`)),
+				Header:     make(http.Header),
+			}
+		}, AddonInstance{Credentials: map[string]intstr.IntOrString{"FAKE_FOO": intstr.FromString("1")}}, nil),
 		Entry("addon found but no extra envs", func(req *http.Request) *http.Response {
 			return &http.Response{
 				StatusCode: 200,
 				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"credentials": {}}`)),
 				Header:     make(http.Header),
 			}
-		}, AddonInstance{Credentials: map[string]string{}}, nil),
+		}, AddonInstance{Credentials: map[string]intstr.IntOrString{}}, nil),
 		Entry("addon not found!", func(req *http.Request) *http.Response {
 			return &http.Response{
 				StatusCode: 404,


### PR DESCRIPTION
根据约定 query_credentials 应该返回的是 Dict[str, str], 但是目前来看这个约定被 GCS-MySQL 这个增强服务打破了。

这个 MR 从两个方面修复这个问题:
- apiserver 添加 slz 做类型转换，保证接口符合约定
- operator 加上对 int 类型的支持, 修复线上问题
