### PR TITLE
refactor: not use monitor as code when no valid token

### DIFF
--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/handlers.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/handlers.py
@@ -18,6 +18,7 @@ to the current version of the project delivered to anyone in the future.
 """
 from typing import Type
 
+from django.conf import settings
 from django.dispatch import receiver
 
 from paasng.engine.models.deployment import Deployment
@@ -31,6 +32,9 @@ from .tasks import delete_rules, refresh_rules_by_module
 
 @receiver(post_appenv_deploy)
 def refresh_rules_after_deploy(sender: ApplicationEnvironment, deployment: Deployment, **kwargs):
+    if not settings.MONITOR_AS_CODE_CONF.get('token'):
+        return
+
     if not deployment.has_succeeded():
         return
 
@@ -41,6 +45,9 @@ def refresh_rules_after_deploy(sender: ApplicationEnvironment, deployment: Deplo
 def refresh_rules_after_offline(
     sender: Type[OfflineOperation], offline_instance: OfflineOperation, environment: str, **kwargs
 ):
+    if not settings.MONITOR_AS_CODE_CONF.get('token'):
+        return
+
     if not offline_instance.has_succeeded():
         return
 


### PR DESCRIPTION
未设置有效 token 时，不启用 monitor as code 配置 app 告警策略