### PR TITLE
refactor: 移除 AppEntitySerializer.get_res_name 协议; 规范 Process.name/Pro…

### DIFF
--- a/apiserver/paasng/paas_wl/networking/ingress/managers/service.py
+++ b/apiserver/paasng/paas_wl/networking/ingress/managers/service.py
@@ -80,4 +80,4 @@ class ProcDefaultServices:
     def should_create_ingress(self):
         """whether to create an ingress rule or not"""
         # TODO: 由 ProcessSpec 模型控制是否创建 ingress
-        return self.process.name == "web"
+        return self.process.type == "web"

--- a/apiserver/paasng/paas_wl/resources/actions/deploy.py
+++ b/apiserver/paasng/paas_wl/resources/actions/deploy.py
@@ -104,7 +104,7 @@ class ZombieProcessesKiller:
     僵尸进程清理者
     两种情况会产生僵尸进程：
     - 用户修改了 process_type
-    - 用户修改了 process_name （后期需要去除掉 process_name）
+    - 用户修改了 command_name( v1 mapper 的资源名依赖了 command_name)
     :return: processes which should be undead
     """
 
@@ -113,7 +113,7 @@ class ZombieProcessesKiller:
 
     def search(self) -> Tuple[List['Process'], List['Process']]:
         """
-        :return: tuple, (type_processes, name_processes)
+        :return: tuple, (List[Process] with inconsistent process types, List[Process] with inconsistent command name)
         """
         # 首次部署
         if not self.last_release or not self.last_release.build:
@@ -131,7 +131,7 @@ class ZombieProcessesKiller:
                 process_type=last_type, release=self.last_release
             )
 
-            if last_process.name not in procfile:
+            if last_process.type not in procfile:
                 zombie_type_processes.append(last_process)
                 continue
 

--- a/apiserver/paasng/paas_wl/resources/base/generation/mapper.py
+++ b/apiserver/paasng/paas_wl/resources/base/generation/mapper.py
@@ -161,6 +161,8 @@ class MapperPack:
     replica_set: MapperField[KReplicaSet]
 
     def __init__(self, client: Optional['EnhancedApiClient'] = None):
+        # client can only be used at CallThroughKresMapper
+        # never be used at Mapper
         self.client = client
 
     @property

--- a/apiserver/paasng/paas_wl/resources/base/generation/v1.py
+++ b/apiserver/paasng/paas_wl/resources/base/generation/v1.py
@@ -35,12 +35,12 @@ class PodMapper(CallThroughKresMapper[KPod]):
 
     @property
     def pod_selector(self) -> str:
-        return f"{v1_scheduler_safe_name(self.process.app)}-{self.process.name}-deployment"
+        return f"{v1_scheduler_safe_name(self.process.app)}-{self.process.type}-deployment"
 
     @property
     def name(self):
         return (
-            f"{v1_scheduler_safe_name(self.process.app)}-{self.process.name}-"
+            f"{v1_scheduler_safe_name(self.process.app)}-{self.process.type}-"
             f"{get_command_name(self.process.runtime.proc_command)}-deployment"
         )
 
@@ -57,7 +57,7 @@ class PodMapper(CallThroughKresMapper[KPod]):
             region=self.process.app.region,
             env=mdata.environment,
             module_name=mdata.module_name,
-            process_id=self.process.name,
+            process_id=self.process.type,
             # mark deployment as bkapp, maybe we will have other category in the future.
             category="bkapp",
             mapper_version="v1",
@@ -75,7 +75,7 @@ class DeploymentMapper(CallThroughKresMapper[KDeployment]):
 
     @property
     def pod_selector(self) -> str:
-        return f"{v1_scheduler_safe_name(self.process.app)}-{self.process.name}-deployment"
+        return f"{v1_scheduler_safe_name(self.process.app)}-{self.process.type}-deployment"
 
     @property
     def labels(self) -> dict:
@@ -93,7 +93,7 @@ class DeploymentMapper(CallThroughKresMapper[KDeployment]):
     @property
     def name(self) -> str:
         return (
-            f"{v1_scheduler_safe_name(self.process.app)}-{self.process.name}-"
+            f"{v1_scheduler_safe_name(self.process.app)}-{self.process.type}-"
             f"{get_command_name(self.process.runtime.proc_command)}-deployment"
         )
 
@@ -103,12 +103,12 @@ class ReplicaSetMapper(CallThroughKresMapper[KReplicaSet]):
 
     @property
     def pod_selector(self) -> str:
-        return f"{v1_scheduler_safe_name(self.process.app)}-{self.process.name}-deployment"
+        return f"{v1_scheduler_safe_name(self.process.app)}-{self.process.type}-deployment"
 
     @property
     def name(self) -> str:
         return (
-            f"{v1_scheduler_safe_name(self.process.app)}-{self.process.name}-"
+            f"{v1_scheduler_safe_name(self.process.app)}-{self.process.type}-"
             f"{get_command_name(self.process.runtime.proc_command)}-deployment"
         )
 

--- a/apiserver/paasng/paas_wl/resources/base/generation/v2.py
+++ b/apiserver/paasng/paas_wl/resources/base/generation/v2.py
@@ -28,11 +28,11 @@ class PodMapper(CallThroughKresMapper[KPod]):
 
     @property
     def name(self) -> str:
-        return f"{self.process.app.scheduler_safe_name}--{self.process.name}"
+        return f"{self.process.app.scheduler_safe_name}--{self.process.type}"
 
     @property
     def pod_selector(self) -> str:
-        return digest_if_length_exceeded(f"{self.process.app.name}-{self.process.name}", 63)
+        return digest_if_length_exceeded(f"{self.process.app.name}-{self.process.type}", 63)
 
     @property
     def labels(self) -> dict:
@@ -44,7 +44,7 @@ class PodMapper(CallThroughKresMapper[KPod]):
             region=self.process.app.region,
             env=mdata.environment,
             module_name=mdata.module_name,
-            process_id=self.process.name,
+            process_id=self.process.type,
             category="bkapp",
             mapper_version="v2",
         )
@@ -61,7 +61,7 @@ class DeploymentMapper(CallThroughKresMapper[KDeployment]):
 
     @property
     def pod_selector(self) -> str:
-        return digest_if_length_exceeded(f"{self.process.app.name}-{self.process.name}", 63)
+        return digest_if_length_exceeded(f"{self.process.app.name}-{self.process.type}", 63)
 
     @property
     def labels(self) -> dict:
@@ -78,7 +78,7 @@ class DeploymentMapper(CallThroughKresMapper[KDeployment]):
 
     @property
     def name(self) -> str:
-        return f"{self.process.app.scheduler_safe_name}--{self.process.name}"
+        return f"{self.process.app.scheduler_safe_name}--{self.process.type}"
 
 
 class ReplicaSetMapper(CallThroughKresMapper[KReplicaSet]):
@@ -86,11 +86,11 @@ class ReplicaSetMapper(CallThroughKresMapper[KReplicaSet]):
 
     @property
     def pod_selector(self) -> str:
-        return digest_if_length_exceeded(f"{self.process.app.name}-{self.process.name}", 63)
+        return digest_if_length_exceeded(f"{self.process.app.name}-{self.process.type}", 63)
 
     @property
     def name(self) -> str:
-        return f"{self.process.app.name.replace('_', '0us0')}--{self.process.name}"
+        return f"{self.process.app.scheduler_safe_name}--{self.process.type}"
 
     @property
     def match_labels(self) -> dict:

--- a/apiserver/paasng/paas_wl/resources/kube_res/base.py
+++ b/apiserver/paasng/paas_wl/resources/kube_res/base.py
@@ -177,9 +177,6 @@ class AppEntitySerializer(BaseTransformer, Generic[AET], metaclass=ABCMeta):
         """Generate kubernetes data by given AppEntity"""
         raise NotImplementedError
 
-    def get_res_name(self, obj: AET, **kwargs) -> str:
-        return obj.name
-
 
 T = TypeVar('T', bound=BaseTransformer)
 
@@ -416,9 +413,7 @@ class AppEntityManager(AppEntityReader, Generic[AET]):
         serializer = self._make_serializer(res.app)
         body = serializer.serialize(res, **kwargs)
         with self.kres(res.app, api_version=serializer.get_apiversion()) as kres_client:
-            kube_data = kres_client.create(
-                serializer.get_res_name(res, **kwargs), body, namespace=self._get_namespace(res.app)
-            )
+            kube_data = kres_client.create(res.name, body, namespace=self._get_namespace(res.app))
         # Set _kube_data
         res._kube_data = kube_data
         return res
@@ -462,7 +457,7 @@ class AppEntityManager(AppEntityReader, Generic[AET]):
         with self.kres(res.app, api_version=serializer.get_apiversion()) as kres_client:
             try:
                 return kres_client.replace_or_patch(
-                    name=serializer.get_res_name(res, mapper_version=mapper_version),
+                    name=res.name,
                     body=body,
                     namespace=self._get_namespace(res.app),
                     update_method=update_method,

--- a/apiserver/paasng/paas_wl/workloads/processes/constants.py
+++ b/apiserver/paasng/paas_wl/workloads/processes/constants.py
@@ -20,6 +20,7 @@ from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 # 注解或标签中存储进程名称的键名
 PROCESS_NAME_KEY = "bkapp.paas.bk.tencent.com/process-name"
+PROCESS_MAPPER_VERSION_KEY = "bkapp.paas.bk.tencent.com/process-mapper-version"
 
 
 class ProcessUpdateType(str, StructuredEnum):

--- a/apiserver/paasng/paas_wl/workloads/processes/controllers.py
+++ b/apiserver/paasng/paas_wl/workloads/processes/controllers.py
@@ -30,7 +30,6 @@ from paas_wl.cnative.specs.models import AppModelDeploy
 from paas_wl.cnative.specs.procs.exceptions import ProcNotFoundInRes
 from paas_wl.cnative.specs.procs.replicas import ProcReplicas
 from paas_wl.platform.applications.models import Release, WlApp
-from paas_wl.platform.applications.models.managers.app_res_ver import AppResVerManager
 from paas_wl.resources.base.base import get_client_by_cluster_name
 from paas_wl.resources.base.kres import KDeployment
 from paas_wl.resources.kube_res.exceptions import AppEntityNotFound
@@ -203,7 +202,7 @@ class AppProcessesController:
         target_ref = ScalingObjectRef(
             api_version=kres_client.get_preferred_version(),
             kind=kres_client.kind,
-            name=AppResVerManager(self.app).curr_version.deployment(process=self._prepare_process(proc_type)).name,
+            name=self._prepare_process(proc_type).name,
         )
 
         return ProcAutoscaling(self.app, proc_type, scaling_config, target_ref)  # type: ignore

--- a/apiserver/paasng/tests/paas_wl/resources/actions/test_deploy.py
+++ b/apiserver/paasng/tests/paas_wl/resources/actions/test_deploy.py
@@ -78,5 +78,5 @@ class TestZombieProcessesKiller:
         assert len(types) == len(diff["types"])
         assert len(names) == len(diff["names"])
 
-        assert {x.name for x in types} == set(diff["types"])
-        assert {x.name for x in names} == set(diff["names"])
+        assert {x.type for x in types} == set(diff["types"])
+        assert {x.type for x in names} == set(diff["names"])

--- a/apiserver/paasng/tests/paas_wl/resources/base/test_client.py
+++ b/apiserver/paasng/tests/paas_wl/resources/base/test_client.py
@@ -26,6 +26,7 @@ from django.conf import settings
 from django.utils import timezone
 from kubernetes.dynamic.resource import ResourceInstance
 
+from paas_wl.platform.applications.models.managers.app_res_ver import AppResVerManager
 from paas_wl.release_controller.models import ContainerRuntimeSpec
 from paas_wl.resources.base.controllers import BuildHandler
 from paas_wl.resources.base.exceptions import (
@@ -54,6 +55,10 @@ RG = settings.DEFAULT_REGION_NAME
 
 
 class TestClientProcess:
+    @pytest.fixture(autouse=True)
+    def set_res_version(self, wl_app):
+        AppResVerManager(wl_app).update("v1")
+
     @pytest.fixture
     def web_process(self, wl_app, wl_release):
         return AppProcessManager(app=wl_app).assemble_process("web", release=wl_release)
@@ -77,7 +82,7 @@ class TestClientProcess:
             deployment_args, deployment_kwargs = kd.call_args_list[0]
             assert deployment_kwargs.get('name') == f"{RG}-{wl_app.name}-web-python-deployment"
             assert deployment_kwargs.get('body')
-            assert deployment_kwargs.get('namespace') == wl_app.name
+            assert deployment_kwargs.get('namespace') == wl_app.namespace
 
             # Check service resource
             assert ks.get.called

--- a/apiserver/paasng/tests/paas_wl/resources/base/test_generation.py
+++ b/apiserver/paasng/tests/paas_wl/resources/base/test_generation.py
@@ -58,19 +58,19 @@ class TestGeneration:
     def test_v1_pod_name(self, v1_mapper, process):
         assert (
             v1_mapper.pod(process=process).name == f"{process.app.region}-{process.app.scheduler_safe_name}-"
-            f"{process.name}-{get_command_name(process.runtime.proc_command)}-deployment"
+            f"{process.type}-{get_command_name(process.runtime.proc_command)}-deployment"
         )
 
         assert (
             v1_mapper.deployment(process=process).name == f"{process.app.region}-{process.app.scheduler_safe_name}-"
-            f"{process.name}-{get_command_name(process.runtime.proc_command)}-deployment"
+            f"{process.type}-{get_command_name(process.runtime.proc_command)}-deployment"
         )
 
     def test_preset_process_client(self, wl_app, process, client, v1_mapper):
         assert (
             v1_mapper.pod(process=process, client=client).name
             == f"{process.app.region}-{process.app.scheduler_safe_name}-"
-            f"{process.name}-{get_command_name(process.runtime.proc_command)}-deployment"
+            f"{process.type}-{get_command_name(process.runtime.proc_command)}-deployment"
         )
 
     def test_v1_get(self, wl_app, process, client, v1_mapper):
@@ -106,5 +106,5 @@ class TestGeneration:
             assert kwargs['namespace'] == mapper.namespace
 
     def test_v2_name(self, process, v2_mapper):
-        assert v2_mapper.pod(process=process).name == f"{process.app.name.replace('_', '0us0')}--{process.name}"
-        assert v2_mapper.deployment(process=process).name == f"{process.app.name.replace('_', '0us0')}--{process.name}"
+        assert v2_mapper.pod(process=process).name == f"{process.app.name.replace('_', '0us0')}--{process.type}"
+        assert v2_mapper.deployment(process=process).name == f"{process.app.name.replace('_', '0us0')}--{process.type}"

--- a/apiserver/paasng/tests/paas_wl/workloads/autoscaling/test_serializers.py
+++ b/apiserver/paasng/tests/paas_wl/workloads/autoscaling/test_serializers.py
@@ -129,10 +129,10 @@ def test_ProcAutoscalingSerializer(wl_app, wl_release, gpa_gvk_config, gpa_manif
     process = Process.from_release(type_="web", release=wl_release)
 
     serializer = ProcAutoscalingSerializer(ProcAutoscaling, gpa_gvk_config)
-    assert serializer.get_res_name(scaling) == process.name
+    assert scaling.name == process.type
 
     excepted = gpa_manifest
-    excepted['metadata']['name'] = process.name
+    excepted['metadata']['name'] = process.type
     excepted['metadata']['namespace'] = wl_app.namespace
     assert serializer.serialize(scaling, mapper_version=get_mapper_version(target="v2")) == excepted
 


### PR DESCRIPTION
refactor: 
- 移除 AppEntitySerializer.get_res_name 协议; 
- 规范 Process.name/Process.type 的值内容和使用方式

> Process.name 继承自 AppEntity.name, 应该只用作 k8s resource 的 metadata.name