### PR TITLE
Refactor "exposer" module, use live addresses instead of fixed URLs generated by *Provider

### DIFF
--- a/apiserver/paasng/paasng/engine/display_blocks.py
+++ b/apiserver/paasng/paasng/engine/display_blocks.py
@@ -149,9 +149,9 @@ class AccessInfo(DisplayBlock):
 
     @classmethod
     def get_detail(cls, engine_app: 'EngineApp') -> dict:
-        from paasng.publish.entrance.exposer import get_default_access_entrance
+        from paasng.publish.entrance.exposer import get_preallocated_url
 
-        info = get_default_access_entrance(module_env=engine_app.env, include_no_running=True)
+        info = get_preallocated_url(engine_app.env)
         if info is None:
             return {}
 

--- a/apiserver/paasng/paasng/engine/views.py
+++ b/apiserver/paasng/paasng/engine/views.py
@@ -100,12 +100,7 @@ from paasng.platform.environments.exceptions import RoleNotAllowError
 from paasng.platform.environments.utils import env_role_protection_check
 from paasng.platform.modules.helpers import get_module_cluster
 from paasng.platform.modules.models import Module
-from paasng.publish.entrance.exposer import (
-    get_default_access_entrance,
-    get_exposed_url,
-    get_exposed_url_live,
-    get_live_addresses,
-)
+from paasng.publish.entrance.exposer import get_deployed_status, get_exposed_url, get_preallocated_url
 from paasng.utils.datetime import calculate_gap_seconds_interval, get_time_delta
 from paasng.utils.error_codes import error_codes
 from paasng.utils.views import allow_resp_patch
@@ -151,7 +146,7 @@ class ReleasedInfoViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
         serializer = self.serializer_class(request.query_params)
 
         offline_data = None
-        default_access_entrance = get_default_access_entrance(module_env, include_no_running=True)
+        default_access_entrance = get_preallocated_url(module_env)
 
         if module_env.is_offlined:
             try:
@@ -161,16 +156,10 @@ class ReleasedInfoViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
             offline_data = OfflineOperationSLZ(offline_operation).data
 
         # Check if current env is running
-        addrs = get_live_addresses(module_env.module)
-        if not addrs.get_is_running(module_env.environment):
+        if not get_deployed_status(module_env.module).get(module_env.environment, False):
             raise error_codes.APP_NOT_RELEASED
 
-        # TODO: Use get_exposed_url_live universally after some refactor
         exposed_link = get_exposed_url(module_env)
-        if not exposed_link:
-            # Get link for cloud-native applications
-            exposed_link = get_exposed_url_live(module_env)
-
         data = {
             "is_offlined": module_env.is_offlined,
             'deployment': self.get_deployment_data(module_env),

--- a/apiserver/paasng/paasng/engine/views.py
+++ b/apiserver/paasng/paasng/engine/views.py
@@ -100,7 +100,7 @@ from paasng.platform.environments.exceptions import RoleNotAllowError
 from paasng.platform.environments.utils import env_role_protection_check
 from paasng.platform.modules.helpers import get_module_cluster
 from paasng.platform.modules.models import Module
-from paasng.publish.entrance.exposer import get_deployed_status, get_exposed_url, get_preallocated_url
+from paasng.publish.entrance.exposer import env_is_deployed, get_exposed_url, get_preallocated_url
 from paasng.utils.datetime import calculate_gap_seconds_interval, get_time_delta
 from paasng.utils.error_codes import error_codes
 from paasng.utils.views import allow_resp_patch
@@ -156,7 +156,7 @@ class ReleasedInfoViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
             offline_data = OfflineOperationSLZ(offline_operation).data
 
         # Check if current env is running
-        if not get_deployed_status(module_env.module).get(module_env.environment, False):
+        if not env_is_deployed(module_env):
             raise error_codes.APP_NOT_RELEASED
 
         exposed_link = get_exposed_url(module_env)

--- a/apiserver/paasng/paasng/platform/applications/models.py
+++ b/apiserver/paasng/paasng/platform/applications/models.py
@@ -540,13 +540,9 @@ class ApplicationFeatureFlag(TimestampedModel):
 
 def get_exposed_links(application: Application) -> Dict:
     """Return exposed links for default module"""
-    from paasng.publish.entrance.exposer import get_module_exposed_links, get_module_exposed_links_live
+    from paasng.publish.entrance.exposer import get_module_exposed_links
 
-    # TODO: use get_module_exposed_links_live universally after refactor
-    if application.type == ApplicationType.CLOUD_NATIVE:
-        return get_module_exposed_links_live(application.get_default_module())
-    else:
-        return get_module_exposed_links(application.get_default_module())
+    return get_module_exposed_links(application.get_default_module())
 
 
 class UserMarkedApplication(OwnerTimestampedModel):

--- a/apiserver/paasng/paasng/publish/entrance/exposer.py
+++ b/apiserver/paasng/paasng/publish/entrance/exposer.py
@@ -50,6 +50,11 @@ class EnvExposedURL(NamedTuple):
         return self.url.as_address()
 
 
+def env_is_deployed(env: ModuleEnvironment) -> bool:
+    """Return the deployed status(aka "is_running") of an environment object"""
+    return get_deployed_status(env.module).get(env.environment, False)
+
+
 def get_deployed_status(module: Module) -> Dict[str, bool]:
     """Return the deployed status(aka "is_running") of module's each environments
 
@@ -108,7 +113,7 @@ def get_exposed_url(module_env: ModuleEnvironment) -> Optional[EnvExposedURL]:
 
     # Handle user preferred root domain, only available for built-in subdomains
     # and subpaths.
-    if addrs[0].type in ['subpath', 'subdomain']:
+    if addr.type in ['subpath', 'subdomain']:
         if preferred_root := module_env.module.user_preferred_root_domain:
             # Find the first address ends with preferred root domain
             preferred_addr = next((a for a in addrs if a.hostname_endswith(preferred_root)), None)

--- a/apiserver/paasng/paasng/publish/entrance/exposer.py
+++ b/apiserver/paasng/paasng/publish/entrance/exposer.py
@@ -20,25 +20,22 @@ to the current version of the project delivered to anyone in the future.
 """
 import json
 import logging
-from itertools import groupby
 from typing import Dict, List, NamedTuple, Optional
 
+from attrs import define
 from django.conf import settings
-from django.db.models import Count
 
-from paasng.engine.constants import JobStatus
 from paasng.engine.controller.cluster import Cluster, get_engine_app_cluster, get_region_cluster_helper
 from paasng.engine.controller.shortcuts import make_internal_client
 from paasng.engine.deploy.engine_svc import EngineDeployClient
 from paasng.engine.deploy.env_vars import env_vars_providers
-from paasng.engine.models.deployment import Deployment
 from paasng.platform.applications.constants import AppEnvironment
 from paasng.platform.applications.models import Application, ModuleEnvironment
 from paasng.platform.modules.constants import ExposedURLType
 from paasng.platform.modules.models import Module
 from paasng.platform.region.models import get_region
-from paasng.publish.entrance.domains import Domain, ModuleEnvDomains, get_preallocated_domain
-from paasng.publish.entrance.subpaths import ModuleEnvSubpaths, Subpath, get_preallocated_path
+from paasng.publish.entrance.domains import ModuleEnvDomains, get_preallocated_domain, get_preallocated_domains_by_env
+from paasng.publish.entrance.subpaths import ModuleEnvSubpaths, get_preallocated_path, get_preallocated_paths_by_env
 from paasng.publish.entrance.utils import URL
 from paasng.publish.market.models import MarketConfig
 
@@ -55,7 +52,7 @@ class EnvExposedURL(NamedTuple):
 
 
 class BaseEnvExposedURLProvider:
-    """Provides accessable URL address for environment"""
+    """Provides accessible URL address for environment"""
 
     provider_type: str = ''
 
@@ -82,13 +79,13 @@ class BaseEnvExposedURLProvider:
         return None
 
     def _provide_url(self) -> Optional[URL]:
-        """provide an accessable url, if current env does not match the pre-conditions,
+        """provide an accessible url, if current env does not match the pre-conditions,
         return None instead
         """
         raise NotImplementedError
 
     def _provide_urls(self) -> Optional[List[URL]]:
-        """provide all accessable urls, if current env does not match the pre-conditions,
+        """provide all accessible urls, if current env does not match the pre-conditions,
         return None instead
         """
         raise NotImplementedError
@@ -128,128 +125,31 @@ class MarketURLProvider(BaseEnvExposedURLProvider):
         return [address]
 
 
-class SubDomainURLProvider(BaseEnvExposedURLProvider):
-    """The default URL for application environments"""
-
-    provider_type = 'default_subdomain'
-
-    def _provide_url(self) -> Optional[URL]:
-        if self.env.module.exposed_url_type != ExposedURLType.SUBDOMAIN:
-            return None
-
-        helper = ModuleEnvDomains(self.env)
-        domains = helper.all()
-        user_preferred = helper.make_user_preferred_one()
-
-        if not domains:
-            return None
-
-        if user_preferred:
-            return user_preferred.as_url()
-
-        domains = sorted(domains, key=Domain.sort_by_type, reverse=True)
-        return domains[0].as_url()
-
-    def _provide_urls(self) -> Optional[List[URL]]:
-        if self.env.module.exposed_url_type != ExposedURLType.SUBDOMAIN:
-            return None
-
-        domains = ModuleEnvDomains(self.env).all()
-        if not domains:
-            return None
-
-        domains = sorted(domains, key=Domain.sort_by_type, reverse=True)
-        _, group = next(groupby(domains, key=Domain.sort_by_type))
-        return [domain.as_url() for domain in group]
-
-
-class SubPathURLProvider(BaseEnvExposedURLProvider):
-    """Provides sub path URL for module environments.
-
-    To make subpath address available:
-
-    - 'sub_path_domains' must be configured in region's `ingress_config` config object
-    - the module's exposed_url_type must be 'subpath' (by default, `expose_type` was set to region's default value
-      when module was created)
-    """
-
-    provider_type = 'subpath'
-
-    def _provide_url(self) -> Optional[URL]:
-        if self.env.module.exposed_url_type != ExposedURLType.SUBPATH:
-            return None
-
-        helper = ModuleEnvSubpaths(self.env)
-        subpaths = helper.all()
-        user_preferred = helper.make_user_preferred_one()
-
-        if not subpaths:
-            return None
-
-        if user_preferred:
-            return user_preferred.as_url()
-
-        subpaths = sorted(subpaths, key=Subpath.sort_by_type, reverse=True)
-        return subpaths[0].as_url()
-
-    def _provide_urls(self) -> Optional[List[URL]]:
-        if self.env.module.exposed_url_type != ExposedURLType.SUBPATH:
-            return None
-
-        subpaths = ModuleEnvSubpaths(self.env).all()
-        if not subpaths:
-            return None
-
-        # Pick addresses which have the biggest "type" by value, see
-        # `SubpathPriorityType` for more details.
-        subpaths = sorted(subpaths, key=Subpath.sort_by_type, reverse=True)
-        _, group = next(groupby(subpaths, key=Subpath.sort_by_type))
-        return [subpath.as_url() for subpath in group]
-
-
-class LegacyEngineURLProvider(BaseEnvExposedURLProvider):
-    """Deprecated: legacy URL address"""
-
-    provider_type = 'legacy'
-
-    def _provide_url(self) -> Optional[URL]:
-        region = get_region(self.app.region)
-        return URL.from_address(self.format_region_url_tmpl(region.basic_info.link_engine_app))
-
-    def _provide_urls(self) -> Optional[List[URL]]:
-        address = self._provide_url()
-        if not address:
-            return None
-        return [address]
-
-
 def get_deployed_status(module: Module) -> Dict[str, bool]:
     """Return the deployed status(aka "is_running") of module's each environments
 
     :return: dict like {'stag': True, 'prod': False}
     """
-    envs = module.envs.all()
-    ret = {}
-    # Exclude offlined envs
-    for env in envs:
-        if env.is_offlined:
-            ret[env.environment] = False
+    addrs = get_live_addresses(module)
+    status = {
+        'stag': addrs.get_is_running('stag'),
+        'prod': addrs.get_is_running('prod'),
+    }
 
-    # Query succeeded deployments count for all environments
-    envs = [env for env in envs if env.environment not in ret]
-    counter_by_env = dict(
-        Deployment.objects.filter(app_environment__in=envs, status=JobStatus.SUCCESSFUL.value)
-        .values_list('app_environment')
-        .annotate(total=Count('app_environment'))
-        .order_by('total')
-    )
-    for env in envs:
-        ret[env.environment] = counter_by_env.get(env.pk, 0) > 0
-    return ret
+    # Exclude archived environments
+    # TODO: Remove this logic because archived applications's "is_running" should
+    # be false naturally after workloads was updated.
+    for env in module.envs.all():
+        if env.is_offlined:
+            status[env.environment] = False
+    return status
 
 
 def get_module_exposed_links(module: Module) -> Dict[str, Dict]:
-    """Get exposed links of module's all environments"""
+    """Get exposed links of module's all environments
+
+    - Support both cloud-native and default applications
+    """
     links = {}
     deployed_statuses = get_deployed_status(module)
     for env in module.get_envs():
@@ -264,59 +164,45 @@ def get_module_exposed_links(module: Module) -> Dict[str, Dict]:
 
 
 def get_exposed_url(module_env: ModuleEnvironment) -> Optional[EnvExposedURL]:
-    """Get exposed url of given module environment
+    """Get exposed url object of given environment, if the environment is not
+    running, return None instead.
 
-    :returns: None if no url can be found
+    - Custom domain is not included
+    - Both cloud-native and default application are supported
+
+    :returns: Return the shortest url by default. If a preferred root domain was
+        set and a match can be found using that domain, the matched address will
+        be returned in priority.
     """
-    providers = [
-        # Market URL has the highest priority
-        MarketURLProvider(module_env),
-        SubPathURLProvider(module_env),
-        SubDomainURLProvider(module_env),
-        LegacyEngineURLProvider(module_env),
-    ]
-    for provider in providers:
-        url = provider.provide()
-        if url:
-            return url
-    return None
+    addrs = get_addresses(module_env)
+    if not addrs:
+        return None
+
+    # Use the first address because the results have been sorted by length already
+    addr = addrs[0]
+
+    # Handle user preferred root domain, only available for built-in subdomains
+    # and subpaths.
+    if addrs[0].type in ['subpath', 'subdomain']:
+        if preferred_root := module_env.module.user_preferred_root_domain:
+            # Find the first address ends with preferred root domain
+            preferred_addr = next((a for a in addrs if a.hostname_endswith(preferred_root)), None)
+            if not preferred_addr:
+                logger.warning('No addresses found matching preferred root domain: %s', preferred_root)
+            else:
+                addr = preferred_addr
+    return addr.to_exposed_url()
 
 
-def get_default_access_entrance(
-    module_env: ModuleEnvironment, include_no_running: bool = False
-) -> Optional[EnvExposedURL]:
-    """返回模块在对应环境下的默认访问入口(由平台提供的)
+def _get_legacy_url(env: ModuleEnvironment) -> Optional[str]:
+    """Deprecated: Get legacy URL address which is a hard-coded value generated
+    y region configuration.
 
-    :returns: None if no url can be found
+    :return: None if not configured.
     """
-    providers = [
-        SubPathURLProvider(module_env),
-        SubDomainURLProvider(module_env),
-        LegacyEngineURLProvider(module_env),
-    ]
-    for provider in providers:
-        url = provider.provide(include_no_running)
-        if url:
-            return url
-    return None
-
-
-def get_default_access_entrances(
-    module_env: ModuleEnvironment, include_no_running: bool = False
-) -> Optional[List[EnvExposedURL]]:
-    """返回模块在对应环境下的所有可选的默认访问入口(由平台提供的)
-
-    :returns: None if no url can be found
-    """
-    providers = [
-        SubPathURLProvider(module_env),
-        SubDomainURLProvider(module_env),
-        LegacyEngineURLProvider(module_env),
-    ]
-    for provider in providers:
-        urls = provider.provide_all(include_no_running)
-        if urls:
-            return urls
+    app = env.application
+    if tmpl := get_region(app.region).basic_info.link_engine_app:
+        return tmpl.format(code=app.code, region=app.region, name=env.engine_app.name)
     return None
 
 
@@ -379,6 +265,38 @@ def refresh_module_subpaths(module: Module) -> None:
         engine_client = EngineDeployClient(env.engine_app)
         subpaths = [d.as_dict() for d in ModuleEnvSubpaths(env).all()]
         engine_client.update_subpaths(subpaths)
+
+
+# pre-allocated addresses related functions start
+
+
+def get_preallocated_url(module_env: ModuleEnvironment) -> Optional[EnvExposedURL]:
+    """获取某环境的默认访问入口地址（不含独立域名)。
+
+    - 地址为预计算生成，无需真实部署，不保证能访问
+    """
+    if items := get_preallocated_urls(module_env):
+        return items[0]
+    return None
+
+
+def get_preallocated_urls(module_env: ModuleEnvironment) -> List[EnvExposedURL]:
+    """获取某环境的所有可选访问入口地址（不含独立域名)。
+
+    - 当集群配置了多个根域时，返回多个结果
+    - 地址为预计算生成，无需真实部署，不保证能访问
+    """
+    module = module_env.module
+    if module.exposed_url_type == ExposedURLType.SUBPATH:
+        subpaths = get_preallocated_paths_by_env(module_env)
+        return [EnvExposedURL(url=p.as_url(), provider_type='subpath') for p in subpaths]
+    elif module.exposed_url_type == ExposedURLType.SUBDOMAIN:
+        domains = get_preallocated_domains_by_env(module_env)
+        return [EnvExposedURL(url=d.as_url(), provider_type='subdomain') for d in domains]
+    elif module.exposed_url_type is None:
+        if url := _get_legacy_url(module_env):
+            return [EnvExposedURL(url=URL.from_address(url), provider_type='legacy')]
+    return []
 
 
 @env_vars_providers.register_env
@@ -450,6 +368,57 @@ def get_bk_doc_url_prefix() -> str:
     return get_preallocated_address(settings.BK_DOC_APP_ID).prod.rstrip("/")
 
 
+# pre-allocated addresses related functions end
+
+
+def get_addresses(env: ModuleEnvironment) -> 'List[Address]':
+    """Get exposed addresses of an environment object, only built-in addresses
+    is returned. This should be the main function for getting addresses of env.
+
+    :returns: address items sorted by URL length, empty list if env has not been
+        deployed yet.
+    """
+    live_addrs = get_live_addresses(env.module)
+    if not live_addrs.get_is_running(env.environment):
+        return []
+
+    # Get addresses by expose type
+    module = env.module
+    addrs: List[Address] = []
+    if module.exposed_url_type == ExposedURLType.SUBPATH:
+        addrs = live_addrs.get_addresses(env.environment, addr_type='subpath')
+    elif module.exposed_url_type == ExposedURLType.SUBDOMAIN:
+        addrs = live_addrs.get_addresses(env.environment, addr_type='subdomain')
+    elif module.exposed_url_type is None:
+        url = _get_legacy_url(env)
+        addrs = [Address(type='legacy', url=url)] if url else []
+
+    addrs.sort(key=lambda a: len(a.url))
+    return addrs
+
+
+# TODO: Add `def get_addresses_with_custom` function which include custom domains.
+
+
+@define
+class Address:
+    """An simple struct stored application's URL address"""
+
+    type: str
+    url: str
+
+    def hostname_endswith(self, s: str) -> bool:
+        """Check if current hostname ends with given string"""
+        obj = URL.from_address(self.url)
+        return obj.hostname.endswith(s)
+
+    def to_exposed_url(self) -> EnvExposedURL:
+        """To exposed URL object"""
+        # INFO: Use self.type as "provider type" directly, this might need to be
+        # changed in the future.
+        return EnvExposedURL(url=URL.from_address(self.url), provider_type=self.type)
+
+
 class ModuleLiveAddrs:
     """Stored a module's addresses and running status"""
 
@@ -464,10 +433,16 @@ class ModuleLiveAddrs:
         d = self._map_by_env.get(env_name, self._empty_item)
         return d['is_running']
 
-    def get_addresses(self, env_name: str) -> List[Dict]:
-        """Given addresses of environment"""
+    def get_addresses(self, env_name: str, addr_type: Optional[str] = None) -> List[Address]:
+        """Given addresses of environment
+
+        :param addr_type: If given, include items whose type equal to this value
+        """
         d = self._map_by_env.get(env_name, self._empty_item)
-        return d['addresses']
+        addrs = d['addresses']
+        if addr_type:
+            addrs = [a for a in d['addresses'] if a['type'] == addr_type]
+        return [Address(**a) for a in addrs]
 
     @property
     def _empty_item(self) -> Dict:
@@ -476,48 +451,10 @@ class ModuleLiveAddrs:
 
 
 def get_live_addresses(module: Module) -> ModuleLiveAddrs:
-    """Get addresses and is_running status for module's environments."""
+    """Get addresses and is_running status for module's environments.
+
+    This is a low-level function, don't use it directly, use `get_addresses`
+    instead.
+    """
     data = make_internal_client().list_env_addresses(module.application.code, module.name)
     return ModuleLiveAddrs(data)
-
-
-def get_module_exposed_links_live(module: Module) -> Dict[str, Dict]:
-    """Get exposed links of module's all environments.
-
-    This is the "live" version of the original `get_module_exposed_links` function,
-    key differences:
-
-    - Support both cloud-native and default applications
-    - market URL and user-preferred addresses not considered
-
-    The goal is to replace `get_module_exposed_links`(and other related *Providers)
-    with this function in the future.
-    """
-    links = {}
-    addrs = get_live_addresses(module)
-    for env in module.get_envs():
-        if items := addrs.get_addresses(env.environment):
-            # TODO: Pick url by priority order in the future
-            url = items[0]['url']
-        else:
-            url = None
-        links[env.environment] = {"deployed": addrs.get_is_running(env.environment), "url": url}
-    return links
-
-
-def get_exposed_url_live(env: ModuleEnvironment) -> Optional[EnvExposedURL]:
-    """Get exposed url of given module environment.
-
-    This is the "live" version of the original `get_exposed_url` function, key
-    differences:
-
-    - Support both cloud-native and default applications
-    - market URL and user-preferred addresses not included
-
-    :returns: None if no url can be found
-    """
-    addrs = get_live_addresses(env.module)
-    if items := addrs.get_addresses(env.environment):
-        # TODO: Pick url by priority order in the future
-        return EnvExposedURL(url=URL.from_address(items[0]['url']), provider_type='live')
-    return None

--- a/apiserver/paasng/paasng/publish/entrance/views.py
+++ b/apiserver/paasng/paasng/publish/entrance/views.py
@@ -30,8 +30,8 @@ from paasng.platform.applications.mixins import ApplicationCodeInPathMixin
 from paasng.platform.modules.constants import ExposedURLType
 from paasng.platform.modules.helpers import get_module_all_root_domains
 from paasng.publish.entrance.exposer import (
-    get_default_access_entrances,
-    get_live_addresses,
+    get_deployed_status,
+    get_preallocated_urls,
     update_exposed_url_type_to_subdomain,
 )
 from paasng.publish.entrance.serializers import (
@@ -78,14 +78,7 @@ class ApplicationAvailableAddressViewset(viewsets.ViewSet, ApplicationCodeInPath
     def list_module_default_entrances(self, request, code, module_name):
         """查看模块的默认的所有访问入口(由平台提供的)，无论是否运行"""
         module = self.get_module_via_path()
-
-        # Get "is_running" data from workloads service
-        #
-        # INFO: Below logic is different from other places in where we get "is_running"
-        # from ModuleEnv's attribute directly by querying for successful Deployment
-        # objects. That approach is not suitable for cloud-native applications and
-        # should be optimized eventually.
-        addrs = get_live_addresses(module)
+        deployed_status = get_deployed_status(module)
 
         def get_plain_entrance():
             # 默认 stag 在 prod 之前创建
@@ -93,10 +86,10 @@ class ApplicationAvailableAddressViewset(viewsets.ViewSet, ApplicationCodeInPath
                 yield from [
                     dict(
                         env=env.environment,
-                        is_running=addrs.get_is_running(env.environment),
+                        is_running=deployed_status.get(env.environment, False),
                         address=entrance.address,
                     )
-                    for entrance in (get_default_access_entrances(env, include_no_running=True) or [])
+                    for entrance in get_preallocated_urls(env)
                 ]
 
         return Response(

--- a/apiserver/paasng/tests/extensions/bk_plugins/test_models.py
+++ b/apiserver/paasng/tests/extensions/bk_plugins/test_models.py
@@ -16,7 +16,6 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-
 from functools import partial
 
 import pytest
@@ -46,7 +45,7 @@ class TestBkPlugin:
         assert obj.id == bk_plugin_app.id.hex
 
 
-def test_get_deployed_statuses(bk_plugin_app):
+def test_get_deployed_statuses(with_empty_live_addrs, bk_plugin_app):
     obj = BkPlugin.from_application(bk_plugin_app)
     assert get_deployed_statuses(obj) is not None
 
@@ -72,12 +71,12 @@ def test_get_or_create_by_application(bk_app):
     assert profile.tag.name == 'sample-tag-1'
 
 
-def test_plugin_to_detailed_default(bk_plugin):
+def test_plugin_to_detailed_default(with_empty_live_addrs, bk_plugin):
     ret = plugin_to_detailed(bk_plugin)
     assert ret.dict()['deployed_statuses']['stag'].get('addresses') is not None
 
 
-def test_plugin_to_detailed_no_addresses(bk_plugin):
+def test_plugin_to_detailed_no_addresses(with_empty_live_addrs, bk_plugin):
     ret = plugin_to_detailed(bk_plugin, include_addresses=False)
     assert ret.dict()['deployed_statuses']['stag'].get('addresses') is None
 

--- a/apiserver/paasng/tests/publish/conftest.py
+++ b/apiserver/paasng/tests/publish/conftest.py
@@ -20,13 +20,7 @@ import pytest
 
 from paasng.platform.core.storages.sqlalchemy import console_db
 from paasng.publish.sync_market.managers import AppTagManger
-from tests.utils.helpers import configure_regions, generate_random_string
-
-
-@pytest.fixture(autouse=True)
-def setup_ieod_region():
-    with configure_regions(['ieod']):
-        yield
+from tests.utils.helpers import generate_random_string
 
 
 @pytest.fixture

--- a/apiserver/paasng/tests/publish/entrance/test_exposer.py
+++ b/apiserver/paasng/tests/publish/entrance/test_exposer.py
@@ -31,10 +31,12 @@ from paasng.publish.entrance.exposer import (
     _get_legacy_url,
     get_addresses,
     get_exposed_url,
+    get_market_address,
     get_preallocated_address,
     get_preallocated_url,
     get_preallocated_urls,
 )
+from paasng.publish.market.models import MarketConfig
 from tests.utils.helpers import override_region_configs
 from tests.utils.mocks.engine import replace_cluster_service
 
@@ -249,3 +251,10 @@ class TestDefaultEntrance:
         with override_region_configs(bk_app.region, update_region_hook):
             urls = get_preallocated_urls(bk_stag_env)
             assert [u.address for u in urls] == [f'http://example.com/{bk_app.region}-legacy-path/']
+
+
+def test_get_market_address(bk_app):
+    MarketConfig.objects.enable_app(bk_app)
+    addr = get_market_address(bk_app)
+    assert addr is not None
+    assert len(addr) > 0

--- a/apiserver/paasng/tests/publish/entrance/test_exposer.py
+++ b/apiserver/paasng/tests/publish/entrance/test_exposer.py
@@ -23,18 +23,19 @@ from unittest import mock
 
 import pytest
 
-from paasng.engine.constants import JobStatus
 from paasng.platform.modules.constants import ExposedURLType
 from paasng.publish.entrance.exposer import (
+    Address,
     ModuleLiveAddrs,
-    SubDomainURLProvider,
-    SubPathURLProvider,
     _default_preallocated_urls,
-    get_exposed_url_live,
-    get_module_exposed_links_live,
+    _get_legacy_url,
+    get_addresses,
+    get_exposed_url,
     get_preallocated_address,
+    get_preallocated_url,
+    get_preallocated_urls,
 )
-from tests.engine.setup_utils import create_fake_deployment
+from tests.utils.helpers import override_region_configs
 from tests.utils.mocks.engine import replace_cluster_service
 
 pytestmark = pytest.mark.django_db
@@ -76,202 +77,175 @@ class TestGetPreallocatedAddress:
             assert get_preallocated_address('test-code').prod == expected_address
 
 
-class TestSubPathURLProvider:
-    @pytest.fixture(autouse=True)
-    def _setup_deployment(self, bk_module):
-        # Create a successful deployment or no address will be generated
-        create_fake_deployment(bk_module, 'stag', status=JobStatus.SUCCESSFUL.value)
-        create_fake_deployment(bk_module, 'prod', status=JobStatus.SUCCESSFUL.value)
-        with replace_cluster_service(
-            replaced_ingress_config={'sub_path_domains': [{"name": 'foo.com'}, {"name": 'bar.com'}]}
-        ):
-            yield
-
-    def test_disabled(self, bk_module, bk_prod_env):
-        bk_module.exposed_url_type = None
-        bk_module.save()
-
-        url = SubPathURLProvider(bk_prod_env).provide()
-        assert url is None
-
-    @pytest.mark.parametrize(
-        "bk_env, user_preferred_root_domain, expected_template",
-        [
-            ("bk_stag_env", None, "http://foo.com/stag--{bk_app.code}/"),
-            ("bk_prod_env", None, "http://foo.com/{bk_app.code}/"),
-            ("bk_stag_env", "bar.com", "http://bar.com/stag--{bk_app.code}/"),
-            ("bk_prod_env", "bar.com", "http://bar.com/{bk_app.code}/"),
-            ("bk_stag_env", "baz.com", "http://baz.com/stag--{bk_app.code}/"),
-            ("bk_prod_env", "baz.com", "http://baz.com/{bk_app.code}/"),
-        ],
-        indirect=["bk_env"],
-    )
-    def test_enabled(self, bk_app, bk_module, bk_env, user_preferred_root_domain, expected_template):
-        bk_module.exposed_url_type = ExposedURLType.SUBPATH
-        bk_module.user_preferred_root_domain = user_preferred_root_domain
-        bk_module.save()
-
-        url = SubPathURLProvider(bk_env).provide()
-        assert url
-        assert url.provider_type == 'subpath'
-        assert url.address == expected_template.format(bk_app=bk_app)
-
-    @pytest.mark.parametrize(
-        "bk_env, user_preferred_root_domain, expected_templates",
-        [
-            (
-                "bk_stag_env",
-                None,
-                ["http://foo.com/stag--{bk_app.code}/", "http://bar.com/stag--{bk_app.code}/"],
-            ),
-            ("bk_prod_env", None, ["http://foo.com/{bk_app.code}/", "http://bar.com/{bk_app.code}/"]),
-            (
-                "bk_stag_env",
-                "bar.com",
-                ["http://foo.com/stag--{bk_app.code}/", "http://bar.com/stag--{bk_app.code}/"],
-            ),
-            ("bk_prod_env", "bar.com", ["http://foo.com/{bk_app.code}/", "http://bar.com/{bk_app.code}/"]),
-        ],
-        indirect=["bk_env"],
-    )
-    def test_provide_all(self, bk_app, bk_module, bk_env, user_preferred_root_domain, expected_templates):
-        bk_module.exposed_url_type = ExposedURLType.SUBPATH
-        bk_module.user_preferred_root_domain = user_preferred_root_domain
-        bk_module.save()
-
-        urls = SubPathURLProvider(bk_env).provide_all()
-        assert urls is not None
-        for url, expected_template in zip(urls, expected_templates):
-            assert url.address == expected_template.format(bk_app=bk_app)
-
-    def test_order_reserved(self, bk_app, bk_module, bk_prod_env):
-        bk_module.exposed_url_type = ExposedURLType.SUBPATH
-        bk_module.save()
-        with replace_cluster_service(
-            replaced_ingress_config={'sub_path_domains': [{"name": 'foo.com', 'reserved': True}, {"name": 'fool.com'}]}
-        ):
-            url = SubPathURLProvider(bk_prod_env).provide()
-            assert url
-            assert url.address == "http://fool.com/{bk_app.code}/".format(bk_app=bk_app)
-
-
-class TestSubDomainURLProvider:
-    @pytest.fixture(autouse=True)
-    def _setup_deployment(self, bk_module):
-        # Create a successful deployment or no address will be generated
-        create_fake_deployment(bk_module, 'stag', status=JobStatus.SUCCESSFUL.value)
-        create_fake_deployment(bk_module, 'prod', status=JobStatus.SUCCESSFUL.value)
-        with replace_cluster_service(
-            replaced_ingress_config={'app_root_domains': [{"name": 'foo.com'}, {"name": 'bar.com'}]}
-        ):
-            yield
-
-    def test_disabled(self, bk_module, bk_prod_env):
-        bk_module.exposed_url_type = None
-        bk_module.save()
-
-        url = SubDomainURLProvider(bk_prod_env).provide()
-        assert url is None
-
-    @pytest.mark.parametrize(
-        "bk_env, user_preferred_root_domain, expected_template",
-        [
-            ("bk_stag_env", None, "http://stag-dot-{bk_app.code}.foo.com"),
-            ("bk_prod_env", None, "http://{bk_app.code}.foo.com"),
-            ("bk_stag_env", "bar.com", "http://stag-dot-{bk_app.code}.bar.com"),
-            ("bk_prod_env", "bar.com", "http://{bk_app.code}.bar.com"),
-            ("bk_stag_env", "baz.com", "http://stag-dot-{bk_app.code}.baz.com"),
-            ("bk_prod_env", "baz.com", "http://{bk_app.code}.baz.com"),
-        ],
-        indirect=["bk_env"],
-    )
-    def test_enabled(self, bk_app, bk_module, bk_env, user_preferred_root_domain, expected_template):
-        bk_module.exposed_url_type = ExposedURLType.SUBDOMAIN
-        bk_module.user_preferred_root_domain = user_preferred_root_domain
-        bk_module.save()
-
-        url = SubDomainURLProvider(bk_env).provide()
-        assert url
-        assert url.provider_type == 'default_subdomain'
-        assert url.address == expected_template.format(bk_app=bk_app)
-
-    @pytest.mark.parametrize(
-        "bk_env, user_preferred_root_domain, expected_templates",
-        [
-            (
-                "bk_stag_env",
-                None,
-                ["http://stag-dot-{bk_app.code}.foo.com", "http://stag-dot-{bk_app.code}.bar.com"],
-            ),
-            ("bk_prod_env", None, ["http://{bk_app.code}.foo.com", "http://{bk_app.code}.bar.com"]),
-            (
-                "bk_stag_env",
-                "bar.com",
-                ["http://stag-dot-{bk_app.code}.foo.com", "http://stag-dot-{bk_app.code}.bar.com"],
-            ),
-            ("bk_prod_env", "bar.com", ["http://{bk_app.code}.foo.com", "http://{bk_app.code}.bar.com"]),
-        ],
-        indirect=["bk_env"],
-    )
-    def test_provide_all(self, bk_app, bk_module, bk_env, user_preferred_root_domain, expected_templates):
-        bk_module.exposed_url_type = ExposedURLType.SUBDOMAIN
-        bk_module.user_preferred_root_domain = user_preferred_root_domain
-        bk_module.save()
-
-        urls = SubDomainURLProvider(bk_env).provide_all()
-        assert urls is not None
-        for url, expected_template in zip(urls, expected_templates):
-            assert url.address == expected_template.format(bk_app=bk_app)
-
-    def test_order_reserved(self, bk_app, bk_module, bk_prod_env):
-        bk_module.exposed_url_type = ExposedURLType.SUBDOMAIN
-        bk_module.save()
-        with replace_cluster_service(
-            replaced_ingress_config={'app_root_domains': [{"name": 'foo.com', 'reserved': True}, {"name": 'fool.com'}]}
-        ):
-            url = SubDomainURLProvider(bk_prod_env).provide()
-            assert url
-            assert url.address == "http://{bk_app.code}.fool.com".format(bk_app=bk_app)
-
-
-@pytest.fixture
-def module_addrs_data():
-    return [
+class TestModuleLiveAddrs:
+    module_addrs_data = [
         {"env": "prod", "is_running": False, "addresses": []},
         {
             "env": "stag",
             "is_running": True,
             "addresses": [
                 {"type": "subdomain", "url": "http://foo.example.com/"},
-                {"type": "subpath", "url": "https://bar.example.com/bar/"},
+                {"type": "subpath", "url": "http://bar.example.com/bar/"},
+                {"type": "custom", "url": "http://custom.example.com/"},
             ],
         },
     ]
 
-
-class TestModuleLiveAddrs:
-    def test_get_is_running(self, module_addrs_data):
-        addrs = ModuleLiveAddrs(module_addrs_data)
+    def test_get_is_running(self):
+        addrs = ModuleLiveAddrs(self.module_addrs_data)
         assert addrs.get_is_running('stag') is True
         assert addrs.get_is_running('prod') is False
         assert addrs.get_is_running('invalid-env') is False
 
-    def test_get_addresses(self, module_addrs_data):
-        addrs = ModuleLiveAddrs(module_addrs_data)
-        assert len(addrs.get_addresses('stag')) == 2
+    def test_get_addresses(self):
+        addrs = ModuleLiveAddrs(self.module_addrs_data)
+        assert len(addrs.get_addresses('stag')) == 3
         assert addrs.get_addresses('prod') == []
         assert addrs.get_addresses('invalid-env') == []
 
-
-@mock.patch('paasng.publish.entrance.exposer.get_live_addresses')
-def test_get_module_exposed_links_live(mocker, module_addrs_data, bk_module):
-    mocker.return_value = ModuleLiveAddrs(module_addrs_data)
-    ret = get_module_exposed_links_live(bk_module)
-    assert ret['stag'] == {'deployed': True, 'url': 'http://foo.example.com/'}
+    def test_get_addresses_with_type(self):
+        addrs = ModuleLiveAddrs(self.module_addrs_data)
+        assert addrs.get_addresses('stag', addr_type='subpath') == [Address("subpath", "http://bar.example.com/bar/")]
 
 
-@mock.patch('paasng.publish.entrance.exposer.get_live_addresses')
-def test_get_exposed_url_live(mocker, module_addrs_data, bk_stag_env, bk_prod_env):
-    mocker.return_value = ModuleLiveAddrs(module_addrs_data)
-    assert get_exposed_url_live(bk_stag_env) is not None
-    assert get_exposed_url_live(bk_prod_env) is None
+def test__get_legacy_url(bk_stag_env):
+    url = _get_legacy_url(bk_stag_env)
+    assert url is not None
+    assert len(url) > 0
+
+
+@pytest.fixture
+def setup_addrs(bk_app):
+    """Set up common mock and configs for testing functions related with addresses"""
+
+    def update_region_hook(config):
+        config['basic_info']['link_engine_app'] = "http://example.com/{region}-legacy-path/"
+
+    with override_region_configs(bk_app.region, update_region_hook), mock.patch(
+        'paasng.publish.entrance.exposer.get_live_addresses'
+    ) as mocker:
+        mocker.return_value = ModuleLiveAddrs(
+            [
+                {"env": "prod", "is_running": False, "addresses": []},
+                {
+                    "env": "stag",
+                    "is_running": True,
+                    "addresses": [
+                        {"type": "subdomain", "url": "http://default-foo.example.com/"},
+                        {"type": "subdomain", "url": "http://foo.example.com/"},
+                        {"type": "subdomain", "url": "http://default-foo.example.org/"},
+                        {"type": "subpath", "url": "http://bar.example.com/bar/"},
+                        {"type": "custom", "url": "http://custom.example.com/"},
+                    ],
+                },
+            ]
+        )
+        yield
+
+
+class TestGetAddresses:
+    @pytest.fixture(autouse=True)
+    def _setup(self, setup_addrs):
+        yield
+
+    def test_not_running(self, bk_prod_env):
+        addrs = get_addresses(bk_prod_env)
+        assert addrs == []
+
+    def test_subpath(self, bk_module, bk_stag_env):
+        bk_module.exposed_url_type = ExposedURLType.SUBPATH
+        bk_module.save()
+
+        addrs = get_addresses(bk_stag_env)
+        assert len(addrs) == 1 and addrs[0].url == 'http://bar.example.com/bar/'
+
+    def test_subdomain(self, bk_module, bk_stag_env):
+        bk_module.exposed_url_type = ExposedURLType.SUBDOMAIN
+        bk_module.save()
+
+        addrs = get_addresses(bk_stag_env)
+        assert len(addrs) == 3 and addrs[0].url == 'http://foo.example.com/'
+
+    def test_none(self, bk_app, bk_module, bk_stag_env):
+        bk_module.exposed_url_type = None
+        bk_module.save()
+
+        addrs = get_addresses(bk_stag_env)
+        assert len(addrs) == 1 and addrs[0].url == f'http://example.com/{bk_app.region}-legacy-path/'
+
+
+class TestGetExposedUrl:
+    @pytest.fixture(autouse=True)
+    def _setup(self, setup_addrs):
+        yield
+
+    def test_not_running(self, bk_prod_env):
+        assert get_exposed_url(bk_prod_env) is None
+
+    @pytest.mark.parametrize(
+        "preferred_root, expected",
+        [
+            (None, "http://foo.example.com/"),
+            ("example.org", "http://default-foo.example.org/"),
+            # An invalid preferred root domain should have no effect
+            ("invalid-example.com", "http://foo.example.com/"),
+        ],
+    )
+    def test_preferred_root(self, preferred_root, expected, bk_module, bk_stag_env):
+        bk_module.exposed_url_type = ExposedURLType.SUBDOMAIN
+        bk_module.user_preferred_root_domain = preferred_root
+        bk_module.save()
+
+        url = get_exposed_url(bk_stag_env)
+        assert url is not None
+        assert url.provider_type == 'subdomain'
+        assert url.address == expected
+
+
+class TestDefaultEntrance:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        with replace_cluster_service(
+            ingress_config={
+                'app_root_domains': [
+                    {"name": 'bar-1.example.com'},
+                    {"name": 'bar-2.example.org'},
+                ],
+            }
+        ):
+            yield
+
+    def test_single_entrance(setup_addrs, bk_app, bk_module, bk_stag_env):
+        """Test: default module's stag env"""
+        bk_module.exposed_url_type = ExposedURLType.SUBDOMAIN
+        bk_module.is_default = True
+        bk_module.save()
+
+        url = get_preallocated_url(bk_stag_env)
+        assert url is not None
+        assert url.address == f'http://stag-dot-{bk_app.code}.bar-1.example.com'
+
+    def test_sub_domain(setup_addrs, bk_app, bk_module, bk_stag_env):
+        """Test: default module's stag env"""
+        bk_module.exposed_url_type = ExposedURLType.SUBDOMAIN
+        bk_module.is_default = True
+        bk_module.save()
+
+        urls = get_preallocated_urls(bk_stag_env)
+        assert [u.address for u in urls] == [
+            f'http://stag-dot-{bk_app.code}.bar-1.example.com',
+            f'http://stag-dot-{bk_app.code}.bar-2.example.org',
+        ]
+
+    def test_get_preallocated_urls_legacy(setup_addrs, bk_app, bk_module, bk_stag_env):
+        """Test: default module's stag env with exposed url type set to None"""
+        bk_module.exposed_url_type = None
+        bk_module.is_default = True
+        bk_module.save()
+
+        def update_region_hook(config):
+            config['basic_info']['link_engine_app'] = "http://example.com/{region}-legacy-path/"
+
+        with override_region_configs(bk_app.region, update_region_hook):
+            urls = get_preallocated_urls(bk_stag_env)
+            assert [u.address for u in urls] == [f'http://example.com/{bk_app.region}-legacy-path/']

--- a/apiserver/paasng/tests/publish/entrance/test_exposer.py
+++ b/apiserver/paasng/tests/publish/entrance/test_exposer.py
@@ -29,6 +29,7 @@ from paasng.publish.entrance.exposer import (
     ModuleLiveAddrs,
     _default_preallocated_urls,
     _get_legacy_url,
+    env_is_deployed,
     get_addresses,
     get_exposed_url,
     get_market_address,
@@ -152,6 +153,12 @@ def setup_addrs(bk_app):
             ]
         )
         yield
+
+
+def test_env_is_deployed(bk_stag_env, bk_prod_env, setup_addrs):
+    # See setup_addrs for details
+    assert env_is_deployed(bk_stag_env) is True
+    assert env_is_deployed(bk_prod_env) is False
 
 
 class TestGetAddresses:

--- a/apiserver/paasng/tests/publish/entrance/test_exposer.py
+++ b/apiserver/paasng/tests/publish/entrance/test_exposer.py
@@ -86,9 +86,12 @@ class TestModuleLiveAddrs:
             "env": "stag",
             "is_running": True,
             "addresses": [
-                {"type": "subdomain", "url": "http://foo.example.com/"},
-                {"type": "subpath", "url": "http://bar.example.com/bar/"},
+                # The addresses was given in random order in purpose
+                {"type": "subpath", "url": "http://bar.example.com/bar-2/", "is_sys_reserved": True},
                 {"type": "custom", "url": "http://custom.example.com/"},
+                {"type": "subdomain", "url": "http://foo.example.com/"},
+                {"type": "unknown", "url": "http://unknown.example.com/"},
+                {"type": "subpath", "url": "http://bar.example.com/bar/"},
             ],
         },
     ]
@@ -101,13 +104,19 @@ class TestModuleLiveAddrs:
 
     def test_get_addresses(self):
         addrs = ModuleLiveAddrs(self.module_addrs_data)
-        assert len(addrs.get_addresses('stag')) == 3
         assert addrs.get_addresses('prod') == []
         assert addrs.get_addresses('invalid-env') == []
 
+        stag_addrs = addrs.get_addresses('stag')
+        assert len(stag_addrs) == 5
+        assert [addr.type for addr in stag_addrs] == ['subpath', 'subpath', 'subdomain', 'custom', 'unknown']
+
     def test_get_addresses_with_type(self):
         addrs = ModuleLiveAddrs(self.module_addrs_data)
-        assert addrs.get_addresses('stag', addr_type='subpath') == [Address("subpath", "http://bar.example.com/bar/")]
+        assert addrs.get_addresses('stag', addr_type='subpath') == [
+            Address("subpath", "http://bar.example.com/bar/"),
+            Address("subpath", "http://bar.example.com/bar-2/", True),
+        ]
 
 
 def test__get_legacy_url(bk_stag_env):

--- a/apiserver/paasng/tests/publish/entrance/test_subpaths.py
+++ b/apiserver/paasng/tests/publish/entrance/test_subpaths.py
@@ -22,13 +22,15 @@ import cattr
 import pytest
 from django.test.utils import override_settings
 
-from paasng.engine.controller.models import IngressConfig, PortMap, Domain as DomainCfg
+from paasng.engine.controller.models import Domain as DomainCfg
+from paasng.engine.controller.models import IngressConfig, PortMap
 from paasng.publish.entrance.subpaths import (
     ModuleEnvSubpaths,
-    get_legacy_compatible_path,
-    get_preallocated_path,
     SubPathAllocator,
     SubpathPriorityType,
+    get_legacy_compatible_path,
+    get_preallocated_path,
+    get_preallocated_paths_by_env,
 )
 from tests.utils.mocks.engine import replace_cluster_service
 
@@ -164,38 +166,6 @@ def test_get_legacy_compatible_path(bk_stag_env):
     assert get_legacy_compatible_path(bk_stag_env) == f'/{module.region}-{bk_stag_env.engine_app.name}/'
 
 
-class TestMakeUserPreferredOne:
-    @pytest.fixture(autouse=True)
-    def _setup(self):
-        with replace_cluster_service(
-            ingress_config={
-                'sub_path_domains': [
-                    {"name": 'bar-1.example.com'},
-                    {"name": 'bar-2.example.com', 'https_enabled': True},
-                ],
-            }
-        ):
-            yield
-
-    @pytest.mark.parametrize(
-        'host,https_enabled',
-        [
-            ('bar-1.example.com', False),
-            ('bar-2.example.com', True),
-        ],
-    )
-    def test_https_enabled(self, bk_app, bk_prod_env, host, https_enabled):
-        bk_prod_env.module.user_preferred_root_domain = host
-        bk_prod_env.module.save()
-
-        p = ModuleEnvSubpaths(bk_prod_env).make_user_preferred_one()
-        assert p is not None
-        assert p.host == host
-        assert p.subpath == f'/{bk_app.code}/'
-        assert p.https_enabled is https_enabled
-        assert p.type == SubpathPriorityType.USER_PREFERRED
-
-
 class TestSubPathAllocator:
     @pytest.fixture
     def allocator(self) -> SubPathAllocator:
@@ -232,3 +202,38 @@ class TestSubPathAllocator:
         p = allocator.get_highest_priority(domain_cfg, 'm1', 'prod', is_default=True)
         assert p.subpath == '/some-app/'
         assert p.type == SubpathPriorityType.ONLY_CODE
+
+
+class TestGetPreallocatedPathsByEnv:
+    @pytest.fixture(autouse=True)
+    def _setup_cluster(self):
+        """Replace cluster info in module level"""
+        with replace_cluster_service(
+            ingress_config={
+                'sub_path_domains': [
+                    {"name": 'sub.example.com'},
+                    {"name": 'sub.example.org'},
+                ]
+            }
+        ):
+            yield
+
+    def test_default_prod_env(self, bk_app, bk_module, bk_prod_env):
+        bk_module.is_default = True
+        bk_module.save(update_fields=['is_default'])
+
+        results = get_preallocated_paths_by_env(bk_prod_env)
+        assert [(d.host, d.subpath) for d in results] == [
+            ('sub.example.com', f'/{bk_app.code}/'),
+            ('sub.example.org', f'/{bk_app.code}/'),
+        ]
+
+    def test_non_default(self, bk_app, bk_module, bk_stag_env):
+        bk_module.is_default = False
+        bk_module.save(update_fields=['is_default'])
+
+        results = get_preallocated_paths_by_env(bk_stag_env)
+        assert [(d.host, d.subpath) for d in results] == [
+            ('sub.example.com', f'/stag--default--{bk_app.code}/'),
+            ('sub.example.org', f'/stag--default--{bk_app.code}/'),
+        ]

--- a/apiserver/paasng/tests/publish/market/test_utils.py
+++ b/apiserver/paasng/tests/publish/market/test_utils.py
@@ -20,30 +20,15 @@ from unittest import mock
 
 import pytest
 
-from paasng.engine.constants import JobStatus
 from paasng.platform.modules.constants import ExposedURLType
 from paasng.platform.region.models import get_all_regions
-from paasng.publish.entrance.exposer import SubDomainURLProvider, SubPathURLProvider
+from paasng.publish.entrance.exposer import ModuleLiveAddrs
 from paasng.publish.market.constant import ProductSourceUrlType
 from paasng.publish.market.models import AvailableAddress, MarketConfig
 from paasng.publish.market.utils import MarketAvailableAddressHelper
-from tests.engine.setup_utils import create_fake_deployment
 from tests.utils.mocks.domain import FakeCustomDomainService
-from tests.utils.mocks.engine import replace_cluster_service
 
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture(autouse=True)
-def setup_cluster():
-    """Replace cluster info in module level"""
-    with replace_cluster_service(
-        ingress_config={
-            'app_root_domains': [{'name': 'example.com', 'https_enabled': True}],
-            'sub_path_domains': [{'name': 'example.com', 'https_enabled': True}],
-        }
-    ):
-        yield
 
 
 @pytest.fixture
@@ -57,17 +42,31 @@ def domain_svc():
 
 class TestMarketAvailableAddressHelper:
     @pytest.fixture(autouse=True)
-    def make_deployment(self, bk_module):
-        create_fake_deployment(bk_module, status=JobStatus.SUCCESSFUL.value)
+    def _setup(self):
+        with mock.patch('paasng.publish.entrance.exposer.get_live_addresses') as mocker:
+            mocker.return_value = ModuleLiveAddrs(
+                [
+                    {
+                        "env": "prod",
+                        "is_running": True,
+                        "addresses": [
+                            {"type": "subdomain", "url": "https://foo.example.com"},
+                            {"type": "subpath", "url": "https://example.org/foo/"},
+                        ],
+                    },
+                ]
+            )
+            yield
 
     @pytest.mark.parametrize(
-        'exposed_url_type, address_cls',
+        'exposed_url_type, expected_addr',
         [
-            (ExposedURLType.SUBDOMAIN.value, SubDomainURLProvider),
-            (ExposedURLType.SUBPATH.value, SubPathURLProvider),
+            (ExposedURLType.SUBDOMAIN.value, '//foo.example.com'),
+            (ExposedURLType.SUBPATH.value, '//example.org/foo/'),
         ],
     )
-    def test_list_by_exposed_url_type(self, exposed_url_type, address_cls, bk_app, bk_module, domain_svc):
+    def test_no_prefer_different_exposed_type(self, exposed_url_type, expected_addr, bk_app, domain_svc):
+        """No prefer HTTPS, test different exposed types"""
         for region in get_all_regions().keys():
             market_config, _ = MarketConfig.objects.get_or_create_by_app(bk_app)
             market_config.source_module.region = region
@@ -75,70 +74,46 @@ class TestMarketAvailableAddressHelper:
             market_config.prefer_https = False
             market_config.source_module.save()
 
-            helper = MarketAvailableAddressHelper(market_config)
-
             domain_svc.set_hostnames(['test.example.com'])
-            default_entrance = address_cls(helper.env).provide()
+            helper = MarketAvailableAddressHelper(market_config)
             assert helper.addresses == [
-                AvailableAddress(address=default_entrance.address.replace("https://", "http://"), type=2),
-                AvailableAddress(address=default_entrance.address.replace("http://", "https://"), type=5),
+                AvailableAddress(address='http:' + expected_addr, type=2),
+                AvailableAddress(address='https:' + expected_addr, type=5),
                 AvailableAddress(address="http://test.example.com", type=4),
             ]
 
     @pytest.mark.parametrize(
-        'exposed_url_type, address_cls',
+        'addr,expected_addr',
         [
-            (ExposedURLType.SUBDOMAIN.value, SubDomainURLProvider),
-            (ExposedURLType.SUBPATH.value, SubPathURLProvider),
+            ('https://foo.example.com', 'https://foo.example.com'),
+            ('http://foo.example.com', 'http://foo.example.com'),
         ],
     )
-    def test_prefer_https(self, exposed_url_type, address_cls, bk_app, bk_module, domain_svc):
-        for region in get_all_regions().keys():
-            market_config, _ = MarketConfig.objects.get_or_create_by_app(bk_app)
-            market_config.source_module.region = region
-            market_config.source_module.exposed_url_type = exposed_url_type
-            market_config.prefer_https = True
-            market_config.source_module.save()
+    def test_prefer_https(self, addr, expected_addr, bk_app, domain_svc):
+        with mock.patch('paasng.publish.entrance.exposer.get_live_addresses') as mocker:
+            mocker.return_value = ModuleLiveAddrs(
+                [
+                    {
+                        "env": "prod",
+                        "is_running": True,
+                        "addresses": [{"type": "subdomain", "url": addr}],
+                    },
+                ]
+            )
 
-            helper = MarketAvailableAddressHelper(market_config)
-
-            domain_svc.set_hostnames(['test.example.com'])
-            default_entrance = address_cls(helper.env).provide()
-            assert default_entrance.url.protocol == "https"
-            assert helper.addresses == [
-                AvailableAddress(address=default_entrance.address, type=2),
-                AvailableAddress(address="http://test.example.com", type=4),
-            ]
-
-    @pytest.mark.parametrize(
-        'exposed_url_type, address_cls',
-        [
-            (ExposedURLType.SUBDOMAIN.value, SubDomainURLProvider),
-            (ExposedURLType.SUBPATH.value, SubPathURLProvider),
-        ],
-    )
-    def test_https_unsupported(self, exposed_url_type, address_cls, bk_app, bk_module, domain_svc):
-        with replace_cluster_service(
-            ingress_config={
-                'app_root_domains': [{'name': 'example.com', 'https_enabled': False}],
-                'sub_path_domains': [{'name': 'example.com', 'https_enabled': False}],
-            }
-        ):
             for region in get_all_regions().keys():
                 market_config, _ = MarketConfig.objects.get_or_create_by_app(bk_app)
                 market_config.source_module.region = region
-                market_config.source_module.exposed_url_type = exposed_url_type
+                market_config.source_module.exposed_url_type = ExposedURLType.SUBDOMAIN.value
                 market_config.prefer_https = True
                 market_config.source_module.save()
 
                 helper = MarketAvailableAddressHelper(market_config)
 
                 domain_svc.set_hostnames(['test.example.com'])
-                default_entrance = address_cls(helper.env).provide()
-                assert default_entrance.url.protocol == "http"
                 assert helper.addresses == [
-                    AvailableAddress(address=default_entrance.address, type=2),
-                    AvailableAddress(address="http://test.example.com", type=4),
+                    AvailableAddress(address=expected_addr, type=2),
+                    AvailableAddress(address='http://test.example.com', type=4),
                 ]
 
     @pytest.mark.parametrize(
@@ -207,7 +182,12 @@ class TestMarketAvailableAddressHelper:
 
 
 class TestMarketAvailableAddressHelperNoDeployment:
-    def test_list_without_deploy(self, bk_app, bk_module, domain_svc):
+    @mock.patch('paasng.publish.market.utils.get_exposed_url')
+    def test_list_without_deploy(self, mocker, bk_app, bk_module, domain_svc):
+        # Mock get_exposed_url to return None in order to simulate env which has
+        # not been deployed yet.
+        mocker.return_value = None
+
         market_config, _ = MarketConfig.objects.get_or_create_by_app(bk_app)
         helper = MarketAvailableAddressHelper(market_config)
 

--- a/apiserver/paasng/tests/publish/sync_market/conftest.py
+++ b/apiserver/paasng/tests/publish/sync_market/conftest.py
@@ -1,0 +1,26 @@
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+import pytest
+
+from tests.utils.helpers import configure_regions
+
+
+@pytest.fixture(autouse=True)
+def setup_ieod_region():
+    with configure_regions(['ieod']):
+        yield

--- a/apiserver/paasng/tests/publish/test_entrance.py
+++ b/apiserver/paasng/tests/publish/test_entrance.py
@@ -29,8 +29,8 @@ from paasng.platform.core.storages.sqlalchemy import console_db
 from paasng.platform.modules.constants import ExposedURLType
 from paasng.platform.modules.models import Module
 from paasng.publish.entrance.exposer import (
-    LegacyEngineURLProvider,
     MarketURLProvider,
+    ModuleLiveAddrs,
     get_exposed_url,
     get_module_exposed_links,
     update_exposed_url_type_to_subdomain,
@@ -114,72 +114,54 @@ class TestMarketURLProvider:
         assert url is None
 
 
-class TestLegacyURLProvider:
-    @pytest.fixture(autouse=True)
-    def setUp(self, bk_module):
-        create_fake_deployment(bk_module, 'stag', status=JobStatus.SUCCESSFUL.value)
-        create_fake_deployment(bk_module, 'prod', status=JobStatus.SUCCESSFUL.value)
-
-    def test_env_normal(self, bk_prod_env):
-        url = LegacyEngineURLProvider(bk_prod_env).provide()
-        assert url
-        assert url.provider_type == 'legacy'
-
-
 class TestIntegratedNotDeployed:
     def test_normal(self, bk_stag_env, bk_prod_env, bk_module):
-        assert get_exposed_url(bk_stag_env) is None
-        assert get_exposed_url(bk_prod_env) is None
+        with mock.patch('paasng.publish.entrance.exposer.get_live_addresses') as mocker:
+            mocker.return_value = ModuleLiveAddrs(
+                [
+                    {"env": "stag", "is_running": False, "addresses": []},
+                    {"env": "prod", "is_running": False, "addresses": []},
+                ]
+            )
 
-        urls = get_module_exposed_links(bk_module)
-        assert urls == {
-            'stag': {'deployed': False, 'url': None},
-            'prod': {'deployed': False, 'url': None},
-        }
+            assert get_exposed_url(bk_stag_env) is None
+            assert get_exposed_url(bk_prod_env) is None
+
+            urls = get_module_exposed_links(bk_module)
+            assert urls == {
+                'stag': {'deployed': False, 'url': None},
+                'prod': {'deployed': False, 'url': None},
+            }
 
 
-class TestIntegratedLegacy:
-    @pytest.fixture(autouse=True)
-    def setUp(self, bk_module):
-        create_fake_deployment(bk_module, 'stag', status=JobStatus.SUCCESSFUL.value)
-        create_fake_deployment(bk_module, 'prod', status=JobStatus.SUCCESSFUL.value)
-        # Set exposed url type to default
-        bk_module.exposed_url_type = None
-        bk_module.save()
-
-    def test_prod_env_without_market(self, bk_stag_env):
-        url = get_exposed_url(bk_stag_env)
-        assert url
-        assert url.provider_type == 'legacy'
-
-    def test_prod_env_with_market(self, bk_app, bk_prod_env):
-        # Enable market
-        market_config, _ = MarketConfig.objects.get_or_create_by_app(bk_app)
-        market_config.enabled = True
-        market_config.save()
-
-        url = get_exposed_url(bk_prod_env)
-        assert url
-        assert url.provider_type == 'market'
-
-    def test_subdomain_without_market(self, bk_module, bk_stag_env):
+def test_get_module_exposed_links(bk_module, bk_stag_env):
+    with mock.patch('paasng.publish.entrance.exposer.get_live_addresses') as mocker:
+        mocker.return_value = ModuleLiveAddrs(
+            [
+                {
+                    "env": "stag",
+                    "is_running": True,
+                    "addresses": [
+                        {"type": "subdomain", "url": "http://foo-stag.example.com"},
+                    ],
+                },
+                {
+                    "env": "prod",
+                    "is_running": True,
+                    "addresses": [
+                        {"type": "subdomain", "url": "http://foo-prod.example.com"},
+                    ],
+                },
+            ]
+        )
         bk_module.exposed_url_type = ExposedURLType.SUBDOMAIN
         bk_module.save()
 
-        url = get_exposed_url(bk_stag_env)
-        assert url
-        assert url.provider_type == 'default_subdomain'
-
-        # Test get_module_exposed_links also
         urls = get_module_exposed_links(bk_module)
         assert urls == {
-            'stag': {'deployed': True, 'url': 'http://stag-dot-some-app-o.bkapps.example.com'},
-            'prod': {'deployed': True, 'url': 'http://some-app-o.bkapps.example.com'},
+            'stag': {'deployed': True, 'url': 'http://foo-stag.example.com'},
+            'prod': {'deployed': True, 'url': 'http://foo-prod.example.com'},
         }
-
-    def test_stag_env_offlined(self, bk_module, bk_stag_env):
-        bk_module.exposed_url_type = ExposedURLType.SUBDOMAIN
-        bk_module.save()
 
         # Simulate case when stag environment was offline
         bk_stag_env.is_offlined = True
@@ -188,7 +170,7 @@ class TestIntegratedLegacy:
         urls = get_module_exposed_links(bk_module)
         assert urls == {
             'stag': {'deployed': False, 'url': None},
-            'prod': {'deployed': True, 'url': 'http://some-app-o.bkapps.example.com'},
+            'prod': {'deployed': True, 'url': 'http://foo-prod.example.com'},
         }
 
 
@@ -207,7 +189,7 @@ class TestUpdateExposedURLType:
         assert bk_module.exposed_url_type == ExposedURLType.SUBDOMAIN
         assert mocked_client().update_domains.called
 
-    def test_with_legacy_market(self, bk_app, bk_module):
+    def test_with_legacy_market(self, with_live_addrs, bk_app, bk_module):
         if (
             getattr(settings, "BK_CONSOLE_DBCONF", None) is None
             or getattr(settings, "PAAS_LEGACY_DBCONF", None) is None
@@ -248,6 +230,7 @@ class TestUpdateExposedURLType:
             assert mocked_client().update_domains.called
             session = console_db.get_scoped_session()
             app = AppManger(session).get(bk_app.code)
+
             # 判断是否已同步至市场
             entrance = MarketAvailableAddressHelper(bk_app.market_config).access_entrance
             assert entrance

--- a/apiserver/paasng/tests/utils/helpers.py
+++ b/apiserver/paasng/tests/utils/helpers.py
@@ -328,7 +328,7 @@ def configure_regions(regions: List[str]):
             value['data'][region] = _tmpl_value
         region_aware_changes[name] = value
 
-    with override_settings(REGION_CONFIGS=new_region_configs, **region_aware_changes):
+    with override_settings(REGION_CONFIGS=new_region_configs, DEFAULT_REGION=regions[0], **region_aware_changes):
         load_regions_from_settings()
         yield
 

--- a/workloads/paas_wl/paas_wl/cluster/models.py
+++ b/workloads/paas_wl/paas_wl/cluster/models.py
@@ -86,6 +86,13 @@ class IngressConfig:
     frontend_ingress_ip: str = ''
     port_map: PortMap = Factory(PortMap)
 
+    def find_app_root_domain(self, hostname: str) -> Optional[Domain]:
+        """Find the possible app_root_domain by given hostname"""
+        for d in self.app_root_domains:
+            if hostname.endswith(d.name):
+                return d
+        return None
+
 
 class ClusterManager(models.Manager):
     @transaction.atomic()

--- a/workloads/paas_wl/paas_wl/platform/system_api/views.py
+++ b/workloads/paas_wl/paas_wl/platform/system_api/views.py
@@ -535,6 +535,7 @@ class EnvDeployedStatusViewSet(SysViewSet):
         列表（addresses）等。
 
         - “云原生”应用和普通应用都会返回有效的访问地址列表
+        - 访问地址排序：基于非保留系统域名，并且更短的排在前面
         """
         app = get_structured_app(code=code)
         results = []

--- a/workloads/paas_wl/tests/cluster/test_models.py
+++ b/workloads/paas_wl/tests/cluster/test_models.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+import cattr
 import pytest
 from blue_krill.contextlib import nullcontext as does_not_raise
 from django.db.utils import IntegrityError
@@ -137,6 +138,21 @@ class TestIngressConfigField:
         assert c.ingress_config.app_root_domains[1].reserved is False
         assert c.ingress_config.app_root_domains[2].name == "baz.com"
         assert c.ingress_config.app_root_domains[2].reserved is True
+
+    def test_find_app_root_domain(self):
+        d = {
+            "app_root_domains": [
+                {"name": "bar.example.com"},
+                {"name": "foo.example.com", "reserved": True},
+            ]
+        }
+        config = cattr.structure(d, IngressConfig)
+        root_domain = config.find_app_root_domain('test.foo.example.com')
+        assert root_domain is not None
+        assert root_domain.name == 'foo.example.com'
+        assert root_domain.reserved is True
+
+        assert config.find_app_root_domain('test.foo.example.org') is None
 
 
 class TestEnhancedConfiguration:


### PR DESCRIPTION
### 概览

本次调整后，所有地址计算算法合并入 `SubDomainAllocator` / `SubPathAllocator` 类。其他需要获取访问地址的地方，主要分为两类：

- 获取可访问的真实地址：`get_addresses()` / `get_exposed_url()` / ...
- 获取不保证可访问的预分布地址：`get_preallocated_*()` / ...

### 相关

- 调整 `exposer.py`，删除所有的 `*Provider` 类型，直接使用 workloads 服务返回的真实地址替代
- 将 `get_default_entrance(s?)` 重构为 `get_preallocated_*` 函数，复用 `*Allocator` 算法模块
- 删除之前为云原生应用编写专用过渡函数 `get_*_live`，与普通应用使用同一套函数
- 调整应用地址相关，直接使用 workloads 返回的真实地址
- 调整 `user_preferred_root_domain` 的生效逻辑，仅在已有地址中做筛选，不再“造”地址
 
### 已知功能性变更

- 使用 `get_exposed_url()` 等函数获取访问地址时，不再返回应用市场地址
- ~当 sub_path_domains 中存在 reserved 为 True 和 False 的域名时，新做法不保证一定优先拿 reserved 为 False 的条目~