### PR TITLE
feat: add validate annotations with BkApp name in webhook

### DIFF
--- a/operator/api/v1alpha2/bkapp_webhook.go
+++ b/operator/api/v1alpha2/bkapp_webhook.go
@@ -29,7 +29,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"

--- a/operator/api/v1alpha2/bkapp_webhook.go
+++ b/operator/api/v1alpha2/bkapp_webhook.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -42,7 +43,7 @@ var appLog = logf.Log.WithName("bkapp-resource")
 
 var (
 	// AppNameRegex 应用名称格式（与 BK_APP_CODE 相同）
-	AppNameRegex = regexp.MustCompile("^[a-z0-9-]{1,16}$")
+	AppNameRegex = regexp.MustCompile("^[a-z0-9-]{1,64}$")
 	// ProcNameRegex 进程名称格式
 	ProcNameRegex = regexp.MustCompile("^[a-z0-9]([-a-z0-9]){1,11}$")
 )
@@ -117,6 +118,9 @@ func (r *BkApp) validateApp() error {
 	if err := r.validateAppName(); err != nil {
 		allErrs = append(allErrs, err)
 	}
+	if err := r.validateAnnotations(); err != nil {
+		allErrs = append(allErrs, err)
+	}
 	if err := r.validateAppSpec(); err != nil {
 		allErrs = append(allErrs, err)
 	}
@@ -136,6 +140,39 @@ func (r *BkApp) validateAppName() *field.Error {
 			field.NewPath("metadata").Child("name"), r.Name, "must match regex "+AppNameRegex.String(),
 		)
 	}
+	return nil
+}
+
+func (r *BkApp) validateAnnotations() *field.Error {
+	annotations := r.GetAnnotations()
+	if _, ok := annotations[BkAppCodeKey]; !ok {
+		return field.Invalid(field.NewPath("metadata").Child("annotations"), annotations, "missing "+BkAppCodeKey)
+	}
+	if _, ok := annotations[ModuleNameKey]; !ok {
+		return field.Invalid(field.NewPath("metadata").Child("annotations"), annotations, "missing "+ModuleNameKey)
+	}
+
+	// 校验 BkApp 的 name 是否满足注解 bkapp.paas.bk.tencent.com/code 和 bkapp.paas.bk.tencent.com/module-name 的拼接规则
+	var expectedRawName string
+	if annotations[ModuleNameKey] != DefaultModuleName {
+		expectedRawName = fmt.Sprintf("%s-m-%s", annotations[BkAppCodeKey], annotations[ModuleNameKey])
+	} else {
+		expectedRawName = annotations[BkAppCodeKey]
+	}
+	if r.Name != DNSSafeName(expectedRawName) {
+		return field.Invalid(
+			field.NewPath("metadata").Child("annotations"),
+			annotations,
+			fmt.Sprintf(
+				"%s and %s don't match with %s %s",
+				BkAppCodeKey,
+				ModuleNameKey,
+				field.NewPath("metadata").Child("name").String(),
+				r.Name,
+			),
+		)
+	}
+
 	return nil
 }
 

--- a/operator/api/v1alpha2/constants.go
+++ b/operator/api/v1alpha2/constants.go
@@ -32,6 +32,9 @@ const (
 
 	// WebProcName 表示 web 进程名称
 	WebProcName = "web"
+
+	// 默认模块名
+	DefaultModuleName = "default"
 )
 
 // ReplicasOne 副本数 1, 用于替换测试程序内的魔数

--- a/operator/api/v1alpha2/names.go
+++ b/operator/api/v1alpha2/names.go
@@ -1,0 +1,30 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+ * Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *	http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package v1alpha2
+
+import "strings"
+
+// 替换非法的字符 _
+const underscoreReplacer = "0us0"
+
+// DNSSafeName 通过替换 _ 等特殊字符串，将其变为可安全用于 DNS 域名的值，该算法与 bkpaas
+// 中其他逻辑保持一致。
+func DNSSafeName(name string) string {
+	return strings.ReplaceAll(name, "_", underscoreReplacer)
+}

--- a/operator/api/v1alpha2/names_test.go
+++ b/operator/api/v1alpha2/names_test.go
@@ -16,38 +16,19 @@
  * to the current version of the project delivered to anyone in the future.
  */
 
-package names
+package v1alpha2_test
 
 import (
-	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	paasv1alpha2 "bk.tencent.com/paas-app-operator/api/v1alpha2"
 )
 
-const (
-	defaultRevision int64 = 1
+var _ = DescribeTable("Get DNS-safe name",
+	func(s string, want string) {
+		Expect(paasv1alpha2.DNSSafeName(s)).To(Equal(want))
+	},
+	Entry("Normal", "bkapp-foo", "bkapp-foo"),
+	Entry("Contains _", "bkapp_foo", "bkapp0us0foo"),
 )
-
-// PreReleaseHook 生成用于执行 pre-release-hook 的 Pod 名称
-func PreReleaseHook(bkapp *paasv1alpha2.BkApp) string {
-	revision := defaultRevision
-	if rev := bkapp.Status.Revision; rev != nil {
-		revision = rev.Revision
-	}
-	return fmt.Sprintf("pre-release-hook-%d", revision)
-}
-
-// Deployment 为应用的不同进程生成 Deployment 资源名称
-func Deployment(bkapp *paasv1alpha2.BkApp, process string) string {
-	return paasv1alpha2.DNSSafeName(bkapp.GetName() + "--" + process)
-}
-
-// Service Return the service name for each process
-func Service(bkapp *paasv1alpha2.BkApp, process string) string {
-	return paasv1alpha2.DNSSafeName(bkapp.GetName() + "--" + process)
-}
-
-// GPA Return the general-pod-autoscaler name for each process
-func GPA(bkapp *paasv1alpha2.BkApp, process string) string {
-	return paasv1alpha2.DNSSafeName(bkapp.GetName() + "--" + process)
-}

--- a/operator/pkg/controllers/resources/names/names_test.go
+++ b/operator/pkg/controllers/resources/names/names_test.go
@@ -28,14 +28,6 @@ import (
 	paasv1alpha2 "bk.tencent.com/paas-app-operator/api/v1alpha2"
 )
 
-var _ = DescribeTable("Get DNS-safe name",
-	func(s string, want string) {
-		Expect(DNSSafeName(s)).To(Equal(want))
-	},
-	Entry("Normal", "bkapp-foo", "bkapp-foo"),
-	Entry("Contains _", "bkapp_foo", "bkapp0us0foo"),
-)
-
 var _ = Describe("Get resource names", func() {
 	var bkapp *paasv1alpha2.BkApp
 


### PR DESCRIPTION
operator 通过区分 BkApp name， 以支持多模块的实现
- webhook 中新增 annotations 校验逻辑
   
=============

多模块的设计说明：
以 app code 为 test4cnative 为例，它有两个模块 default, backend.

test4cnative 会对应两个 BkApp 模型
- default 模块: BkApp name = test4cnative
- backend 模块: BkApp name = test4cnative-m-backend

test4cnative 一共有两个命名空间
- 测试环境：bkapp-test4cnative-stag
- 正式环境：bkapp-test4cnative-prod
   