### PR TITLE
fix: some k8s cluster return minor version endswith +

### DIFF
--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/config/metric_label.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/config/metric_label.py
@@ -66,7 +66,7 @@ def get_cluster_id(app_code: str, run_env: str, module_name: str) -> str:
     """
     cluster_info = _get_cluster_info_cache(app_code, run_env, module_name)
     version = cluster_info['version']
-    if (int(version.major), int(version.minor)) < (1, 12):
+    if (int(version.major), int(version.minor.rstrip('+'))) < (1, 12):
         raise BKMonitorNotSupportedError(f'bkmonitor does not support k8s version {version} which below 1.12')
 
     return cluster_info['bcs_cluster_id']

--- a/apiserver/paasng/tests/monitoring/test_metric_label.py
+++ b/apiserver/paasng/tests/monitoring/test_metric_label.py
@@ -41,7 +41,10 @@ class FakeVersionInfo:
     [
         FakeVersionInfo('1', '8'),
         FakeVersionInfo('1', '10'),
+        pytest.param(FakeVersionInfo('1', '11+')),
         pytest.param(FakeVersionInfo('1', '12'), marks=pytest.mark.xfail),
+        pytest.param(FakeVersionInfo('1', '12+'), marks=pytest.mark.xfail),
+        pytest.param(FakeVersionInfo('1', '14+'), marks=pytest.mark.xfail),
         pytest.param(FakeVersionInfo('1', '20'), marks=pytest.mark.xfail),
     ],
 )


### PR DESCRIPTION
兼容部分k8s集群返回的minor version 带 + 号， 如14+