### PR TITLE
refactor: replace cluster_id to bcs_cluster_id in ClusterNamespaceSLZ

### DIFF
--- a/apiserver/paasng/paasng/plat_admin/system/serializers.py
+++ b/apiserver/paasng/paasng/plat_admin/system/serializers.py
@@ -153,5 +153,5 @@ class AddonSpecsSLZ(serializers.Serializer):
 
 
 class ClusterNamespaceSLZ(serializers.Serializer):
-    cluster_id = serializers.CharField(help_text="集群 ID")
+    bcs_cluster_id = serializers.CharField(help_text="BCS 集群 ID")
     namespace = serializers.CharField(help_text="命名空间名称")

--- a/apiserver/paasng/paasng/plat_admin/system/views.py
+++ b/apiserver/paasng/paasng/plat_admin/system/views.py
@@ -294,7 +294,9 @@ class ClusterNamespaceInfoView(ApplicationCodeInPathMixin, viewsets.ViewSet):
         namespace_cluster_map: Dict[str, str] = {}
         for wl_app in wl_apps:
             if (ns := wl_app.namespace) not in namespace_cluster_map:
-                namespace_cluster_map[ns] = get_cluster_by_app(wl_app).name
+                namespace_cluster_map[ns] = get_cluster_by_app(wl_app).bcs_cluster_id or ''
 
-        data = [{'namespace': ns, 'cluster_id': cluster_id} for ns, cluster_id in namespace_cluster_map.items()]
+        data = [
+            {'namespace': ns, 'bcs_cluster_id': bcs_cluster_id} for ns, bcs_cluster_id in namespace_cluster_map.items()
+        ]
         return Response(ClusterNamespaceSLZ(data, many=True).data)

--- a/apiserver/paasng/tests/plat_admin/test_system.py
+++ b/apiserver/paasng/tests/plat_admin/test_system.py
@@ -266,7 +266,10 @@ class TestClusterNamespaceInfoViewSet:
     def create_cluster_obj(self, bk_app, with_wl_apps):
         wl_apps = [app.wl_app for app in bk_app.envs.all()]
         for wl_app in wl_apps:
-            Cluster.objects.get_or_create(name=wl_app.latest_config.cluster)
+            Cluster.objects.get_or_create(
+                name=wl_app.latest_config.cluster,
+                defaults={'annotations': {'bcs_cluster_id': generate_random_string()}},
+            )
 
     def test_list_by_code(self, bk_app, with_wl_apps, sys_api_client):
         url = f'/sys/api/bkapps/applications/{bk_app.code}/cluster_namespaces/'
@@ -275,4 +278,4 @@ class TestClusterNamespaceInfoViewSet:
         assert response.status_code == 200
         assert len(response.data) == 2
         assert response.data[0]['namespace']
-        assert response.data[0]['cluster_id']
+        assert response.data[0]['bcs_cluster_id']


### PR DESCRIPTION
命名调整为 bcs_cluster_id，减少与 Cluster model uuid 的歧义