### PR TITLE
fix: 调整 pre-release-hook 探测执行结束的探针逻辑为判断主容器是否正常退出, 以兼容 sidecar 容器

### DIFF
--- a/workloads/paas_wl/paas_wl/resources/base/exceptions.py
+++ b/workloads/paas_wl/paas_wl/resources/base/exceptions.py
@@ -46,11 +46,11 @@ class PodNotSucceededError(KubeException):
         self.exit_code = kwargs.get("exit_code", -1)
 
 
-class PodNotSucceededAbsentError(PodNotSucceededError):
+class PodAbsentError(PodNotSucceededError):
     """pod not succeeded triggered by pod's absence"""
 
 
-class PodNotSucceededTimeoutError(PodNotSucceededError):
+class PodTimeoutError(PodNotSucceededError):
     """pod not succeeded triggered by timeout"""
 
 

--- a/workloads/paas_wl/tests/resources/base/test_client.py
+++ b/workloads/paas_wl/tests/resources/base/test_client.py
@@ -32,9 +32,9 @@ from paas_wl.release_controller.entities import Runtime
 from paas_wl.resources.base.client import K8sScheduler
 from paas_wl.resources.base.controllers import BuildHandler
 from paas_wl.resources.base.exceptions import (
-    PodNotSucceededAbsentError,
+    PodAbsentError,
     PodNotSucceededError,
-    PodNotSucceededTimeoutError,
+    PodTimeoutError,
     ResourceDuplicate,
     ResourceMissing,
 )
@@ -308,14 +308,14 @@ class TestClientBuildNew:
         assert scheduler_client.interrupt_builder(namespace=app.namespace, name=generate_builder_name(app)) is False
 
     def test_wait_for_succeeded_no_pod(self, app, scheduler_client):
-        with pytest.raises(PodNotSucceededAbsentError):
+        with pytest.raises(PodAbsentError):
             scheduler_client.wait_build_succeeded(app.namespace, generate_builder_name(app), timeout=1)
 
     @pytest.mark.parametrize(
         'phase, exc_context',
         [
-            ('Pending', pytest.raises(PodNotSucceededTimeoutError)),
-            ('Running', pytest.raises(PodNotSucceededTimeoutError)),
+            ('Pending', pytest.raises(PodTimeoutError)),
+            ('Running', pytest.raises(PodTimeoutError)),
             ('Failed', pytest.raises(PodNotSucceededError)),
             ('Unknown', pytest.raises(PodNotSucceededError)),
             ('Succeeded', does_not_raise()),

--- a/workloads/paas_wl/tests/resources/base/test_controllers.py
+++ b/workloads/paas_wl/tests/resources/base/test_controllers.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+from textwrap import dedent
+
+import pytest
+from django_dynamic_fixture import G
+
+from paas_wl.release_controller.hooks.entities import Command, command_kmodel
+from paas_wl.release_controller.hooks.models import Command as CommandModel
+from paas_wl.resources.base.controllers import CommandHandler
+from paas_wl.resources.base.exceptions import PodNotSucceededTimeoutError
+from paas_wl.resources.base.generation import get_mapper_version
+from paas_wl.resources.kube_res.exceptions import AppEntityNotFound
+from paas_wl.workloads.resource_templates.constants import AppAddOnType
+from paas_wl.workloads.resource_templates.models import AppAddOnTemplate
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.auto_create_ns
+class TestCommand:
+    @pytest.fixture
+    def command_model(self, app):
+        config = app.latest_config
+        config.runtime.image = "busybox:latest"
+        config.runtime.endpoint = ["sh", "-c"]
+        config.save()
+        return G(
+            CommandModel,
+            app=app,
+            command="echo 'finished'",
+            config=config,
+        )
+
+    @pytest.fixture
+    def command(self, command_model):
+        return Command.from_db_obj(command_model)
+
+    @pytest.fixture
+    def handler(self, k8s_client, settings):
+        return CommandHandler(
+            client=k8s_client,
+            default_connect_timeout=settings.K8S_DEFAULT_CONNECT_TIMEOUT,
+            default_request_timeout=settings.K8S_DEFAULT_CONNECT_TIMEOUT + settings.K8S_DEFAULT_READ_TIMEOUT,
+            mapper_version=get_mapper_version(
+                target=settings.GLOBAL_DEFAULT_MAPPER_VERSION, init_kwargs={'client': k8s_client}
+            ),
+        )
+
+    def test_run(self, handler, command):
+        with pytest.raises(AppEntityNotFound):
+            command_kmodel.get(command.app, command.name)
+
+        handler.run_command(command)
+        handler._wait_pod_succeeded(namespace=command.app.namespace, pod_name=command.name, timeout=60)
+        command_in_k8s = command_kmodel.get(command.app, command.name)
+        assert command_in_k8s.status == "Succeeded"
+
+    @pytest.fixture
+    def sidecar(self, app):
+        template = G(
+            AppAddOnTemplate,
+            name="sidecar",
+            spec=dedent(
+                """
+                {
+                    "name": "sidecar",
+                    "image": "busybox:latest",
+                    "command": ["sleep", "600"]
+                }
+            """
+            ),
+            type=AppAddOnType.SIMPLE_SIDECAR,
+        )
+        return template.link_to_app(app)
+
+    def test_run_with_sidecar(self, handler, command, sidecar):
+        handler.run_command(command)
+        handler.wait_for_succeeded(command, timeout=60)
+        with pytest.raises(PodNotSucceededTimeoutError):
+            handler._wait_pod_succeeded(namespace=command.app.namespace, pod_name=command.name, timeout=1)
+        command_in_k8s = command_kmodel.get(command.app, command.name)
+        # 虽然 Pod 仍在运行, 但是主容器已退出
+        assert command_in_k8s.status == "Running"
+        assert command_in_k8s.main_container_exit_code == 0


### PR DESCRIPTION
只要主容器退出, 就认为 pre-release-hook 执行完毕