### PR TITLE
feat: 插件信息中 extraFields 定义类型修改

### DIFF
--- a/apiserver/paasng/paasng/pluginscenter/definitions.py
+++ b/apiserver/paasng/paasng/pluginscenter/definitions.py
@@ -121,7 +121,7 @@ class PluginBasicInfoDefinition(BaseModel):
     releaseMethod: Literal["code", "sourcePackage", "image"] = Field(description="插件发布方式")
     initTemplates: List[PluginCodeTemplate] = Field(description="插件初始化模板")
     repositoryGroup: str = Field(description="插件代码初始化仓库组")
-    extraFields: Dict[str, FieldSchema] = Field(default_factory=dict)
+    extraFields: dict = Field(default_factory=dict)
     api: PluginBackendAPI = Field(description="基础信息操作接口集")
     syncMembers: PluginBackendAPIResource = Field(description="人员同步接口")
 
@@ -157,7 +157,7 @@ class PluginMarketInfoDefinition(BaseModel):
     )
     category: PluginBackendAPIResource = Field(description="市场类型分类查询接口")
     api: Optional[PluginBackendAPI] = Field(description="插件市场信息操作接口集")
-    extraFields: Dict[str, FieldSchema] = Field(default_factory=dict)
+    extraFields: dict = Field(default_factory=dict)
     # TODO: visibleRange
 
 
@@ -171,7 +171,7 @@ class ReleaseRevisionDefinition(BaseModel):
     versionNo: Literal["automatic", "revision", "commit-hash", "self-fill"] = Field(
         description="版本号生成规则, 自动生成(automatic)," "与代码版本一致(revision)," "与提交哈希一致(commit-hash)," "用户自助填写(self-fill)"
     )
-    extraFields: Dict[str, FieldSchema] = Field(default_factory=dict)
+    extraFields: dict = Field(default_factory=dict)
     api: Optional[PluginBackendAPI] = Field(description="发布版本-操作接口集, 如需要回调至第三方系统, 则需要提供 create 接口")
 
 

--- a/apiserver/paasng/paasng/pluginscenter/management/commands/create_or_update_plugin_type.py
+++ b/apiserver/paasng/paasng/pluginscenter/management/commands/create_or_update_plugin_type.py
@@ -48,7 +48,6 @@ class Command(BaseCommand):
         parser.add_argument('--dry-run', dest="dry_run", help="dry run", action="store_true")
 
     def handle(self, identifier, env, dry_run, *args, **options):
-
         file_path = Path(settings.BASE_DIR) / 'support-files' / 'plugin' / f'{identifier}-{env}.yaml'
         with open(file_path, 'r', encoding='utf-8') as f:
             data = yaml.load(f)
@@ -79,7 +78,6 @@ class Command(BaseCommand):
                 'features': pd_data.features,
             },
         )
-
         # 插件基本信息
         models.PluginBasicInfoDefinition.objects.update_or_create(
             pd=pd,

--- a/apiserver/paasng/paasng/pluginscenter/migrations/0001_initial.py
+++ b/apiserver/paasng/paasng/pluginscenter/migrations/0001_initial.py
@@ -157,7 +157,7 @@ class Migration(migrations.Migration):
                 ('storage', models.CharField(max_length=16, verbose_name='存储方式')),
                 ('category', paasng.pluginscenter.models.definitions.PluginBackendAPIResourceField()),
                 ('api', paasng.pluginscenter.models.definitions.PluginBackendAPIField(null=True)),
-                ('extra_fields', paasng.pluginscenter.models.definitions.PluginExtraFieldField(default=dict)),
+                ('extra_fields', models.JSONField(default=dict)),
                 ('pd', models.OneToOneField(db_constraint=False, on_delete=django.db.models.deletion.CASCADE, related_name='market_info_definition', to='pluginscenter.plugindefinition')),
             ],
             options={
@@ -195,7 +195,7 @@ class Migration(migrations.Migration):
                 ('release_method', models.CharField(max_length=16, verbose_name='发布方式')),
                 ('repository_group', models.CharField(max_length=255, verbose_name='插件代码初始化仓库组')),
                 ('api', paasng.pluginscenter.models.definitions.PluginBackendAPIField()),
-                ('extra_fields', paasng.pluginscenter.models.definitions.PluginExtraFieldField(default=dict)),
+                ('extra_fields', models.JSONField(default=dict)),
                 ('pd', models.OneToOneField(db_constraint=False, on_delete=django.db.models.deletion.CASCADE, related_name='basic_info_definition', to='pluginscenter.plugindefinition')),
             ],
             options={

--- a/apiserver/paasng/paasng/pluginscenter/models/definitions.py
+++ b/apiserver/paasng/paasng/pluginscenter/models/definitions.py
@@ -16,7 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-from typing import Dict, List
+from typing import List
 
 from django.db import models
 from translated_fields import TranslatedFieldWithFallback
@@ -43,7 +43,6 @@ ReleaseStageDefinitionField = make_json_field("ReleaseStageDefinitionField", Lis
 PluginLogConfigField = make_json_field("PluginLogConfigField", PluginLogConfig)
 PluginCreateApprovalField = make_json_field("PluginCreateApprovalField", PluginCreateApproval)
 PluginCodeTemplateListField = make_json_field("PluginCodeTemplateListField", List[PluginCodeTemplate])
-PluginExtraFieldField = make_json_field("PluginExtraFieldField", Dict[str, FieldSchema])
 PluginConfigColumnDefinitionField = make_json_field(
     "PluginConfigColumnDefinitionField", List[PluginConfigColumnDefinition]
 )
@@ -77,7 +76,7 @@ class PluginBasicInfoDefinition(AuditedModel):
     repository_group = models.CharField(verbose_name="插件代码初始化仓库组", max_length=255)
     api: PluginBackendAPI = PluginBackendAPIField()
     sync_members: PluginBackendAPIResource = PluginBackendAPIResourceField(null=True)
-    extra_fields = PluginExtraFieldField(default=dict)
+    extra_fields = models.JSONField(default=dict)
 
     @classmethod
     def get_languages(cls) -> List[str]:
@@ -99,7 +98,7 @@ class PluginMarketInfoDefinition(AuditedModel):
     storage = models.CharField(verbose_name="存储方式", max_length=16)
     category: PluginBackendAPIResource = PluginBackendAPIResourceField()
     api: PluginBackendAPI = PluginBackendAPIField(null=True)
-    extra_fields = PluginExtraFieldField(default=dict)
+    extra_fields = models.JSONField(default=dict)
 
 
 class PluginConfigInfoDefinition(AuditedModel):


### PR DESCRIPTION
extraFields 需要按照蓝鲸表单生成器的格式定义以下内容：
```
{
    "schema": {
        "type": "object",
        "properties": {
            "distributor_codes": {
                "title": "插件使用方",
                "type": "array",
                "items": {
                    "type": "string"
                },
                "ui:component": {
                    "name": "select",
                    "props": {
                        "clearable": true,
                        "remoteConfig": {
                            "url": "${BACKEND_URL}/api/bk_plugin_distributors/",
                            "label": "name",
                            "value": "code_name"
                        },
                        "searchable": true
                    }
                },
                "ui:reactions": [
                    {
                        "lifetime": "init",
                        "then": {
                            "actions": [
                                "{{ $loadDataSource }}"
                            ]
                        }
                    }
                ]
            }
        }
    }
}
```