### PR TITLE
support monitor rules for cnative app

### DIFF
--- a/apiserver/paasng/paasng/engine/views.py
+++ b/apiserver/paasng/paasng/engine/views.py
@@ -591,7 +591,7 @@ class OfflineViewset(viewsets.ViewSet, ApplicationCodeInPathMixin):
     def get_offline_result(self, request, code, module_name, uuid):
         """
         查询下线任务结果
-        - /api/bkapps/applications/{code})/offline_operations/{uuid}/result/
+        - /api/bkapps/applications/{code})/off line_operations/{uuid}/result/
         - path param: code, app名
         - path param: uuid, 部署任务的uuid(即deployment_id)
         """

--- a/apiserver/paasng/paasng/engine/views.py
+++ b/apiserver/paasng/paasng/engine/views.py
@@ -591,7 +591,7 @@ class OfflineViewset(viewsets.ViewSet, ApplicationCodeInPathMixin):
     def get_offline_result(self, request, code, module_name, uuid):
         """
         查询下线任务结果
-        - /api/bkapps/applications/{code})/off line_operations/{uuid}/result/
+        - /api/bkapps/applications/{code})/offline_operations/{uuid}/result/
         - path param: code, app名
         - path param: uuid, 部署任务的uuid(即deployment_id)
         """

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/ascode/rules_tpl/oom_killed.yaml.j2
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/ascode/rules_tpl/oom_killed.yaml.j2
@@ -11,7 +11,7 @@ query:
   data_source: prometheus
   data_type: time_series
   query_configs:
-  - metric: 'sum (increase(kube_pod_container_status_terminated_reason{reason="OOMKilled", namespace="{{ metric_labels['namespace'] }}", bcs_cluster_id="{{ metric_labels['bcs_cluster_id'] }}"}[5m])) by (namespace, pod_name)'
+  - metric: 'sum (increase(kube_pod_container_status_terminated_reason{reason="OOMKilled", namespace="{{ metric_labels['namespace'] }}", bcs_cluster_id="{{ metric_labels['bcs_cluster_id'] }}"}[2m])) by (namespace, pod_name)'
     interval: 60 # 单位 s
 
 detect: # 检测配置
@@ -20,7 +20,7 @@ detect: # 检测配置
     - type: Threshold # 算法类型
       config: "{{ threshold_expr }}" # 算法配置
 
-  trigger: 2/15/15 # 触发条件. 异常次数/检测周期数/恢复周期数
+  trigger: 1/5/5 # 触发条件. 异常次数/检测周期数/恢复周期数
 
 notice: # 通知配置
   interval: 120 # 通知收敛间隔(分钟)

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/config/__init__.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/config/__init__.py
@@ -16,5 +16,5 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-from .app_rule import RuleConfig  # noqa
+from .app_rule import RuleConfig, get_supported_alert_codes  # noqa
 from .generator import AppRuleConfigGenerator  # noqa

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/config/constants.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/config/constants.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+from blue_krill.data_types.enum import StructuredEnum
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
@@ -25,39 +26,39 @@ RUN_ENVS = AppEnvironment.get_values()
 
 RABBITMQ_SERVICE_NAME = settings.RABBITMQ_MONITOR_CONF.get('service_name', 'rabbitmq')
 
-DEFAULT_RULE_CONFIGS = {
-    'module_scoped': {
-        'high_cpu_usage': {
-            'display_name': _('CPU 使用率过高'),
-            'metric_label_names': ['namespace', 'bcs_cluster_id'],
-            'threshold_expr': '>= 0.8',  # 使用率 80%
-        },
-        'high_mem_usage': {
-            'display_name': _('内存使用率过高'),
-            'metric_label_names': ['namespace', 'bcs_cluster_id'],
-            'threshold_expr': '>= 0.95',  # 使用率 95%
-        },
-        'pod_restart': {
-            'display_name': _('异常重启'),
-            'metric_label_names': ['namespace', 'bcs_cluster_id'],
-            'threshold_expr': '>= 1',  # 出现至少 1 次
-        },
-        'oom_killed': {
-            'display_name': _('OOMKilled 退出'),
-            'metric_label_names': ['namespace', 'bcs_cluster_id'],
-            'threshold_expr': '>= 1',  # 出现至少 1 次
-        },
-    }
-}
 
-# 开启 rabbitmq 监控
-if settings.RABBITMQ_MONITOR_CONF.get('enabled', False):
-    DEFAULT_RULE_CONFIGS['module_scoped'].update(
-        {
-            'high_rabbitmq_queue_messages': {
-                'display_name': _('队列消息数过多'),
-                'metric_label_names': ['vhost'],
-                'threshold_expr': '>= 2000',  # 超过 2000 条
-            },
-        }
-    )
+class AlertCode(str, StructuredEnum):
+    HIGH_CPU_USAGE = 'high_cpu_usage'
+    HIGH_MEM_USAGE = 'high_mem_usage'
+    POD_RESTART = 'pod_restart'
+    OOM_KILLED = 'oom_killed'
+    HIGH_RABBITMQ_QUEUE_MESSAGES = 'high_rabbitmq_queue_messages'
+
+
+DEFAULT_RULE_CONFIGS = {
+    AlertCode.HIGH_CPU_USAGE.value: {
+        'display_name': _('CPU 使用率过高'),
+        'metric_label_names': ['namespace', 'bcs_cluster_id'],
+        'threshold_expr': '>= 0.8',  # 使用率 80%
+    },
+    AlertCode.HIGH_MEM_USAGE.value: {
+        'display_name': _('内存使用率过高'),
+        'metric_label_names': ['namespace', 'bcs_cluster_id'],
+        'threshold_expr': '>= 0.95',  # 使用率 95%
+    },
+    AlertCode.POD_RESTART.value: {
+        'display_name': _('异常重启'),
+        'metric_label_names': ['namespace', 'bcs_cluster_id'],
+        'threshold_expr': '>= 1',  # 出现至少 1 次
+    },
+    AlertCode.OOM_KILLED.value: {
+        'display_name': _('OOMKilled 退出'),
+        'metric_label_names': ['namespace', 'bcs_cluster_id'],
+        'threshold_expr': '>= 1',  # 出现至少 1 次
+    },
+    AlertCode.HIGH_RABBITMQ_QUEUE_MESSAGES.value: {
+        'display_name': _('队列消息数过多'),
+        'metric_label_names': ['vhost'],
+        'threshold_expr': '>= 2000',  # 超过 2000 条
+    },
+}

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/handlers.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/handlers.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+from typing import Type
+
+from django.dispatch import receiver
+
+from paasng.engine.models.deployment import Deployment
+from paasng.engine.models.offline import OfflineOperation
+from paasng.engine.signals import post_appenv_deploy
+from paasng.platform.applications.models import ApplicationEnvironment
+from paasng.platform.applications.signals import module_environment_offline_success
+
+from .tasks import delete_rules, refresh_rules_by_module
+
+
+@receiver(post_appenv_deploy)
+def refresh_rules_after_deploy(sender: ApplicationEnvironment, deployment: Deployment, **kwargs):
+    if not deployment.has_succeeded():
+        return
+
+    refresh_rules_by_module.delay(sender.application.code, sender.module.name, sender.environment)
+
+
+@receiver(module_environment_offline_success)
+def refresh_rules_after_offline(
+    sender: Type[OfflineOperation], offline_instance: OfflineOperation, environment: str, **kwargs
+):
+    if not offline_instance.has_succeeded():
+        return
+
+    app_environment = offline_instance.app_environment
+    delete_rules.delay(app_environment.application.code, app_environment.module.name, environment)

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/manager.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/manager.py
@@ -22,7 +22,7 @@ from paasng.monitoring.monitor.models import AppAlertRule
 from paasng.platform.applications.models import Application
 
 from .ascode.client import AsCodeClient
-from .config import AppRuleConfigGenerator, RuleConfig
+from .config import AppRuleConfigGenerator, RuleConfig, get_supported_alert_codes
 
 
 class AlertRuleManager:
@@ -33,6 +33,7 @@ class AlertRuleManager:
         self.app_code = self.application.code
         self.default_receivers = application.get_developers()
         self.config_generator = AppRuleConfigGenerator(self.application, self.default_receivers)
+        self.supported_alerts = get_supported_alert_codes(application.type)
 
     def init_rules(self):
         """为 app 初始化告警规则. 其中规则包括了 app scoped 和 app module scoped
@@ -52,21 +53,6 @@ class AlertRuleManager:
         self._apply_rule_configs(rule_configs)
         self._save_rule_configs(rule_configs)
 
-    def create_module_rules(self, module_name: str):
-        """为新 module 创建告警规则
-
-        :param module_name: 新模块名
-        """
-        module_rule_configs = self.config_generator.gen_module_scoped_rule_configs(module_name)
-
-        rule_configs = self.config_generator.gen_rule_configs_from_qs(
-            AppAlertRule.objects.filter(application=self.application)
-        )
-        rule_configs.extend(module_rule_configs)
-
-        self._apply_rule_configs(rule_configs)
-        self._save_rule_configs(module_rule_configs)
-
     def update_rule(self, rule_obj: AppAlertRule, update_fields: Dict) -> AppAlertRule:
         """更新 app 的告警规则
 
@@ -83,6 +69,32 @@ class AlertRuleManager:
 
         return rule_obj
 
+    def refresh_rules_by_module(self, module_name: str, run_env: str):
+        """刷新 app 的告警规则
+
+        使用场景:
+        - app 部署 module 后, 刷新告警规则
+        """
+        if not self._need_refresh(module_name, run_env):
+            return
+
+        rule_configs = self._get_refreshable_app_scoped_rules(run_env)
+        rule_configs.extend(self._get_refreshable_module_scoped_rules(module_name, run_env))
+
+        self._apply_rule_configs(rule_configs)
+        self._save_rule_configs(rule_configs)
+
+    def delete_rules(self, module_name: str, run_env: str):
+        """删除 app 的模块告警规则
+
+        使用场景:
+        - app 下线 module 后, 刷新告警规则
+        """
+        AppAlertRule.objects.filter(
+            application=self.application, module__name=module_name, environment=run_env
+        ).delete()
+        self.refresh_rules()
+
     def refresh_rules(self):
         """向 bkmonitor 刷新 app 的告警规则(从已存在的 AppAlertRule queryset 读取后刷新)
 
@@ -93,6 +105,52 @@ class AlertRuleManager:
             AppAlertRule.objects.filter(application=self.application)
         )
         self._apply_rule_configs(existed_rule_configs)
+
+    def _get_refreshable_app_scoped_rules(self, run_env: str) -> List[RuleConfig]:
+        """获取待刷新的 app scoped 告警规则"""
+        rule_qs = AppAlertRule.objects.filter(application=self.application, environment=run_env, module=None)
+        rule_configs = self.config_generator.gen_rule_configs_from_qs(rule_qs)
+        existed_alert_codes = {c.alert_code for c in rule_configs}
+
+        if new_alert_codes := set(self.supported_alerts.app_scoped_codes) - existed_alert_codes:
+            rule_configs.extend(self.config_generator.gen_app_scoped_rule_configs([run_env], list(new_alert_codes)))
+
+        return rule_configs
+
+    def _get_refreshable_module_scoped_rules(self, module_name: str, run_env: str) -> List[RuleConfig]:
+        """获取待刷新的 module scoped 告警规则"""
+        rule_qs = AppAlertRule.objects.filter(application=self.application, environment=run_env).exclude(module=None)
+        rule_configs = self.config_generator.gen_rule_configs_from_qs(rule_qs)
+        existed_alert_codes = {c.alert_code for c in rule_configs if getattr(c, 'module_name', None) == module_name}
+
+        if new_alert_codes := set(self.supported_alerts.module_scoped_codes) - existed_alert_codes:
+            rule_configs.extend(
+                self.config_generator.gen_module_scoped_rule_configs(module_name, [run_env], list(new_alert_codes))
+            )
+
+        return rule_configs
+
+    def _need_refresh(self, module_name: str, run_env: str) -> bool:
+        """根据 AppAlertRule 表中的记录, 确定是否需要刷新告警规则"""
+        expected_alert_codes = self.supported_alerts.app_scoped_codes
+        if AppAlertRule.objects.filter(
+            application=self.application, environment=run_env, module=None, alert_code__in=expected_alert_codes
+        ).count() != len(expected_alert_codes):
+            return True
+
+        expected_alert_codes = self.supported_alerts.module_scoped_codes
+        if (
+            AppAlertRule.objects.filter(
+                application=self.application,
+                environment=run_env,
+                module__name=module_name,
+                alert_code__in=expected_alert_codes,
+            ).count()
+            != len(expected_alert_codes)
+        ):
+            return True
+
+        return False
 
     def _apply_rule_configs(self, rule_configs: List[RuleConfig]):
         """通过 MonitorAsCode 方式下发告警规则到 bkmonitor"""

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/tasks.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/tasks.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+import logging
+
+from celery import shared_task
+
+from paasng.platform.applications.models import Application
+
+from .manager import AlertRuleManager
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task
+def refresh_rules_by_module(app_code: str, module_name: str, run_env: str):
+    try:
+        rule_mgr = AlertRuleManager(Application.objects.get(code=app_code))
+        rule_mgr.refresh_rules_by_module(module_name, run_env)
+    except Exception:
+        logger.exception(
+            f"Unable to refresh alert rules after release app"
+            f"(code: {app_code}, module: {module_name}, run_env: {run_env})"
+        )
+
+
+@shared_task
+def delete_rules(app_code: str, module_name: str, run_env: str):
+    try:
+        rule_mgr = AlertRuleManager(Application.objects.get(code=app_code))
+        rule_mgr.delete_rules(module_name, run_env)
+    except Exception:
+        logger.exception(
+            f"Unable to refresh alert rules after offline app"
+            f"(code: {app_code}, module: {module_name}, run_env: {run_env})"
+        )
+
+
+@shared_task
+def refresh_rules(app_code: str):
+    try:
+        rule_mgr = AlertRuleManager(Application.objects.get(code=app_code))
+        rule_mgr.refresh_rules()
+    except Exception:
+        logger.exception(f"Unable to refresh alert rules for app(code: {app_code})")

--- a/apiserver/paasng/paasng/monitoring/monitor/apps.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/apps.py
@@ -21,3 +21,6 @@ from django.apps import AppConfig
 
 class MonitorConfig(AppConfig):
     name = 'paasng.monitoring.monitor'
+
+    def ready(self):
+        from .alert_rules import handlers  # noqa

--- a/apiserver/paasng/paasng/monitoring/monitor/models.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/models.py
@@ -31,8 +31,12 @@ class AppAlertRuleManager(models.Manager):
             return qs.filter(environment=run_env)
         return qs
 
-    def filter_module_scoped(self, app: Application, run_env: Optional[str] = None):
-        qs = self.filter(application=app).exclude(module=None)
+    def filter_module_scoped(self, app: Application, run_env: Optional[str] = None, module_name: Optional[str] = None):
+        if module_name:
+            qs = self.filter(application=app, module__name=module_name)
+        else:
+            qs = self.filter(application=app).exclude(module=None)
+
         if run_env:
             return qs.filter(environment=run_env)
         return qs

--- a/apiserver/paasng/paasng/monitoring/monitor/urls.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
         'api/monitor/applications/<slug:code>/modules/<slug:module_name>/alert_rules/',
         views.AlertRulesView.as_view({'get': 'list'}),
     ),
+    # TODO init_alert_rules will be deprecated
     path(
         'api/monitor/applications/<slug:code>/alert_rules/init/',
         views.AlertRulesView.as_view({'post': 'init_alert_rules'}),

--- a/apiserver/paasng/paasng/monitoring/monitor/views.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/views.py
@@ -213,11 +213,8 @@ class AlertRulesView(GenericViewSet, ApplicationCodeInPathMixin):
         """列举支持的告警规则"""
         supported_alerts = []
 
-        for _, alert_config in DEFAULT_RULE_CONFIGS.items():
-            for alert_code in alert_config:
-                supported_alerts.append(
-                    {'alert_code': alert_code, 'display_name': alert_config[alert_code]['display_name']}
-                )
+        for alert_code, alert_config in DEFAULT_RULE_CONFIGS.items():
+            supported_alerts.append({'alert_code': alert_code, 'display_name': alert_config['display_name']})
 
         serializer = SupportedAlertSLZ(supported_alerts, many=True)
         return Response(serializer.data)

--- a/apiserver/paasng/tests/monitoring/alert_rules/test_api.py
+++ b/apiserver/paasng/tests/monitoring/alert_rules/test_api.py
@@ -55,7 +55,7 @@ class TestAlertRulesView:
     def test_list_supported_alert_rules(self, api_client):
         resp = api_client.get('/api/monitor/supported_alert_rules/')
         alert_info = {alert['alert_code']: alert['display_name'] for alert in resp.data}
-        assert alert_info['high_cpu_usage'] == DEFAULT_RULE_CONFIGS['module_scoped']['high_cpu_usage']['display_name']
+        assert alert_info['high_cpu_usage'] == DEFAULT_RULE_CONFIGS['high_cpu_usage']['display_name']
 
 
 class TestInitAlertRulesAPI:

--- a/apiserver/paasng/tests/monitoring/alert_rules/test_manager.py
+++ b/apiserver/paasng/tests/monitoring/alert_rules/test_manager.py
@@ -40,10 +40,10 @@ class TestAlertRuleManager:
     def test_refresh_rules_by_module(self, bk_app, wl_namespaces):
         manager = AlertRuleManager(bk_app)
         manager.refresh_rules_by_module(bk_app.get_default_module().name, 'stag')
-        assert AppAlertRule.objects.filter(application=bk_app, module=None).count() == len(
+        assert AppAlertRule.objects.filter_app_scoped(bk_app).count() == len(
             get_supported_alert_codes(bk_app.type).app_scoped_codes
         )
-        assert AppAlertRule.objects.filter(application=bk_app).exclude(module=None).count() == len(
+        assert AppAlertRule.objects.filter_module_scoped(bk_app).count() == len(
             get_supported_alert_codes(bk_app.type).module_scoped_codes
         )
         assert (
@@ -54,10 +54,10 @@ class TestAlertRuleManager:
     def test_refresh_rules_by_module_with_rule_obj(self, bk_app, wl_namespaces, cpu_usage_alert_rule_obj):
         manager = AlertRuleManager(bk_app)
         manager.refresh_rules_by_module(bk_app.get_default_module().name, 'stag')
-        assert AppAlertRule.objects.filter(application=bk_app, module=None).count() == len(
+        assert AppAlertRule.objects.filter_app_scoped(bk_app).count() == len(
             get_supported_alert_codes(bk_app.type).app_scoped_codes
         )
-        assert AppAlertRule.objects.filter(application=bk_app).exclude(module=None).count() == len(
+        assert AppAlertRule.objects.filter_module_scoped(bk_app).count() == len(
             get_supported_alert_codes(bk_app.type).module_scoped_codes
         )
         # 与 test_refresh_rules_by_module 不同, 这里测试 AlertRuleManager.refresh_rules_by_module 能够保留原 DB 中的配置值

--- a/apiserver/paasng/tests/monitoring/alert_rules/test_manager.py
+++ b/apiserver/paasng/tests/monitoring/alert_rules/test_manager.py
@@ -18,7 +18,8 @@ to the current version of the project delivered to anyone in the future.
 """
 import pytest
 
-from paasng.monitoring.monitor.alert_rules.manager import AlertRuleManager
+from paasng.monitoring.monitor.alert_rules.config.constants import DEFAULT_RULE_CONFIGS
+from paasng.monitoring.monitor.alert_rules.manager import AlertRuleManager, get_supported_alert_codes
 from paasng.monitoring.monitor.models import AppAlertRule
 
 pytestmark = pytest.mark.django_db(databases=['default', 'workloads'])
@@ -34,14 +35,35 @@ class TestAlertRuleManager:
         manager = AlertRuleManager(bk_app)
         manager.init_rules()
         mock_import_configs.assert_called_with(bk_app_init_rule_configs)
-        assert AppAlertRule.objects.filter(alert_code='high_cpu_usage').count() == 2
+        assert AppAlertRule.objects.filter(application=bk_app, alert_code='high_cpu_usage').count() == 2
 
-    def test_create_module_rules(self, bk_app, create_module_for_alert):
+    def test_refresh_rules_by_module(self, bk_app, wl_namespaces):
         manager = AlertRuleManager(bk_app)
-        manager.create_module_rules(create_module_for_alert.name)
-        assert AppAlertRule.objects.filter(module=create_module_for_alert, alert_code='high_cpu_usage').count() == 2
+        manager.refresh_rules_by_module(bk_app.get_default_module().name, 'stag')
+        assert AppAlertRule.objects.filter(application=bk_app, module=None).count() == len(
+            get_supported_alert_codes(bk_app.type).app_scoped_codes
+        )
+        assert AppAlertRule.objects.filter(application=bk_app).exclude(module=None).count() == len(
+            get_supported_alert_codes(bk_app.type).module_scoped_codes
+        )
+        assert (
+            AppAlertRule.objects.get(application=bk_app, alert_code='high_cpu_usage').threshold_expr
+            == DEFAULT_RULE_CONFIGS['high_cpu_usage']['threshold_expr']
+        )
 
-    def test_update(self, bk_app, wl_namespaces, cpu_usage_alert_rule_obj):
+    def test_refresh_rules_by_module_with_rule_obj(self, bk_app, wl_namespaces, cpu_usage_alert_rule_obj):
+        manager = AlertRuleManager(bk_app)
+        manager.refresh_rules_by_module(bk_app.get_default_module().name, 'stag')
+        assert AppAlertRule.objects.filter(application=bk_app, module=None).count() == len(
+            get_supported_alert_codes(bk_app.type).app_scoped_codes
+        )
+        assert AppAlertRule.objects.filter(application=bk_app).exclude(module=None).count() == len(
+            get_supported_alert_codes(bk_app.type).module_scoped_codes
+        )
+        # 与 test_refresh_rules_by_module 不同, 这里测试 AlertRuleManager.refresh_rules_by_module 能够保留原 DB 中的配置值
+        assert AppAlertRule.objects.get(id=cpu_usage_alert_rule_obj.id).threshold_expr == 'N/A'
+
+    def test_update_rule(self, bk_app, wl_namespaces, cpu_usage_alert_rule_obj):
         from tests.utils.helpers import generate_random_string
 
         receivers = [generate_random_string(6)]
@@ -51,3 +73,10 @@ class TestAlertRuleManager:
         rule_obj = AppAlertRule.objects.get(id=cpu_usage_alert_rule_obj.id)
         assert rule_obj.enabled is False
         assert rule_obj.receivers == receivers
+
+    def test_delete_rules(self, bk_app, cpu_usage_alert_rule_obj):
+        module_name = bk_app.get_default_module().name
+        assert AppAlertRule.objects.filter(application=bk_app, module__name=module_name).exists() is True
+        manager = AlertRuleManager(bk_app)
+        manager.delete_rules(module_name, 'stag')
+        assert AppAlertRule.objects.filter(application=bk_app, module__name=module_name).exists() is False


### PR DESCRIPTION
对接蓝鲸监控：统一普通应用与云原生应用
- 根据应用类型分别配置 app_scoped_alert_codes 和 module_scoped_alert_codes
- 注册 refresh_rules handler。 部署和下线时，能够刷新告警规则(celery task)