### PR TITLE
feat: add retrieve_specs api in SysAddonsAPIViewSet

### DIFF
--- a/apiserver/paasng/paasng/plat_admin/system/urls.py
+++ b/apiserver/paasng/paasng/plat_admin/system/urls.py
@@ -61,4 +61,13 @@ urlpatterns = [
         SysAddonsAPIViewSet.as_view({"get": "list_services"}),
         name="sys.api.applications.list_addons",
     ),
+    re_path(
+        make_app_pattern(
+            suffix="/services/(?P<service_id>[0-9a-f-]{32,36})/specs/",
+            include_envs=False,
+            prefix="sys/api/bkapps/applications/",
+        ),
+        SysAddonsAPIViewSet.as_view({"get": "retrieve_specs"}),
+        name="sys.api.applications.retrieve_specs",
+    ),
 ]

--- a/apiserver/paasng/paasng/plat_admin/system/views.py
+++ b/apiserver/paasng/paasng/plat_admin/system/views.py
@@ -217,7 +217,7 @@ class SysAddonsAPIViewSet(ApplicationCodeInPathMixin, viewsets.ViewSet):
             for rel in mixed_service_mgr.list_all_rels(env.engine_app, service_id=service_id):
                 plan = rel.get_plan()
                 specs = plan.specifications
-                break
+                break  # 现阶段所有环境的服务规格一致，因此只需要拿一个
 
         spec_data: Dict[str, str] = {}
         for definition in service.specifications:

--- a/apiserver/paasng/paasng/plat_admin/system/views.py
+++ b/apiserver/paasng/paasng/plat_admin/system/views.py
@@ -198,6 +198,35 @@ class SysAddonsAPIViewSet(ApplicationCodeInPathMixin, viewsets.ViewSet):
         service_info = ServicesInfo.get_detail(engine_app)['services_info']
         return Response(data=service_info)
 
+    @swagger_auto_schema(tags=["SYSTEMAPI"])
+    @site_perm_required(SiteAction.SYSAPI_READ_SERVICES)
+    def retrieve_specs(self, request, code, module_name, service_id):
+        """获取应用已绑定的服务规格.
+        接口实现逻辑参考 paasng.dev_resources.servicehub.views.ModuleServicesViewSet.retrieve_specs
+        """
+        application = self.get_application()
+        module = self.get_module_via_path()
+        service = mixed_service_mgr.get_or_404(service_id, region=application.region)
+
+        # 如果模块与增强服务之间没有绑定关系，直接返回 404 状态码
+        if not mixed_service_mgr.module_is_bound_with(service, module):
+            raise Http404
+
+        specs = {}
+        for env in module.envs.all():
+            for rel in mixed_service_mgr.list_all_rels(env.engine_app, service_id=service_id):
+                plan = rel.get_plan()
+                specs = plan.specifications
+                break
+
+        spec_data: Dict[str, str] = {}
+        for definition in service.specifications:
+            result = definition.as_dict()
+            result['value'] = specs.get(definition.name)
+            spec_data[result['name']] = result['value']
+
+        return Response({'results': spec_data})
+
     @staticmethod
     def _get_pub_recommended_specs(svc: ServiceObj) -> Optional[dict]:
         """获取增强服务的推荐 specs"""

--- a/apiserver/paasng/paasng/plat_admin/system/views.py
+++ b/apiserver/paasng/paasng/plat_admin/system/views.py
@@ -219,12 +219,9 @@ class SysAddonsAPIViewSet(ApplicationCodeInPathMixin, viewsets.ViewSet):
                 specs = plan.specifications
                 break  # 现阶段所有环境的服务规格一致，因此只需要拿一个
 
-        spec_data: Dict[str, str] = {}
-        for definition in service.specifications:
-            result = definition.as_dict()
-            result['value'] = specs.get(definition.name)
-            spec_data[result['name']] = result['value']
-
+        spec_data: Dict[str, Optional[str]] = {
+            definition.name: specs.get(definition.name) for definition in service.specifications
+        }
         return Response({'results': spec_data})
 
     @staticmethod

--- a/operator/pkg/controllers/reconcilers/addons.go
+++ b/operator/pkg/controllers/reconcilers/addons.go
@@ -54,9 +54,17 @@ type AddonReconciler struct {
 
 // Reconcile ...
 func (r *AddonReconciler) Reconcile(ctx context.Context, bkapp *paasv1alpha2.BkApp) Result {
-	// 未启用增强服务, 直接返回
+	// 未启用增强服务, 清空 addon 的历史 status 并返回
 	if len(bkapp.Spec.Addons) == 0 {
+		// 因为在 NewRevisionReconciler 中默认初始化了 type 为 AddOnsProvisioned 的 condition, 这里需要删除
+		apimeta.RemoveStatusCondition(&bkapp.Status.Conditions, paasv1alpha2.AddOnsProvisioned)
+		bkapp.Status.AddonStatuses = nil
+
+		if updateErr := r.Client.Status().Update(ctx, bkapp); updateErr != nil {
+			return r.Result.withError(updateErr)
+		}
 		return r.Result
+
 	}
 
 	addonStatuses, err := r.doReconcile(ctx, bkapp)
@@ -155,8 +163,8 @@ func (r *AddonReconciler) provisionAddon(
 		return addonStatus, errors.Wrapf(err, "QueryAddonSpecs failed, detail")
 	}
 
-	for _, spec := range specResult.Data {
-		addonStatus.Specs = append(addonStatus.Specs, paasv1alpha2.AddonSpec{Name: spec.Name, Value: spec.Value})
+	for name, value := range specResult.Data {
+		addonStatus.Specs = append(addonStatus.Specs, paasv1alpha2.AddonSpec{Name: name, Value: value})
 	}
 
 	return addonStatus, nil

--- a/operator/pkg/controllers/reconcilers/addons.go
+++ b/operator/pkg/controllers/reconcilers/addons.go
@@ -56,15 +56,13 @@ type AddonReconciler struct {
 func (r *AddonReconciler) Reconcile(ctx context.Context, bkapp *paasv1alpha2.BkApp) Result {
 	// 未启用增强服务, 清空 addon 的历史 status 并返回
 	if len(bkapp.Spec.Addons) == 0 {
-		// 因为在 NewRevisionReconciler 中默认初始化了 type 为 AddOnsProvisioned 的 condition, 这里需要删除
-		apimeta.RemoveStatusCondition(&bkapp.Status.Conditions, paasv1alpha2.AddOnsProvisioned)
-		bkapp.Status.AddonStatuses = nil
-
-		if updateErr := r.Client.Status().Update(ctx, bkapp); updateErr != nil {
-			return r.Result.withError(updateErr)
+		if bkapp.Status.AddonStatuses != nil {
+			bkapp.Status.AddonStatuses = nil
+			if updateErr := r.Client.Status().Update(ctx, bkapp); updateErr != nil {
+				return r.Result.withError(updateErr)
+			}
 		}
 		return r.Result
-
 	}
 
 	addonStatuses, err := r.doReconcile(ctx, bkapp)

--- a/operator/pkg/controllers/reconcilers/addons_test.go
+++ b/operator/pkg/controllers/reconcilers/addons_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Test AddonReconciler", func() {
 						return &http.Response{
 							StatusCode: 200,
 							Body: ioutil.NopCloser(
-								bytes.NewBufferString(`{"results": [{"name": "version", "value": "5.0.0"}]}`),
+								bytes.NewBufferString(`{"results": {"version": "5.0.0"}}`),
 							),
 							Header: make(http.Header),
 						}

--- a/operator/pkg/platform/external/addons.go
+++ b/operator/pkg/platform/external/addons.go
@@ -35,15 +35,9 @@ type AddonInstance struct {
 	Credentials map[string]intstr.IntOrString `json:"credentials"`
 }
 
-// AddonSpecsData ...
-type AddonSpecsData struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
-}
-
 // AddonSpecsResult ...
 type AddonSpecsResult struct {
-	Data []AddonSpecsData `json:"results,omitempty"`
+	Data map[string]string `json:"results,omitempty"`
 }
 
 // AddonSpecs define specs of the add-on service
@@ -99,7 +93,7 @@ func (c *Client) QueryAddonInstance(
 func (c *Client) QueryAddonSpecs(ctx context.Context, appCode, moduleName, svcID string) (*AddonSpecsResult, error) {
 	result := &AddonSpecsResult{}
 	path := fmt.Sprintf(
-		"/system/bkapps/applications/%s/modules/%s/services/%s/specs",
+		"/system/bkapps/applications/%s/modules/%s/services/%s/specs/",
 		appCode,
 		moduleName,
 		svcID,

--- a/operator/pkg/platform/external/addons_test.go
+++ b/operator/pkg/platform/external/addons_test.go
@@ -92,13 +92,15 @@ var _ = Describe("TestClient", func() {
 			Expect(err).To(BeNil())
 			Expect(*result).To(Equal(expectedSpecs))
 		},
-		Entry("return valid specs", &SimpleResponse{StatusCode: 200, Body: toJsonString(fakeAddonSpecsResult{
-			Data: []addonSpecsData{{Name: "version", Value: "5.0.0", RecommendedValue: "5.0.0", DisplayName: "版本"}},
-		})}, AddonSpecsResult{Data: []AddonSpecsData{{Name: "version", Value: "5.0.0"}}}),
+		Entry(
+			"return valid specs",
+			&SimpleResponse{StatusCode: 200, Body: `{"results": {"version": "5.0.0"}}`},
+			AddonSpecsResult{Data: map[string]string{"version": "5.0.0"}},
+		),
 		Entry(
 			"return empty list",
-			&SimpleResponse{StatusCode: 200, Body: toJsonString(fakeAddonSpecsResult{})},
-			AddonSpecsResult{},
+			&SimpleResponse{StatusCode: 200, Body: `{"results": {}}`},
+			AddonSpecsResult{Data: make(map[string]string)},
 		),
 	)
 
@@ -130,18 +132,6 @@ var _ = Describe("TestClient", func() {
 		Entry("500 for provision failed", &SimpleResponse{StatusCode: 500}, AddonSpecs{}, HaveOccurred()),
 	)
 })
-
-type fakeAddonSpecsResult struct {
-	Data []addonSpecsData `json:"results,omitempty"`
-}
-
-type addonSpecsData struct {
-	Name             string `json:"name"`
-	Value            string `json:"value"`
-	RecommendedValue string `json:"recommended_value"`
-	DisplayName      string `json:"display_name"`
-	Description      string `json:"description"`
-}
 
 func toJsonString(v interface{}) string {
 	b, _ := json.Marshal(v)


### PR DESCRIPTION
参考 `paasng.dev_resources.servicehub.views.ModuleServicesViewSet.retrieve_specs`的实现，将retrieve_specs添加到系统接口中