### PR TITLE
Fix module/app deletion, delete related custom domains and other resources

### DIFF
--- a/apiserver/paasng/paasng/engine/controller/client.py
+++ b/apiserver/paasng/paasng/engine/controller/client.py
@@ -327,6 +327,12 @@ class ControllerClient:
         """List all env's addresses under given module, result include "is_running" status"""
         return self.request('GET', f'/applications/{app_code}/modules/{module_name}/addresses/')
 
+    def delete_module_related_res(self, app_code: str, module_name: str):
+        """Delete module's related resources"""
+        return self.request(
+            'DELETE', f'/applications/{app_code}/modules/{module_name}/related_resources/', desired_code=204
+        )
+
     # Bk-App(module) related end
 
     # App Domains start

--- a/apiserver/paasng/paasng/platform/modules/manager.py
+++ b/apiserver/paasng/paasng/platform/modules/manager.py
@@ -359,10 +359,12 @@ class ModuleCleaner:
 
     def delete_engine_apps(self):
         """调用 workloads 接口删除与当前模块关联的 EngineApp"""
+        # Delete all related resources in workloads
+        controller_client.delete_module_related_res(self.module.application.code, self.module.name)
+
+        # Delete related EngineApp db records
         for env in self.module.get_envs():
-            engine_app = env.get_engine_app()
-            controller_client.app__delete(app_name=engine_app.name, region=engine_app.region)
-            engine_app.delete()
+            env.get_engine_app().delete()
 
     def delete_module(self):
         """删除模块的数据库记录(真删除)"""

--- a/apiserver/paasng/tests/utils/mocks/engine.py
+++ b/apiserver/paasng/tests/utils/mocks/engine.py
@@ -142,3 +142,6 @@ class StubControllerClient:
 
     def sync_processes_specs(self, region: str, app_name: str, processes: List[Dict]):
         return
+
+    def delete_module_related_res(self, app_code: str, module_name: str):
+        return

--- a/workloads/paas_wl/paas_wl/platform/applications/models_utils.py
+++ b/workloads/paas_wl/paas_wl/platform/applications/models_utils.py
@@ -1,0 +1,66 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+"""Utilities related with application models"""
+import logging
+
+from django.db import models
+
+from paas_wl.cnative.specs.models import AppModelDeploy, AppModelResource, AppModelRevision
+from paas_wl.networking.ingress.models import Domain
+from paas_wl.platform.applications.models import BuildProcess, EngineApp
+from paas_wl.platform.applications.struct_models import Module, get_structured_app
+from paas_wl.resources.actions.delete import delete_app_resources
+from paas_wl.workloads.processes.models import ProcessSpec
+
+logger = logging.getLogger(__name__)
+
+
+def delete_module_related_res(module: Module) -> None:
+    """Delete all related resources of module"""
+    app = get_structured_app(code=module.application.code)
+
+    # Remove module level data
+    model_cls: models.Model
+    for model_cls in [Domain, AppModelDeploy, AppModelResource, AppModelRevision]:
+        model_cls.objects.filter(module_id=module.id).delete()
+
+    # Environment/EngineApp level data
+    for env in app.get_envs_by_module(module):
+        # Manually remove data which don't has a foreign key relation
+        ProcessSpec.objects.filter(engine_app_id=env.engine_app_id).delete()
+        # Remove OutputStream manually because there is no backward foreign key
+        # relationship.
+        for bp in BuildProcess.objects.filter(app__uuid=env.engine_app_id):
+            bp.output_stream.delete()
+
+        # Delete EngineApp and it's related resources and models
+        try:
+            engine_app = EngineApp.objects.get(pk=env.engine_app_id)
+        except EngineApp.DoesNotExist:
+            continue
+
+        # Delete all resources in cluster, allow failure
+        try:
+            delete_app_resources(engine_app)
+        except Exception as e:
+            logger.warning('Error deleting app cluster resources, app: %s, error: %s', engine_app, e)
+
+        # This will also remove cascaded models:
+        # Build, BuildProcess, Config, Release, AppMetricsMonitor, AppImageCredential,
+        # AppAddOn, AppDomain, AppSubpath.
+        engine_app.delete()

--- a/workloads/paas_wl/paas_wl/platform/system_api/urls.py
+++ b/workloads/paas_wl/paas_wl/platform/system_api/urls.py
@@ -122,4 +122,8 @@ urlpatterns += [
         make_app_path(r'/addresses/$', include_envs=False),
         views.EnvDeployedStatusViewSet.as_view({'get': 'list_addrs'}),
     ),
+    re_path(
+        make_app_path(r'/related_resources/$', include_envs=False),
+        views.BkModuleRelatedResourcesViewSet.as_view({'delete': 'destroy'}),
+    ),
 ]

--- a/workloads/paas_wl/paas_wl/resources/actions/delete.py
+++ b/workloads/paas_wl/paas_wl/resources/actions/delete.py
@@ -16,39 +16,20 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-import logging
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
-
-from django.db import models
 
 from paas_wl.platform.applications.models import Release
 from paas_wl.resources.utils.app import get_scheduler_client_by_app
 
 if TYPE_CHECKING:
-    from paas_wl.platform.applications.models.app import App
+    from paas_wl.platform.applications.models.app import EngineApp
 
 
-logger = logging.getLogger(__name__)
-
-
-@dataclass
-class AppDeletion:
-    app: 'App'
-
-    def perform(self, *args, **kwargs):
-        """delete app resource under namespace"""
-        try:
-            release = Release.objects.get_latest(self.app, ignore_failed=True)
-        except models.ObjectDoesNotExist:
-            # 应用未发布过, 不执行删除逻辑
-            return
-
-        if release.build is None:
-            # NOTE: 由于历史原因, 如果应用未发布过, 有可能存在 build is None 的 Release 对象。
-            # 应用未发布过, 不执行删除逻辑
-            return
-
-        scheduler_client = get_scheduler_client_by_app(self.app)
-        scheduler_client.delete_all_under_namespace(namespace=self.app.namespace)
+def delete_app_resources(app: 'EngineApp'):
+    """Delete app's resources in cluster"""
+    if not Release.objects.any_successful(app):
         return
+
+    scheduler_client = get_scheduler_client_by_app(app)
+    scheduler_client.delete_all_under_namespace(namespace=app.namespace)
+    return

--- a/workloads/paas_wl/tests/api/system_api/conftest.py
+++ b/workloads/paas_wl/tests/api/system_api/conftest.py
@@ -28,11 +28,11 @@ from paas_wl.release_controller.builder.tasks import start_build_process
 
 
 @pytest.fixture
-def engine_app(fake_app):
+def engine_app(bk_stag_engine_app):
     Config.objects.create(
-        app=fake_app, metadata={"environment": 'prod', "paas_app_code": 'foo', "module_name": 'default'}
+        app=bk_stag_engine_app, metadata={"environment": 'prod', "paas_app_code": 'foo', "module_name": 'default'}
     )
-    return fake_app
+    return bk_stag_engine_app
 
 
 @pytest.fixture

--- a/workloads/paas_wl/tests/platform/applications/test_models_utils.py
+++ b/workloads/paas_wl/tests/platform/applications/test_models_utils.py
@@ -1,0 +1,43 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+import pytest
+
+from paas_wl.networking.ingress.models import Domain
+from paas_wl.platform.applications.models import Build, EngineApp, Release
+from paas_wl.platform.applications.models_utils import delete_module_related_res
+
+pytestmark = pytest.mark.django_db
+
+
+class TestDeleteModuleRelatedRes:
+    @pytest.mark.mock_get_structured_app
+    def test_normal(self, bk_user, bk_module, bk_stag_env, bk_stag_engine_app):
+        # Setup data
+        Domain.objects.create(name='example.com', module_id=bk_module.id, environment_id=bk_stag_env.id)
+        build = Build.objects.create(owner=bk_user.username, app=bk_stag_engine_app)
+        bk_stag_engine_app.release_set.new(bk_user.username, build=build, procfile={'web': 'true'})
+
+        assert Domain.objects.filter(module_id=bk_module.id).exists()
+        assert EngineApp.objects.filter(uuid=bk_stag_env.engine_app_id).exists()
+        assert Release.objects.filter(app__uuid=bk_stag_env.engine_app_id).exists()
+
+        delete_module_related_res(bk_module)
+
+        assert not Domain.objects.filter(module_id=bk_module.id).exists()
+        assert not EngineApp.objects.filter(uuid=bk_stag_env.engine_app_id).exists()
+        assert not Release.objects.filter(app__uuid=bk_stag_env.engine_app_id).exists()

--- a/workloads/paas_wl/tests/platform/applications/test_struct_models.py
+++ b/workloads/paas_wl/tests/platform/applications/test_struct_models.py
@@ -40,6 +40,12 @@ from tests.utils.mocks.platform import FakePlatformSvcClient, make_structured_ap
 
 
 @pytest.fixture
+def structured_app_data(bk_app):
+    """Structured application data with one default module"""
+    return make_structured_app_data(bk_app)
+
+
+@pytest.fixture
 def application():
     return Application(
         id=uuid.uuid4(),


### PR DESCRIPTION
- fix: module deletion protections not working at all.
- workloads: add `delete_module_related_res` API
- workloads: refactor test fixture
- apiserver: use updated API for deleting module in order to delete related custom domains