### PR TITLE
refactor: 调整 Processes 相关模块的结构

### DIFF
--- a/apiserver/paasng/paas_wl/admin/views/processes.py
+++ b/apiserver/paasng/paas_wl/admin/views/processes.py
@@ -28,7 +28,7 @@ from paas_wl.admin.mixins import PaginationMixin
 from paas_wl.admin.serializers.processes import InstanceSerializer, ProcessSpecBoundInfoSLZ, ProcessSpecPlanSLZ
 from paas_wl.platform.applications.models import WlApp
 from paas_wl.workloads.processes.constants import ProcessTargetStatus
-from paas_wl.workloads.processes.controllers import get_proc_mgr
+from paas_wl.workloads.processes.controllers import get_proc_ctl
 from paas_wl.workloads.processes.models import ProcessSpec, ProcessSpecPlan
 from paas_wl.workloads.processes.readers import instance_kmodel
 from paasng.accounts.permissions.global_site import SiteAction, site_perm_class
@@ -131,7 +131,7 @@ class ProcessSpecManageViewSet(GenericViewSet):
         wl_app = self.get_app()
         data = request.data
         process_spec = get_object_or_404(ProcessSpec, engine_app_id=wl_app.pk, name=process_type)
-        ctl = get_proc_mgr(get_env_by_wl_app(wl_app))
+        ctl = get_proc_ctl(get_env_by_wl_app(wl_app))
         if process_spec.target_replicas != int(data["target_replicas"]):
             ctl.scale(process_spec.name, target_replicas=int(data["target_replicas"]))
 

--- a/apiserver/paasng/paas_wl/monitoring/metrics/models.py
+++ b/apiserver/paasng/paas_wl/monitoring/metrics/models.py
@@ -39,8 +39,7 @@ from paas_wl.platform.applications.models import WlApp
 from paas_wl.workloads.processes.readers import instance_kmodel, process_kmodel
 
 if TYPE_CHECKING:
-    from paas_wl.workloads.processes.models import Process
-
+    from paas_wl.workloads.processes.entities import Process
 
 logger = logging.getLogger(__name__)
 

--- a/apiserver/paasng/paas_wl/networking/ingress/managers/service.py
+++ b/apiserver/paasng/paas_wl/networking/ingress/managers/service.py
@@ -26,7 +26,7 @@ from paas_wl.networking.ingress.managers import AppDefaultIngresses
 from paas_wl.networking.ingress.utils import make_service_name
 from paas_wl.platform.applications.models import WlApp
 from paas_wl.resources.kube_res.exceptions import AppEntityNotFound
-from paas_wl.workloads.processes.models import Process
+from paas_wl.workloads.processes.entities import Process
 
 logger = logging.getLogger(__name__)
 

--- a/apiserver/paasng/paas_wl/platform/system_api/serializers.py
+++ b/apiserver/paasng/paas_wl/platform/system_api/serializers.py
@@ -21,7 +21,7 @@ import re
 from rest_framework import serializers
 
 from paas_wl.monitoring.metrics.constants import MetricsSeriesType
-from paas_wl.workloads.processes.models import Instance
+from paas_wl.workloads.processes.entities import Instance
 
 # proc type name is alphanumeric
 # https://docs-v2.readthedocs.io/en/latest/using-workflow/process-types-and-the-procfile/#declaring-process-types

--- a/apiserver/paasng/paas_wl/resources/actions/archive.py
+++ b/apiserver/paasng/paas_wl/resources/actions/archive.py
@@ -19,11 +19,9 @@ to the current version of the project delivered to anyone in the future.
 """Archive related deploy functions"""
 import logging
 
-from paas_wl.cnative.specs.procs import get_proc_specs
 from paas_wl.monitoring.app_monitor.managers import make_bk_monitor_controller
-from paas_wl.platform.applications.models import Release
-from paas_wl.workloads.processes.controllers import AppProcessesController, CNativeProcController
-from paasng.platform.applications.constants import ApplicationType
+from paas_wl.workloads.processes.controllers import get_proc_ctl
+from paas_wl.workloads.processes.shim import ProcessManager
 from paasng.platform.applications.models import ModuleEnvironment
 
 logger = logging.getLogger(__name__)
@@ -41,20 +39,8 @@ class ArchiveOperationController:
 
     def stop_all_processes(self):
         """Stop all processes"""
-        if self.env.application.type == ApplicationType.CLOUD_NATIVE:
-            self._stop_cnative_all_processes()
-        else:
-            self._stop_all_processes()
-
-    def _stop_all_processes(self):
-        """普通应用，插件应用等根据 DB 中的配置，逐个停止进程"""
-        ctl = AppProcessesController(env=self.env)
-        release: Release = Release.objects.get_latest(self.env.wl_app)
-        for proc_type in release.get_procfile().keys():
+        ctl = get_proc_ctl(env=self.env)
+        lister = ProcessManager(env=self.env)
+        for proc_spec in lister.list_processes_specs():
+            proc_type = proc_spec["name"]
             ctl.stop(proc_type=proc_type)
-
-    def _stop_cnative_all_processes(self):
-        """云原生应用取线上现有进程，逐个停止"""
-        ctl = CNativeProcController(env=self.env)
-        for spec in get_proc_specs(self.env):
-            ctl.stop(proc_type=spec.name)

--- a/apiserver/paasng/paas_wl/resources/actions/deploy.py
+++ b/apiserver/paasng/paas_wl/resources/actions/deploy.py
@@ -35,7 +35,7 @@ from paas_wl.workloads.processes.utils import get_command_name
 if TYPE_CHECKING:
     from paas_wl.platform.applications.models import Release, WlApp
     from paas_wl.resources.base.client import K8sScheduler
-    from paas_wl.workloads.processes.models import Process
+    from paas_wl.workloads.processes.entities import Process
 
 logger = logging.getLogger(__name__)
 

--- a/apiserver/paasng/paas_wl/resources/base/client.py
+++ b/apiserver/paasng/paas_wl/resources/base/client.py
@@ -38,7 +38,7 @@ from paas_wl.resources.base.generation import get_mapper_version
 from paas_wl.resources.base.kres import KNode, set_default_options
 from paas_wl.workloads.autoscaling.entities import ProcAutoscaling
 from paas_wl.workloads.images.entities import ImageCredentials, credentials_kmodel
-from paas_wl.workloads.processes.models import Process
+from paas_wl.workloads.processes.entities import Process
 
 if TYPE_CHECKING:
     from paas_wl.resources.base.base import EnhancedApiClient

--- a/apiserver/paasng/paas_wl/resources/base/controllers.py
+++ b/apiserver/paasng/paas_wl/resources/base/controllers.py
@@ -49,7 +49,7 @@ from paas_wl.utils.kubestatus import (
     parse_pod,
 )
 from paas_wl.workloads.autoscaling.entities import ProcAutoscaling
-from paas_wl.workloads.processes.models import Process
+from paas_wl.workloads.processes.entities import Process
 
 if TYPE_CHECKING:
     from paas_wl.resources.base.base import EnhancedApiClient

--- a/apiserver/paasng/paas_wl/resources/base/generation/mapper.py
+++ b/apiserver/paasng/paas_wl/resources/base/generation/mapper.py
@@ -24,8 +24,7 @@ from paas_wl.resources.base.kres import BaseKresource, KDeployment, KPod, KRepli
 
 if TYPE_CHECKING:
     from paas_wl.resources.base.base import EnhancedApiClient
-    from paas_wl.workloads.processes.models import Process
-
+    from paas_wl.workloads.processes.entities import Process
 
 MapperResource = TypeVar("MapperResource", bound=BaseKresource)
 

--- a/apiserver/paasng/paas_wl/workloads/processes/drf_serializers.py
+++ b/apiserver/paasng/paas_wl/workloads/processes/drf_serializers.py
@@ -31,7 +31,8 @@ from paas_wl.platform.applications.models import Release
 from paas_wl.workloads.autoscaling.constants import ScalingMetric, ScalingMetricSourceType
 from paas_wl.workloads.autoscaling.models import AutoscalingConfig
 from paas_wl.workloads.processes.constants import ProcessUpdateType
-from paas_wl.workloads.processes.models import Instance, ProcessSpec
+from paas_wl.workloads.processes.entities import Instance
+from paas_wl.workloads.processes.models import ProcessSpec
 
 
 class HumanizeDateTimeField(serializers.DateTimeField):

--- a/apiserver/paasng/paas_wl/workloads/processes/entities.py
+++ b/apiserver/paasng/paas_wl/workloads/processes/entities.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from kubernetes.dynamic import ResourceField
+
+from paas_wl.cluster.utils import get_cluster_by_app
+from paas_wl.platform.applications.constants import WlAppType
+from paas_wl.platform.applications.models import Release
+from paas_wl.platform.applications.models.managers import AppConfigVarManager
+from paas_wl.platform.applications.models.managers.app_res_ver import AppResVerManager
+from paas_wl.release_controller.constants import ImagePullPolicy
+from paas_wl.resources.base import kres
+from paas_wl.resources.kube_res.base import AppEntity, Schedule
+from paas_wl.resources.utils.basic import get_full_node_selector, get_full_tolerations
+from paas_wl.workloads.images.constants import PULL_SECRET_NAME
+from paas_wl.workloads.processes.serializers import InstanceDeserializer, ProcessDeserializer, ProcessSerializer
+
+
+@dataclass
+class Resources:
+    """计算资源定义"""
+
+    @dataclass
+    class Spec:
+        cpu: str
+        memory: str
+
+    limits: Optional[Spec] = None
+    requests: Optional[Spec] = None
+
+
+@dataclass
+class Runtime:
+    """运行相关"""
+
+    envs: Dict[str, str]
+    image: str
+    # 实际的镜像启动命令
+    command: List[str]
+    args: List[str]
+    # [deprecated] TODO: 删除 proc_command 以及与其相关的字段
+    # 由于 command 本身经过了镜像启动脚本的封装
+    # 所以这里我们额外存储一个用户填写的启动命令
+    # 类似 procfile 中是 web: python manage.py runserver
+    # command: ./init.sh start web
+    # proc_command: python manage.py runserver
+    proc_command: str = ""
+    image_pull_policy: ImagePullPolicy = field(default=ImagePullPolicy.IF_NOT_PRESENT)
+    image_pull_secrets: List[Dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class Probe:
+    type: str = "common"
+    params: dict = field(default_factory=dict)
+
+
+@dataclass
+class Status:
+    replicas: int
+    success: int = 0
+    failed: int = 0
+
+    version: int = 0
+
+    def to_dict(self) -> Dict[str, int]:
+        return {'replicas': self.replicas, 'success': self.success, 'failed': self.failed}
+
+
+@dataclass
+class Instance(AppEntity):
+    """副本实例定义
+
+    肩负着内部程序流转和 K8S 交互的重任
+
+    :param process_type: 进程类型
+    :param host_ip: Pod 分配的 host_ip
+    :param start_time: 启动时间
+    :param state: Pod 的状态
+    :param state_message: Pod 处于 Terminated, Waiting 的原因
+    :param image: 当前进程使用的镜像, 即主容器使用的镜像
+    :param envs: 直接在 Pod 中声明的环境变量
+    :param ready: 进程实例是否就绪
+    :param restart_count: 重启次数
+    :param version: 当前实例的版本号, 每次部署递增
+    """
+
+    process_type: str
+    host_ip: str = ""
+    start_time: str = ""
+    state: str = ""
+    state_message: str = ""
+    image: str = ""
+    envs: Dict[str, str] = field(default_factory=dict)
+    ready: bool = True
+    restart_count: int = 0
+
+    version: int = 0
+
+    class Meta:
+        kres_class = kres.KPod
+        deserializer = InstanceDeserializer
+
+    @property
+    def shorter_name(self) -> str:
+        """Return a simplified name
+
+        'ieod-x-gunicorn-deployment-59b9789f76wk82' -> '59b9789f76wk82'
+        """
+        return self.get_shorter_instance_name(self.name)
+
+    @classmethod
+    def get_shorter_instance_name(cls, instance_name: str) -> str:
+        return instance_name.split('-')[-1]
+
+
+@dataclass
+class Process(AppEntity):
+    """进程定义
+
+    肩负着内部程序流转和 K8S 交互的重任
+    """
+
+    version: int
+    replicas: int
+    type: str
+    schedule: Schedule
+    runtime: Runtime
+    resources: Optional[Resources] = None
+    readiness_probe: Optional[Probe] = None
+
+    # 实际资源的动态状态
+    metadata: Optional['ResourceField'] = None
+    status: Optional[Status] = None
+    instances: List[Instance] = field(default_factory=list)
+
+    class Meta:
+        kres_class = kres.KDeployment
+        deserializer = ProcessDeserializer
+        serializer = ProcessSerializer
+
+    @classmethod
+    def from_release(cls, type_: str, release: 'Release', extra_envs: Optional[dict] = None) -> 'Process':
+        """通过 release 生成 Process"""
+        config = release.config
+        procfile = release.get_procfile()
+        envs = AppConfigVarManager(app=release.app).get_process_envs(type_)
+        envs.update(release.get_envs())
+        envs.update(extra_envs or {})
+
+        entrypoint = config.runtime.get_entrypoint()
+        # cnb runtime 的 entrypoint 只需要设置成 type_ 即可
+        # See: https://github.com/buildpacks/lifecycle/blob/main/cmd/launcher/cli/launcher.go#L78
+        # TODO: 更好的方式区分 cnb runtime 和 heroku runtime?
+        if entrypoint == ["launcher"]:
+            entrypoint = [type_]
+            command = []
+        else:
+            command = config.runtime.get_command(type_, procfile)
+
+        mapper_version = AppResVerManager(release.app).curr_version
+        process = Process(
+            app=release.app,
+            # AppEntity.name should be the name of k8s resource
+            name="should-set-by-mapper",
+            type=type_,
+            version=release.version,
+            replicas=release.app.get_structure().get(type_, 0),
+            runtime=Runtime(
+                envs=envs,
+                image=config.get_image(),
+                command=entrypoint,
+                args=command,
+                proc_command=procfile[type_],
+                image_pull_policy=config.runtime.get_image_pull_policy(),
+                image_pull_secrets=[{"name": PULL_SECRET_NAME}],
+            ),
+            schedule=Schedule(
+                node_selector=get_full_node_selector(release.app, config),
+                tolerations=get_full_tolerations(release.app, config),
+                cluster_name=get_cluster_by_app(release.app).name,
+            ),
+            resources=Resources(**config.resource_requirements.get(type_, {})),
+        )
+        # TODO: 解决 MapperVersion 与 Process 循环依赖的问题
+        process.name = mapper_version.deployment(process=process).name
+        return process
+
+    @property
+    def main_container_name(self) -> str:
+        # TODO: 统一主容器的名字
+        if self.app.type == WlAppType.DEFAULT:
+            return f"{self.app.region}-{self.app.scheduler_safe_name}"
+        return self.type
+
+    def fulfill_runtime(self, replicas: int, success: int, metadata: 'ResourceField' = None):
+        """填充运行时具体信息"""
+        self.status = Status(replicas=replicas, success=success, failed=max(replicas - success, 0))
+        self.metadata = metadata

--- a/apiserver/paasng/paas_wl/workloads/processes/managers.py
+++ b/apiserver/paasng/paas_wl/workloads/processes/managers.py
@@ -22,7 +22,7 @@ from typing import Iterable, Optional
 
 from paas_wl.platform.applications.models import Release, WlApp
 
-from .models import Process
+from .entities import Process
 
 logger = logging.getLogger(__name__)
 

--- a/apiserver/paasng/paas_wl/workloads/processes/models.py
+++ b/apiserver/paasng/paas_wl/workloads/processes/models.py
@@ -17,30 +17,19 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 from django.conf import settings
 from django.db import models
 from jsonfield import JSONField
-from kubernetes.dynamic import ResourceField
 
-from paas_wl.cluster.utils import get_cluster_by_app
-from paas_wl.platform.applications.constants import WlAppType
-from paas_wl.platform.applications.models.managers import AppConfigVarManager
 from paas_wl.platform.applications.models.managers.app_metadata import get_metadata
-from paas_wl.platform.applications.models.managers.app_res_ver import AppResVerManager
-from paas_wl.release_controller.constants import ImagePullPolicy
-from paas_wl.resources.base import kres
-from paas_wl.resources.kube_res.base import AppEntity, Schedule
-from paas_wl.resources.utils.basic import get_full_node_selector, get_full_tolerations
 from paas_wl.utils.models import TimestampedModel
-from paas_wl.workloads.images.constants import PULL_SECRET_NAME
 from paas_wl.workloads.processes.constants import ProcessTargetStatus
-from paas_wl.workloads.processes.serializers import InstanceDeserializer, ProcessDeserializer, ProcessSerializer
 
 if TYPE_CHECKING:
-    from paas_wl.platform.applications.models import Release, WlApp
+    from paas_wl.platform.applications.models import WlApp
 
 logger = logging.getLogger(__name__)
 
@@ -220,186 +209,3 @@ class ProcessTmpl:
 
     def __post_init__(self):
         self.name = self.name.lower()
-
-
-@dataclass
-class Resources:
-    """计算资源定义"""
-
-    @dataclass
-    class Spec:
-        cpu: str
-        memory: str
-
-    limits: Optional[Spec] = None
-    requests: Optional[Spec] = None
-
-
-@dataclass
-class Runtime:
-    """运行相关"""
-
-    envs: Dict[str, str]
-    image: str
-    # 实际的镜像启动命令
-    command: List[str]
-    args: List[str]
-    # [deprecated] TODO: 删除 proc_command 以及与其相关的字段
-    # 由于 command 本身经过了镜像启动脚本的封装
-    # 所以这里我们额外存储一个用户填写的启动命令
-    # 类似 procfile 中是 web: python manage.py runserver
-    # command: ./init.sh start web
-    # proc_command: python manage.py runserver
-    proc_command: str = ""
-    image_pull_policy: ImagePullPolicy = field(default=ImagePullPolicy.IF_NOT_PRESENT)
-    image_pull_secrets: List[Dict[str, str]] = field(default_factory=list)
-
-
-@dataclass
-class Probe:
-    type: str = "common"
-    params: dict = field(default_factory=dict)
-
-
-@dataclass
-class Status:
-    replicas: int
-    success: int = 0
-    failed: int = 0
-
-    version: int = 0
-
-    def to_dict(self) -> Dict[str, int]:
-        return {'replicas': self.replicas, 'success': self.success, 'failed': self.failed}
-
-
-@dataclass
-class Instance(AppEntity):
-    """副本实例定义
-
-    肩负着内部程序流转和 K8S 交互的重任
-
-    :param process_type: 进程类型
-    :param host_ip: Pod 分配的 host_ip
-    :param start_time: 启动时间
-    :param state: Pod 的状态
-    :param state_message: Pod 处于 Terminated, Waiting 的原因
-    :param image: 当前进程使用的镜像, 即主容器使用的镜像
-    :param envs: 直接在 Pod 中声明的环境变量
-    :param ready: 进程实例是否就绪
-    :param restart_count: 重启次数
-    :param version: 当前实例的版本号, 每次部署递增
-    """
-
-    process_type: str
-    host_ip: str = ""
-    start_time: str = ""
-    state: str = ""
-    state_message: str = ""
-    image: str = ""
-    envs: Dict[str, str] = field(default_factory=dict)
-    ready: bool = True
-    restart_count: int = 0
-
-    version: int = 0
-
-    class Meta:
-        kres_class = kres.KPod
-        deserializer = InstanceDeserializer
-
-    @property
-    def shorter_name(self) -> str:
-        """Return a simplified name
-
-        'ieod-x-gunicorn-deployment-59b9789f76wk82' -> '59b9789f76wk82'
-        """
-        return self.get_shorter_instance_name(self.name)
-
-    @classmethod
-    def get_shorter_instance_name(cls, instance_name: str) -> str:
-        return instance_name.split('-')[-1]
-
-
-@dataclass
-class Process(AppEntity):
-    """进程定义
-
-    肩负着内部程序流转和 K8S 交互的重任
-    """
-
-    version: int
-    replicas: int
-    type: str
-    schedule: Schedule
-    runtime: Runtime
-    resources: Optional[Resources] = None
-    readiness_probe: Optional[Probe] = None
-
-    # 实际资源的动态状态
-    metadata: Optional['ResourceField'] = None
-    status: Optional[Status] = None
-    instances: List[Instance] = field(default_factory=list)
-
-    class Meta:
-        kres_class = kres.KDeployment
-        deserializer = ProcessDeserializer
-        serializer = ProcessSerializer
-
-    @classmethod
-    def from_release(cls, type_: str, release: 'Release', extra_envs: Optional[dict] = None) -> 'Process':
-        """通过 release 生成 Process"""
-        config = release.config
-        procfile = release.get_procfile()
-        envs = AppConfigVarManager(app=release.app).get_process_envs(type_)
-        envs.update(release.get_envs())
-        envs.update(extra_envs or {})
-
-        entrypoint = config.runtime.get_entrypoint()
-        # cnb runtime 的 entrypoint 只需要设置成 type_ 即可
-        # See: https://github.com/buildpacks/lifecycle/blob/main/cmd/launcher/cli/launcher.go#L78
-        # TODO: 更好的方式区分 cnb runtime 和 heroku runtime?
-        if entrypoint == ["launcher"]:
-            entrypoint = [type_]
-            command = []
-        else:
-            command = config.runtime.get_command(type_, procfile)
-
-        mapper_version = AppResVerManager(release.app).curr_version
-        process = Process(
-            app=release.app,
-            # AppEntity.name should be the name of k8s resource
-            name="should-set-by-mapper",
-            type=type_,
-            version=release.version,
-            replicas=release.app.get_structure().get(type_, 0),
-            runtime=Runtime(
-                envs=envs,
-                image=config.get_image(),
-                command=entrypoint,
-                args=command,
-                proc_command=procfile[type_],
-                image_pull_policy=config.runtime.get_image_pull_policy(),
-                image_pull_secrets=[{"name": PULL_SECRET_NAME}],
-            ),
-            schedule=Schedule(
-                node_selector=get_full_node_selector(release.app, config),
-                tolerations=get_full_tolerations(release.app, config),
-                cluster_name=get_cluster_by_app(release.app).name,
-            ),
-            resources=Resources(**config.resource_requirements.get(type_, {})),
-        )
-        # TODO: 解决 MapperVersion 与 Process 循环依赖的问题
-        process.name = mapper_version.deployment(process=process).name
-        return process
-
-    @property
-    def main_container_name(self) -> str:
-        # TODO: 统一主容器的名字
-        if self.app.type == WlAppType.DEFAULT:
-            return f"{self.app.region}-{self.app.scheduler_safe_name}"
-        return self.type
-
-    def fulfill_runtime(self, replicas: int, success: int, metadata: 'ResourceField' = None):
-        """填充运行时具体信息"""
-        self.status = Status(replicas=replicas, success=success, failed=max(replicas - success, 0))
-        self.metadata = metadata

--- a/apiserver/paasng/paas_wl/workloads/processes/processes.py
+++ b/apiserver/paasng/paas_wl/workloads/processes/processes.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+import logging
+from typing import Dict, List, Optional
+
+from attrs import define
+
+logger = logging.getLogger(__name__)
+
+
+@define
+class Instance:
+    """A Process instance object
+    TODO: 与 PlainInstance 统一
+    """
+
+    name: str
+    host_ip: str
+    start_time: str
+    state: str
+    ready: bool
+    image: str
+    restart_count: int
+    version: int
+    process_type: Optional[str] = None
+    namespace: Optional[str] = None
+
+    def __str__(self):
+        return f'Instance<{self.name}-{self.state}>'
+
+
+@define
+class Process:
+    """
+    Q: What's the differences between Process and ProcessSpec?
+    A: Process represents the actual data from engine backend, and ProcessSpec represents the expectation of user.
+    TODO: 与 PlainProcess 统一
+    """
+
+    type: str
+    version: int
+    command: str
+    process_status: Dict
+    desired_replicas: str
+    instances: List[Instance]
+
+    @property
+    def available_instance_count(self):
+        return len([instance for instance in self.instances if instance.ready and instance.version == self.version])
+
+    def __repr__(self):
+        return f'Process<{self.type}>'

--- a/apiserver/paasng/paas_wl/workloads/processes/readers.py
+++ b/apiserver/paasng/paas_wl/workloads/processes/readers.py
@@ -24,8 +24,8 @@ from paas_wl.resources.base.kres import KPod
 from paas_wl.resources.kube_res.base import AppEntityReader, ResourceList
 from paas_wl.resources.kube_res.exceptions import AppEntityNotFound
 from paas_wl.workloads.processes.constants import PROCESS_NAME_KEY
+from paas_wl.workloads.processes.entities import Instance, Process
 from paas_wl.workloads.processes.managers import AppProcessManager
-from paas_wl.workloads.processes.models import Instance, Process
 
 if TYPE_CHECKING:
     from paas_wl.platform.applications.models import WlApp

--- a/apiserver/paasng/paas_wl/workloads/processes/serializers.py
+++ b/apiserver/paasng/paas_wl/workloads/processes/serializers.py
@@ -35,7 +35,7 @@ from paas_wl.workloads.resource_templates.utils import AddonManager
 
 if TYPE_CHECKING:
     from paas_wl.resources.base.generation.mapper import MapperPack
-    from paas_wl.workloads.processes.models import Instance, Process
+    from paas_wl.workloads.processes.entities import Instance, Process
 
 
 def extract_type_from_name(name: str, namespace: str) -> Optional[str]:
@@ -85,7 +85,7 @@ class ProcessDeserializer(AppEntityDeserializer['Process']):
 
     def _deserialize_for_cnative_app(self, app: WlApp, kube_data: ResourceInstance) -> 'Process':
         """deserialize process info for cloud native type app"""
-        from paas_wl.workloads.processes.models import Runtime, Schedule
+        from paas_wl.workloads.processes.entities import Runtime, Schedule
 
         main_container = self._get_main_container(app, kube_data)
 

--- a/apiserver/paasng/paas_wl/workloads/processes/shim.py
+++ b/apiserver/paasng/paas_wl/workloads/processes/shim.py
@@ -16,80 +16,46 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-import logging
 from dataclasses import asdict
 from typing import Dict, List, Optional
 
 import cattr
-from attrs import define
 from django.utils.functional import cached_property
 
 from paas_wl.cluster.utils import get_cluster_by_app
+from paas_wl.cnative.specs.procs import get_proc_specs
 from paas_wl.platform.applications.models import WlApp
 from paas_wl.resources.base.bcs_client import BCSClient
-from paas_wl.workloads.processes.controllers import get_processes_status, list_proc_specs
+from paas_wl.workloads.processes.controllers import get_processes_status
+from paas_wl.workloads.processes.drf_serializers import CNativeProcSpecSLZ, ProcessSpecSLZ
 from paas_wl.workloads.processes.models import ProcessSpecManager, ProcessTmpl
+from paas_wl.workloads.processes.processes import Process
 from paas_wl.workloads.processes.readers import process_kmodel
-from paasng.engine.models import EngineApp
-
-logger = logging.getLogger(__name__)
-
-
-@define
-class Instance:
-    """A Process instance object"""
-
-    name: str
-    host_ip: str
-    start_time: str
-    state: str
-    ready: bool
-    image: str
-    restart_count: int
-    version: int
-    process_type: Optional[str] = None
-    namespace: Optional[str] = None
-
-    def __str__(self):
-        return f'Instance<{self.name}-{self.state}>'
+from paasng.platform.applications.constants import ApplicationType
+from paasng.platform.applications.models import ModuleEnvironment
 
 
-@define
-class Process:
+def _list_proc_specs(env: ModuleEnvironment) -> List[Dict]:
+    """Return all processes specs of an app
+
+    :return: list of process specs
     """
-    Q: What's the differences between Process and ProcessSpec?
-    A: Process represents the actual data from engine backend, and ProcessSpec represents the expectation of user.
-    """
-
-    type: str
-    app_name: str
-    version: int
-    command: str
-    process_status: Dict
-    desired_replicas: str
-    instances: List[Instance]
-
-    @property
-    def available_instance_count(self):
-        return len([instance for instance in self.instances if instance.ready and instance.version == self.version])
-
-    @property
-    def engine_app_name(self):
-        return self.app_name
-
-    def __repr__(self):
-        return f'Process<{self.type}>'
+    # TODO: 统一返回值的字段？
+    if env.application.type == ApplicationType.CLOUD_NATIVE:
+        return CNativeProcSpecSLZ(get_proc_specs(env), many=True).data
+    wl_app = env.wl_app
+    return ProcessSpecSLZ(wl_app.process_specs.all(), many=True).data
 
 
 class ProcessManager:
     """Manager for engine processes"""
 
-    def __init__(self, app: EngineApp):
-        self.app = app
+    def __init__(self, env: ModuleEnvironment):
+        self.env = env
 
     @cached_property
     def wl_app(self) -> WlApp:
-        return self.app.to_wl_obj()
+        return self.env.wl_app
 
     def sync_processes_specs(self, processes: List[ProcessTmpl]):
         """Sync specs by plain ProcessSpec structure
@@ -105,7 +71,7 @@ class ProcessManager:
 
         :param target_status: if given, filter results by given target_status
         """
-        specs = list_proc_specs(self.wl_app)
+        specs = _list_proc_specs(self.env)
         results = []
         for item in specs:
             # Filter by given conditions
@@ -133,10 +99,9 @@ class ProcessManager:
         return [cattr.structure(x, Process) for x in items]
 
     def get_running_image(self) -> str:
-        manager = ProcessManager(self.app)
-        images = {instance.image for process in manager.list_processes() for instance in process.instances}
+        images = {instance.image for process in self.list_processes() for instance in process.instances}
         if len(images) == 0:
-            raise RuntimeError(f"Can't find running image for App<{self.app}>")
+            raise RuntimeError(f"Can't find running image for Env<{self.env}>")
         elif len(images) > 1:
             raise RuntimeError("multiple image found!")
         return images.pop()

--- a/apiserver/paasng/paas_wl/workloads/processes/watch.py
+++ b/apiserver/paasng/paas_wl/workloads/processes/watch.py
@@ -19,7 +19,7 @@ to the current version of the project delivered to anyone in the future.
 import logging
 import queue
 import threading
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, Generator, Iterable, List, Optional, Tuple, Type
 
 from django.db import connection
@@ -29,7 +29,7 @@ from paas_wl.platform.applications.models import WlApp
 from paas_wl.platform.system_api.serializers import InstanceSerializer, ProcSpecsSerializer
 from paas_wl.resources.kube_res.base import AppEntity
 from paas_wl.resources.kube_res.exceptions import WatchKubeResourceError
-from paas_wl.workloads.processes.models import Instance, Process
+from paas_wl.workloads.processes.entities import Instance, Process
 from paas_wl.workloads.processes.readers import instance_kmodel, process_kmodel
 
 logger = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 def watch_process_events(
     app: WlApp, timeout_seconds: int, rv_proc: Optional[int] = None, rv_inst: Optional[int] = None
-) -> Generator[Dict, None, None]:
+) -> Generator['ProcWatchEvent', None, None]:
     """Create a watch stream to track app's all process related changes
 
     :param timeout_seconds: timeout seconds for generated event stream, recommended value: less than 120 seconds
@@ -58,7 +58,7 @@ def watch_process_events(
     parallel_gen = ParallelChainedGenerator(event_gens)
     parallel_gen.start()
     for event in parallel_gen.iter_results():
-        yield asdict(ProcWatchEvent.make_event(event))
+        yield ProcWatchEvent.make_event(event)
 
     parallel_gen.close()
 

--- a/apiserver/paasng/paasng/engine/deploy/release/legacy.py
+++ b/apiserver/paasng/paasng/engine/deploy/release/legacy.py
@@ -25,6 +25,7 @@ from typing import Optional, Tuple
 from blue_krill.async_utils.poll_task import CallbackHandler, CallbackResult, CallbackStatus, TaskPoller
 from pydantic import ValidationError as PyDanticValidationError
 
+from paas_wl.workloads.processes.shim import ProcessManager
 from paasng.engine.configurations.building import get_processes_by_build
 from paasng.engine.configurations.config_var import get_env_variables
 from paasng.engine.configurations.image import update_image_runtime_config
@@ -35,7 +36,6 @@ from paasng.engine.deploy.engine_svc import EngineDeployClient
 from paasng.engine.exceptions import StepNotInPresetListError
 from paasng.engine.models.deployment import Deployment
 from paasng.engine.models.phases import DeployPhaseTypes
-from paasng.engine.models.processes import ProcessManager
 from paasng.engine.signals import on_release_created
 from paasng.engine.workflow import DeployStep
 from paasng.platform.applications.models import ModuleEnvironment
@@ -53,7 +53,7 @@ class ApplicationReleaseMgr(DeployStep):
     @DeployStep.procedures
     def start(self):
         with self.procedure('更新进程配置'):
-            ProcessManager(self.engine_app).sync_processes_specs(self.deployment.get_processes())
+            ProcessManager(self.engine_app.env).sync_processes_specs(self.deployment.get_processes())
 
         with self.procedure('更新应用配置'):
             update_image_runtime_config(deployment=self.deployment)

--- a/apiserver/paasng/paasng/engine/processes/models.py
+++ b/apiserver/paasng/paasng/engine/processes/models.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
-    from paas_wl.workloads.processes.models import Process, Status
+    from paas_wl.workloads.processes.entities import Process, Status
 
 
 def condense_processes(processes: 'List[Process]') -> 'List[PlainProcess]':

--- a/apiserver/paasng/paasng/engine/processes/views.py
+++ b/apiserver/paasng/paasng/engine/processes/views.py
@@ -25,6 +25,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.status import HTTP_403_FORBIDDEN
 
+from paas_wl.workloads.processes.shim import ProcessManager
 from paasng.accessories.iam.permissions.resources.application import AppAction
 from paasng.accessories.serializers import DocumentaryLinkSLZ
 from paasng.accessories.smart_advisor.advisor import DocumentaryLinkAdvisor
@@ -33,7 +34,6 @@ from paasng.accounts.constants import AccountFeatureFlag as AFF
 from paasng.accounts.permissions.application import application_perm_class
 from paasng.accounts.permissions.user import user_has_feature
 from paasng.engine.constants import RuntimeType
-from paasng.engine.models.processes import ProcessManager
 from paasng.engine.processes import serializers as slzs
 from paasng.platform.applications.constants import ApplicationType
 from paasng.platform.applications.mixins import ApplicationCodeInPathMixin
@@ -64,8 +64,8 @@ class ApplicationProcessWebConsoleViewSet(viewsets.ViewSet, ApplicationCodeInPat
 
         application = self.get_application()
         module = self.get_module_via_path()
-        engine_app = self.get_engine_app_via_path()
-        manager = ProcessManager(engine_app)
+        env = self.get_env_via_path()
+        manager = ProcessManager(env)
 
         if not PFF.get_default_flags()[PFF.ENABLE_WEB_CONSOLE]:
             # 平台不支持 WebConsole 功能

--- a/apiserver/paasng/paasng/engine/views/release.py
+++ b/apiserver/paasng/paasng/engine/views/release.py
@@ -25,12 +25,12 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from paas_wl.release_controller.api import get_latest_build_id
+from paas_wl.workloads.processes.shim import ProcessManager
 from paasng.accessories.iam.permissions.resources.application import AppAction
 from paasng.accounts.permissions.application import application_perm_class
 from paasng.engine.deploy.release.legacy import release_by_engine
 from paasng.engine.models import Deployment, OfflineOperation
 from paasng.engine.models.config_var import ENVIRONMENT_NAME_FOR_GLOBAL
-from paasng.engine.models.processes import ProcessManager
 from paasng.engine.serializers import DeploymentSLZ, GetReleasedInfoSLZ, OfflineOperationSLZ
 from paasng.platform.applications.constants import AppFeatureFlag
 from paasng.platform.applications.mixins import ApplicationCodeInPathMixin
@@ -60,7 +60,7 @@ class ReleasedInfoViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
             'exposed_link': {"url": entrance.address if entrance else None},
         }
         if serializer.data['with_processes']:
-            _specs = ProcessManager(module_env.engine_app).list_processes_specs()
+            _specs = ProcessManager(module_env).list_processes_specs()
             # Change structure of "specs", make it compatible with frontend client
             specs = [{spec['name']: spec} for spec in _specs]
             data['processes'] = specs
@@ -111,7 +111,7 @@ class ReleasedInfoViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
             },
         }
         if serializer.data['with_processes']:
-            _specs = ProcessManager(module_env.engine_app).list_processes_specs()
+            _specs = ProcessManager(module_env).list_processes_specs()
             # Change structure of "specs", make it compatible with frontend client
             specs = [{spec['name']: spec} for spec in _specs]
             data['processes'] = specs

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/applications/detail/engine/processes.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/applications/detail/engine/processes.html
@@ -55,8 +55,8 @@
                 $[ props.row.available_instance_count ]/$[ props.row.desired_replicas ]
             </template>
         </bk-table-column>
-        <bk-table-column label="资源方案" prop="process_spec.plan.name"></bk-table-column>
-        <bk-table-column label="操作">
+        <bk-table-column label="资源方案" prop="process_spec.plan.name" v-if="application.type === 'cloud_native'"></bk-table-column>
+        <bk-table-column label="操作" v-if="application.type === 'cloud_native'">
             <template slot-scope="props">
                 <a class="bk-text-button mr10" href="javascript:void(0);" @click="editProcessSpecPlan(props.row)">修改资源方案</a>
                 <a class="bk-text-button mr10" href="javascript:void(0);" @click="scale(props.row)" v-if="props.row.command !== null">调整实例数</a>

--- a/apiserver/paasng/paasng/plat_admin/admin42/views/engine/proc_spec.py
+++ b/apiserver/paasng/paasng/plat_admin/admin42/views/engine/proc_spec.py
@@ -25,12 +25,13 @@ from rest_framework.request import Request
 
 from paas_wl.admin.serializers.processes import ProcessSpecPlanSLZ
 from paas_wl.workloads.processes.models import ProcessSpecPlan
+from paas_wl.workloads.processes.shim import ProcessManager
 from paasng.accounts.permissions.constants import SiteAction
 from paasng.accounts.permissions.global_site import site_perm_class
 from paasng.engine.constants import AppEnvName
-from paasng.engine.models.processes import ProcessManager
 from paasng.plat_admin.admin42.utils.mixins import GenericTemplateView
 from paasng.plat_admin.admin42.views.applications import ApplicationDetailBaseView
+from paasng.platform.applications.constants import ApplicationType
 from paasng.platform.applications.models import ModuleEnvironment
 from paasng.platform.region.models import get_all_regions
 from paasng.utils.text import remove_prefix
@@ -85,7 +86,7 @@ class ProcessSpecManageView(ApplicationDetailBaseView):
         processes: List[Dict] = []
 
         for env in envs:
-            process_manager = ProcessManager(env.engine_app)
+            process_manager = ProcessManager(env)
             process_spec_map = {}
             for process_spec in process_manager.list_processes_specs():
                 process_spec_map[process_spec["name"]] = process_spec
@@ -104,7 +105,9 @@ class ProcessSpecManageView(ApplicationDetailBaseView):
                     "command": process.command,
                     "available_instance_count": process.available_instance_count,
                     "instances": cattr.unstructure(process.instances),
-                    "process_spec": {
+                }
+                if application.type == ApplicationType.CLOUD_NATIVE:
+                    process_map[process.type]["process_spec"] = {
                         "plan": {
                             "id": process_spec["plan_id"],
                             "name": process_spec["plan_name"],
@@ -112,8 +115,7 @@ class ProcessSpecManageView(ApplicationDetailBaseView):
                             "requests": process_spec["resource_requests"],
                             "max_replicas": process_spec["max_replicas"],
                         }
-                    },
-                }
+                    }
             processes.extend(process_map.values())
 
         kwargs["processes"] = processes

--- a/apiserver/paasng/tests/engine/processes/test_wait.py
+++ b/apiserver/paasng/tests/engine/processes/test_wait.py
@@ -40,7 +40,7 @@ from paasng.engine.deploy.bg_wait.wait_deployment import (
 )
 
 if TYPE_CHECKING:
-    from paas_wl.workloads.processes.models import Process
+    from paas_wl.workloads.processes.entities import Process
 
 pytestmark = pytest.mark.django_db(databases=["default", "workloads"])
 

--- a/apiserver/paasng/tests/extensions/declarative/conftest.py
+++ b/apiserver/paasng/tests/extensions/declarative/conftest.py
@@ -35,7 +35,7 @@ def setup_mocks(mock_wl_services_in_creation):
             "sub_path_domains": [],
             "app_root_domains": [{"name": "bkapps.example.com"}],
         }
-    ), mock.patch("paasng.engine.models.processes.ProcessManager.sync_processes_specs"):
+    ), mock.patch("paas_wl.workloads.processes.shim.ProcessManager.sync_processes_specs"):
         yield
 
 

--- a/apiserver/paasng/tests/paas_wl/utils/wl_app.py
+++ b/apiserver/paasng/tests/paas_wl/utils/wl_app.py
@@ -25,7 +25,7 @@ from django.utils.crypto import get_random_string
 
 from paas_wl.platform.applications.models import Build, Release, WlApp
 from paas_wl.platform.applications.models.config import Config
-from paas_wl.workloads.processes.models import Instance
+from paas_wl.workloads.processes.entities import Instance
 from tests.utils.auth import create_user
 
 

--- a/apiserver/paasng/tests/paas_wl/workloads/autoscaling/test_serializers.py
+++ b/apiserver/paasng/tests/paas_wl/workloads/autoscaling/test_serializers.py
@@ -28,7 +28,7 @@ from paas_wl.workloads.autoscaling.constants import ScalingMetric, ScalingMetric
 from paas_wl.workloads.autoscaling.entities import ProcAutoscaling
 from paas_wl.workloads.autoscaling.models import AutoscalingConfig, MetricSpec, ScalingObjectRef
 from paas_wl.workloads.autoscaling.serializers import ProcAutoscalingDeserializer, ProcAutoscalingSerializer
-from paas_wl.workloads.processes.models import Process
+from paas_wl.workloads.processes.entities import Process
 
 pytestmark = pytest.mark.django_db(databases=["default", "workloads"])
 

--- a/apiserver/paasng/tests/paas_wl/workloads/processes/test_controllers.py
+++ b/apiserver/paasng/tests/paas_wl/workloads/processes/test_controllers.py
@@ -22,7 +22,7 @@ import pytest
 
 from paas_wl.resources.kube_res.exceptions import AppEntityNotFound
 from paas_wl.workloads.processes.controllers import env_is_running, get_processes_status
-from paas_wl.workloads.processes.models import Instance, Process
+from paas_wl.workloads.processes.entities import Instance, Process
 from tests.paas_wl.cnative.specs.utils import create_cnative_deploy
 from tests.paas_wl.utils.wl_app import create_wl_app
 from tests.paas_wl.workloads.conftest import create_release

--- a/apiserver/paasng/tests/paas_wl/workloads/processes/test_managers.py
+++ b/apiserver/paasng/tests/paas_wl/workloads/processes/test_managers.py
@@ -25,7 +25,7 @@ from paas_wl.resources.base.generation import get_mapper_version
 from paas_wl.resources.base.kres import KPod
 from paas_wl.resources.kube_res.base import AppEntityManager
 from paas_wl.resources.utils.basic import get_client_by_app
-from paas_wl.workloads.processes.models import Process
+from paas_wl.workloads.processes.entities import Process
 from paas_wl.workloads.processes.readers import instance_kmodel, process_kmodel
 from paas_wl.workloads.processes.serializers import extract_type_from_name
 from tests.paas_wl.utils.wl_app import create_wl_release

--- a/apiserver/paasng/tests/paas_wl/workloads/processes/test_managers.py
+++ b/apiserver/paasng/tests/paas_wl/workloads/processes/test_managers.py
@@ -122,7 +122,7 @@ class TestProcInstManager:
     def test_get_logs(self, wl_app, pod):
         # Query process instances
         inst = instance_kmodel.list_by_process_type(wl_app, 'web')[0]
-        with mock.patch('paas_wl.workloads.processes.models.Instance.Meta.kres_class') as kp:
+        with mock.patch('paas_wl.workloads.processes.entities.Instance.Meta.kres_class') as kp:
             instance_kmodel.get_logs(inst)
             assert kp().get_log.called
 


### PR DESCRIPTION
refactor: 调整 Processes 相关的模块结构
- Process 相关的查询逻辑下沉到 paas_wl 模块;
- 统一云原生应用和普通应用查询 process_spec 的接口(ProcessManager.list_processes_specs);
- 从 processes/models.py 拆分出 entities.py 模块