### PR TITLE
Turn on connection polling when requesting "workloads" from "apiserver"(and vice versa)

### DIFF
--- a/apiserver/paasng/paasng/engine/controller/client.py
+++ b/apiserver/paasng/paasng/engine/controller/client.py
@@ -21,11 +21,11 @@ to the current version of the project delivered to anyone in the future.
 import logging
 from typing import Any, Dict, List, Optional
 
-import requests
 from blue_krill.auth.jwt import ClientJWTAuth, JWTAuthConf
 from django.conf import settings
 from requests.status_codes import codes
 
+from paasng.utils.basic import get_requests_session
 from paasng.utils.local import local
 
 from .exceptions import BadResponse
@@ -422,7 +422,7 @@ class ControllerClient:
         kwargs['headers'] = {settings.REQUEST_ID_HEADER_KEY: local.request_id}
         kwargs['auth'] = self.auth_instance
         logger.debug(f"Controller client sending request to [{method}]{url}, kwargs={kwargs}.")
-        resp = requests.request(method, url, **kwargs)
+        resp = get_requests_session().request(method, url, **kwargs)
 
         if resp.status_code == desired_code:
             try:

--- a/apiserver/paasng/paasng/utils/basic.py
+++ b/apiserver/paasng/paasng/utils/basic.py
@@ -21,6 +21,8 @@ import re
 import subprocess
 from typing import TYPE_CHECKING, Any, ClassVar, Iterable, Tuple
 
+import requests
+import requests.adapters
 from bkpaas_auth import get_user_by_user_id
 from django.urls.resolvers import RegexPattern, URLPattern, URLResolver
 from django.utils.encoding import force_text
@@ -203,3 +205,15 @@ def re_path(route, view, kwargs=None, name=None):
         return URLPattern(pattern, view, kwargs, name)
     else:
         raise TypeError('view must be a callable or a list/tuple in the case of include().')
+
+
+# Make a global session object to turn on connection polling
+_requests_session = requests.Session()
+_adapter = requests.adapters.HTTPAdapter(pool_connections=10, pool_maxsize=10)
+_requests_session.mount('http://', _adapter)
+_requests_session.mount('https://', _adapter)
+
+
+def get_requests_session() -> requests.Session:
+    """Return the global requests session object which supports connection polling"""
+    return _requests_session

--- a/apiserver/paasng/paasng/utils/basic.py
+++ b/apiserver/paasng/paasng/utils/basic.py
@@ -207,7 +207,7 @@ def re_path(route, view, kwargs=None, name=None):
         raise TypeError('view must be a callable or a list/tuple in the case of include().')
 
 
-# Make a global session object to turn on connection polling
+# Make a global session object to turn on connection pooling
 _requests_session = requests.Session()
 _adapter = requests.adapters.HTTPAdapter(pool_connections=10, pool_maxsize=10)
 _requests_session.mount('http://', _adapter)
@@ -215,5 +215,5 @@ _requests_session.mount('https://', _adapter)
 
 
 def get_requests_session() -> requests.Session:
-    """Return the global requests session object which supports connection polling"""
+    """Return the global requests session object which supports connection pooling"""
     return _requests_session

--- a/workloads/paas_wl/paas_wl/utils/basic.py
+++ b/workloads/paas_wl/paas_wl/utils/basic.py
@@ -23,6 +23,8 @@ from typing import ClassVar, Collection, Dict, Tuple
 from uuid import UUID
 
 import cattr
+import requests
+import requests.adapters
 from attrs import define
 from django.urls.resolvers import RegexPattern, URLPattern, URLResolver
 from django.utils.encoding import force_bytes
@@ -187,3 +189,15 @@ class HumanizeURL:
         if self._default_port_map[self.protocol] == self.port:
             port_s = ''
         return f"{self.protocol}://{self.hostname}{port_s}{self.path}{query_s}"
+
+
+# Make a global session object to turn on connection polling
+_requests_session = requests.Session()
+_adapter = requests.adapters.HTTPAdapter(pool_connections=10, pool_maxsize=10)
+_requests_session.mount('http://', _adapter)
+_requests_session.mount('https://', _adapter)
+
+
+def get_requests_session() -> requests.Session:
+    """Return the global requests session object which supports connection polling"""
+    return _requests_session

--- a/workloads/paas_wl/paas_wl/utils/basic.py
+++ b/workloads/paas_wl/paas_wl/utils/basic.py
@@ -191,7 +191,7 @@ class HumanizeURL:
         return f"{self.protocol}://{self.hostname}{port_s}{self.path}{query_s}"
 
 
-# Make a global session object to turn on connection polling
+# Make a global session object to turn on connection pooling
 _requests_session = requests.Session()
 _adapter = requests.adapters.HTTPAdapter(pool_connections=10, pool_maxsize=10)
 _requests_session.mount('http://', _adapter)
@@ -199,5 +199,5 @@ _requests_session.mount('https://', _adapter)
 
 
 def get_requests_session() -> requests.Session:
-    """Return the global requests session object which supports connection polling"""
+    """Return the global requests session object which supports connection pooling"""
     return _requests_session


### PR DESCRIPTION
Besides the changes made in current PR, gunicron with async worker is also required to support connection polling, ref: https://docs.gunicorn.org/en/stable/faq.html#why-is-there-no-http-keep-alive