### PR TITLE
apply alert rules in an incremental update manner

### DIFF
--- a/apiserver/paasng/paasng/accessories/bkmonitorv3/backend/apigw.py
+++ b/apiserver/paasng/paasng/accessories/bkmonitorv3/backend/apigw.py
@@ -76,6 +76,14 @@ class Group(OperationGroup):
         path='/promql_query/',
     )
 
+    # 下发告警规则
+    as_code_import_config = bind_property(
+        Operation,
+        name='as_code_import_config',
+        method='POST',
+        path='/as_code_import_config/',
+    )
+
 
 class Client(APIGatewayClient):
     """bkmonitorv3

--- a/apiserver/paasng/paasng/accessories/bkmonitorv3/backend/esb.py
+++ b/apiserver/paasng/paasng/accessories/bkmonitorv3/backend/esb.py
@@ -70,6 +70,14 @@ class MonitorV3Group(OperationGroup):
         path='/api/c/compapi/v2/monitor_v3/graph_promql_query/',
     )
 
+    # 下发告警规则(esb 不可用)
+    as_code_import_config = bind_property(
+        Operation,
+        name='as_code_import_config',
+        method='POST',
+        path='/api/c/compapi/v2/monitor_v3/as_code_import_config/',
+    )
+
 
 class Client(ESBClient):
     """ESB Components"""

--- a/apiserver/paasng/paasng/engine/deploy/release/operator.py
+++ b/apiserver/paasng/paasng/engine/deploy/release/operator.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 # Try to load the access control module
 ApplicationAccessControlSwitch: Optional[Type]
 try:
-    from paasng.security.access_control.models import ApplicationAccessControlSwitch
+    from paasng.security.access_control.models import ApplicationAccessControlSwitch  # type: ignore
 except ImportError:
     logger.info('access control only supported in te edition, skip import')
     ApplicationAccessControlSwitch = None

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/ascode/client.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/ascode/client.py
@@ -76,8 +76,6 @@ class AsCodeClient:
     def _render_configs(self, rule_configs: List[RuleConfig]) -> Dict:
         """按照 MonitorAsCode 规则, 渲染出如下示例目录结构:
 
-        ├── notice
-          └── notice.yaml
         └── rule
           ├── high_cpu_usage.yaml
           └── high_mem_usage.yaml

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/ascode/client.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/ascode/client.py
@@ -50,7 +50,7 @@ class AsCodeClient:
     def apply_rule_configs(self, rule_configs: List[RuleConfig]):
         """下发告警规则"""
         self._validate(rule_configs)
-        configs = self._render_configs(rule_configs)
+        configs = self._render_rule_configs(rule_configs)
         self._apply_rule_configs(configs)
 
     def apply_notice_group(self, receivers: List[str]):
@@ -73,7 +73,7 @@ class AsCodeClient:
                     f'app_code({self.app_code})'
                 )
 
-    def _render_configs(self, rule_configs: List[RuleConfig]) -> Dict:
+    def _render_rule_configs(self, rule_configs: List[RuleConfig]) -> Dict:
         """按照 MonitorAsCode 规则, 渲染出如下示例目录结构:
 
         └── rule

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/ascode/client.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/ascode/client.py
@@ -19,15 +19,16 @@ to the current version of the project delivered to anyone in the future.
 import logging
 import os
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import jinja2
-import requests
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
-from rest_framework import status
 
+from paasng.accessories.bkmonitorv3.client import make_bk_monitor_client
+from paasng.accessories.bkmonitorv3.shim import get_or_create_bk_monitor_space
 from paasng.monitoring.monitor.alert_rules.config import RuleConfig
+from paasng.platform.applications.models import Application
 
 from .exceptions import AsCodeAPIError
 
@@ -42,27 +43,37 @@ class AsCodeClient:
     :param default_receivers: app 的默认告警接收者
     """
 
-    def __init__(self, app_code: str, rule_configs: List[RuleConfig], default_receivers: List[str]):
+    def __init__(self, app_code: str):
         self.app_code = app_code
-        self.rule_configs = rule_configs
-        self.default_receivers = default_receivers
         self.default_notice_group_name = f"[{self.app_code}] {_('通知组')}"
 
-    def apply_rule_configs(self):
+    def apply_rule_configs(self, rule_configs: List[RuleConfig]):
         """下发告警规则"""
-        self._validate()
-        configs = self._render_configs()
+        self._validate(rule_configs)
+        configs = self._render_configs(rule_configs)
         self._apply_rule_configs(configs)
 
-    def _validate(self):
-        for config in self.rule_configs:
+    def apply_notice_group(self, receivers: List[str]):
+        """下发通知组"""
+        tpl_dir = Path(os.path.dirname(__file__))
+        loader = jinja2.FileSystemLoader([tpl_dir / 'notice_tpl'])
+        j2_env = jinja2.Environment(loader=loader, trim_blocks=True)
+        configs = {
+            'notice/default_notice.yaml': j2_env.get_template('notice.yaml.j2').render(
+                notice_group_name=self.default_notice_group_name, receivers=receivers
+            )
+        }
+        self._apply_rule_configs(configs, f'{self.app_code}_notice_group', incremental=False)
+
+    def _validate(self, rule_configs: List[RuleConfig]):
+        for config in rule_configs:
             if config.app_code != self.app_code:
                 raise ValueError(
                     f'apply rules error: app_code({config.app_code}) from rule_configs not match '
                     f'app_code({self.app_code})'
                 )
 
-    def _render_configs(self) -> Dict:
+    def _render_configs(self, rule_configs: List[RuleConfig]) -> Dict:
         """按照 MonitorAsCode 规则, 渲染出如下示例目录结构:
 
         ├── notice
@@ -76,18 +87,9 @@ class AsCodeClient:
         j2_env = jinja2.Environment(loader=loader, trim_blocks=True)
 
         configs = {}
-        for conf in self.rule_configs:
+        for conf in rule_configs:
             ctx = conf.to_dict()
-
-            if set(conf.receivers) == set(self.default_receivers):
-                ctx['notice_group_name'] = self.default_notice_group_name
-            else:
-                # 配置中告警接收者与 app 的默认告警接收者不一致时, 单独创建告警组
-                ctx['notice_group_name'] = f"{conf.alert_rule_display_name} {_('通知组')}"
-                configs[f'notice/{conf.alert_rule_name}.yaml'] = j2_env.get_template('notice.yaml.j2').render(
-                    notice_group_name=ctx['notice_group_name'], receivers=conf.receivers
-                )
-
+            ctx['notice_group_name'] = self.default_notice_group_name
             # 涉及到 rabbitmq 的告警策略, 指标是通过 bkmonitor 配置的采集器采集, 需要添加指标前缀
             if 'rabbitmq' in conf.alert_code:
                 ctx['rabbitmq_metric_name_prefix'] = settings.RABBITMQ_MONITOR_CONF.get('metric_name_prefix', '')
@@ -96,38 +98,24 @@ class AsCodeClient:
                 **ctx
             )
 
-        # 配置 App 默认通知组
-        configs['notice/default_notice.yaml'] = j2_env.get_template('notice.yaml.j2').render(
-            notice_group_name=self.default_notice_group_name, receivers=self.default_receivers
-        )
-
         return configs
 
-    def _apply_rule_configs(self, configs: Dict):
-        """同步告警配置到 bkmonitor"""
-        # TODO import_config 接口接入网关后, 调整为通过 apigw 访问
-        http_schema_url = settings.BK_MONITORV3_URL.replace('https', 'http', 1)
-        resp = requests.post(
-            url=f'{http_schema_url}/rest/v2/as_code/import_config/',
-            json={
-                'bk_biz_id': settings.MONITOR_AS_CODE_CONF.get('bk_biz_id'),
-                'app': self.app_code,
-                'configs': configs,
-                'overwrite': False,
-            },
-            headers={'Authorization': f"Bearer {settings.MONITOR_AS_CODE_CONF.get('token')}"},
-            verify=False,
-        )
+    def _apply_rule_configs(self, configs: Dict, config_group: Optional[str] = None, incremental: bool = True):
+        """同步告警配置到 bkmonitor
 
-        err_msg_format = f'ascode import alert rule configs of app_code({self.app_code}) error: {{err_msg}}'
-
-        if resp.status_code == status.HTTP_200_OK:
-            resp_data = resp.json()
-            if resp_data['result']:
-                return
-
-            logger.error(err_msg_format.format(err_msg=resp.text))
-            raise AsCodeAPIError(resp_data['message'])
-
-        logger.error(err_msg_format.format(err_msg=resp.text))
-        raise AsCodeAPIError('unknown error')
+        :param configs: 告警规则配置
+        :param config_group: 配置分组
+        :param incremental: 是否增量更新
+        """
+        space, _ = get_or_create_bk_monitor_space(Application.objects.get(code=self.app_code))
+        try:
+            make_bk_monitor_client().as_code_import_config(
+                configs,
+                int(space.iam_resource_id),
+                config_group or self.app_code,
+                overwrite=False,
+                incremental=incremental,
+            )
+        except Exception as e:
+            logger.error(f'ascode import alert rule configs of app_code({self.app_code}) error: {e}')
+            raise AsCodeAPIError(e)

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/ascode/notice_tpl/notice.yaml.j2
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/ascode/notice_tpl/notice.yaml.j2
@@ -3,20 +3,20 @@ name: '{{ notice_group_name }}'
 alert:
   '00:00--23:59':
     remind:
-      type: [weixin, mail]
+      type: [rtx, weixin]
     warning:
-      type: [weixin, mail]
+      type: [rtx, weixin]
     fatal:
-      type: [weixin, mail]
+      type: [rtx, weixin]
 
 action:
   '00:00--23:59':
     execute:
-      type: [weixin, mail]
+      type: [rtx, weixin]
     execute_failed:
-      type: [weixin, mail]
+      type: [rtx, weixin]
     execute_success:
-      type: [weixin, mail]
+      type: [rtx, weixin]
 
 users:
 {% for user in receivers or []%}

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/config/generator.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/config/generator.py
@@ -16,11 +16,8 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-from typing import Dict, List, Optional
+from typing import List, Optional
 
-from django.db.models import QuerySet
-
-from paasng.monitoring.monitor.models import AppAlertRule
 from paasng.platform.applications.models import Application
 
 from .app_rule import AppScopedRuleConfig, ModuleScopedRuleConfig, RuleConfig, get_supported_alert_codes
@@ -80,28 +77,3 @@ class AppRuleConfigGenerator:
             rule_configs.extend([c for c in r_configs if c.is_valid()])
 
         return rule_configs
-
-    def gen_rule_configs_from_qs(self, qs: 'QuerySet[AppAlertRule]') -> List[RuleConfig]:
-        """从 AppAlertRule queryset 中生成告警规则配置"""
-        rule_configs: List[RuleConfig] = []
-        config: RuleConfig
-
-        for rule_obj in qs or []:
-            if rule_obj.module:
-                config = ModuleScopedRuleConfig.from_alert_rule_obj(rule_obj)
-            else:
-                config = AppScopedRuleConfig.from_alert_rule_obj(rule_obj)
-
-            rule_configs.append(config)
-
-        return rule_configs
-
-    def gen_rule_config_from_obj(self, rule_obj: AppAlertRule, override_fields: Optional[Dict] = None) -> RuleConfig:
-        """从 AppAlertRule object 中生成告警规则配置
-
-        :param rule_obj: 告警规则对象
-        :param override_fields: 覆盖 rule_obj 中的字段
-        """
-        if rule_obj.module:
-            return ModuleScopedRuleConfig.from_alert_rule_obj(rule_obj, override_fields)
-        return AppScopedRuleConfig.from_alert_rule_obj(rule_obj, override_fields)

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/handlers.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/handlers.py
@@ -16,40 +16,24 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-from typing import Type
-
-from django.conf import settings
 from django.dispatch import receiver
 
 from paasng.engine.models.deployment import Deployment
-from paasng.engine.models.offline import OfflineOperation
 from paasng.engine.signals import post_appenv_deploy
 from paasng.platform.applications.models import ApplicationEnvironment
-from paasng.platform.applications.signals import module_environment_offline_success
+from paasng.platform.applications.signals import application_member_updated
 
-from .tasks import delete_rules, refresh_rules_by_module
+from . import tasks
 
 
 @receiver(post_appenv_deploy)
-def refresh_rules_after_deploy(sender: ApplicationEnvironment, deployment: Deployment, **kwargs):
-    if not settings.MONITOR_AS_CODE_CONF.get('token'):
-        return
-
+def create_rules_after_deploy(sender: ApplicationEnvironment, deployment: Deployment, **kwargs):
     if not deployment.has_succeeded():
         return
 
-    refresh_rules_by_module.delay(sender.application.code, sender.module.name, sender.environment)
+    tasks.create_rules.delay(sender.application.code, sender.module.name, sender.environment)
 
 
-@receiver(module_environment_offline_success)
-def refresh_rules_after_offline(
-    sender: Type[OfflineOperation], offline_instance: OfflineOperation, environment: str, **kwargs
-):
-    if not settings.MONITOR_AS_CODE_CONF.get('token'):
-        return
-
-    if not offline_instance.has_succeeded():
-        return
-
-    app_environment = offline_instance.app_environment
-    delete_rules.delay(app_environment.application.code, app_environment.module.name, environment)
+@receiver(application_member_updated)
+def update_notice_group(sender, application, **kwargs):
+    tasks.update_notice_group.delay(application.code)

--- a/apiserver/paasng/paasng/monitoring/monitor/alert_rules/tasks.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/alert_rules/tasks.py
@@ -28,33 +28,21 @@ logger = logging.getLogger(__name__)
 
 
 @shared_task
-def refresh_rules_by_module(app_code: str, module_name: str, run_env: str):
+def create_rules(app_code: str, module_name: str, run_env: str):
     try:
         rule_mgr = AlertRuleManager(Application.objects.get(code=app_code))
-        rule_mgr.refresh_rules_by_module(module_name, run_env)
+        rule_mgr.create_rules(module_name, run_env)
     except Exception:
         logger.exception(
-            f"Unable to refresh alert rules after release app"
+            f"Unable to create alert rules after release app"
             f"(code: {app_code}, module: {module_name}, run_env: {run_env})"
         )
 
 
 @shared_task
-def delete_rules(app_code: str, module_name: str, run_env: str):
+def update_notice_group(app_code: str):
     try:
         rule_mgr = AlertRuleManager(Application.objects.get(code=app_code))
-        rule_mgr.delete_rules(module_name, run_env)
+        rule_mgr.update_notice_group()
     except Exception:
-        logger.exception(
-            f"Unable to refresh alert rules after offline app"
-            f"(code: {app_code}, module: {module_name}, run_env: {run_env})"
-        )
-
-
-@shared_task
-def refresh_rules(app_code: str):
-    try:
-        rule_mgr = AlertRuleManager(Application.objects.get(code=app_code))
-        rule_mgr.refresh_rules()
-    except Exception:
-        logger.exception(f"Unable to refresh alert rules for app(code: {app_code})")
+        logger.exception(f"Unable to update notice group (code: {app_code})")

--- a/apiserver/paasng/paasng/monitoring/monitor/models.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/models.py
@@ -43,7 +43,7 @@ class AppAlertRuleManager(models.Manager):
 
 
 class AppAlertRule(AuditedModel):
-    """记录 app 告警规则配置"""
+    """记录 app 初始的告警规则配置"""
 
     alert_code = models.CharField(max_length=64, help_text='alert rule code e.g. high_cpu_usage')
     display_name = models.CharField(max_length=512)

--- a/apiserver/paasng/paasng/monitoring/monitor/serializers.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/serializers.py
@@ -22,7 +22,6 @@ from paasng.accessories.bkmonitorv3.params import QueryAlertsParams
 from paasng.engine.constants import AppEnvName
 from paasng.utils.serializers import HumanizeTimestampField
 
-from .alert_rules.manager import AlertRuleManager
 from .models import AppAlertRule
 
 
@@ -45,18 +44,6 @@ class AlertRuleSLZ(serializers.ModelSerializer):
             'display_name': {'read_only': True},
             'environment': {'read_only': True},
         }
-
-    def update(self, instance, validated_data):
-        manager = AlertRuleManager(instance.application)
-        instance = manager.update_rule(
-            instance,
-            update_fields={
-                'threshold_expr': validated_data['threshold_expr'],
-                'receivers': validated_data['receivers'],
-                'enabled': validated_data['enabled'],
-            },
-        )
-        return instance
 
 
 class SupportedAlertSLZ(serializers.Serializer):

--- a/apiserver/paasng/paasng/monitoring/monitor/urls.py
+++ b/apiserver/paasng/paasng/monitoring/monitor/urls.py
@@ -48,9 +48,6 @@ urlpatterns = [
         'api/monitor/applications/<slug:code>/alert_rules/init/',
         views.AlertRulesView.as_view({'post': 'init_alert_rules'}),
     ),
-    path(
-        'api/monitor/applications/<slug:code>/alert_rules/<int:id>/', views.AlertRulesView.as_view({'put': 'update'})
-    ),
     path('api/monitor/supported_alert_rules/', views.AlertRulesView.as_view({'get': 'list_supported_alert_rules'})),
     path('api/monitor/applications/<slug:code>/alerts/', views.ListAlertsView.as_view({'post': 'list'})),
 ]

--- a/apiserver/paasng/tests/monitoring/alert_rules/conftest.py
+++ b/apiserver/paasng/tests/monitoring/alert_rules/conftest.py
@@ -34,7 +34,7 @@ random_vhost = generate_random_string()
 random_cluster_id = generate_random_string()
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_import_configs():
     with mock.patch.object(AsCodeClient, "_apply_rule_configs", return_value=None) as mock_method:
         yield mock_method
@@ -117,10 +117,13 @@ def bk_app_init_rule_configs(bk_app, wl_namespaces):
                 notice_group_name=notice_group_name,
             )
 
-    init_rule_configs['notice/default_notice.yaml'] = j2_env.get_template('notice.yaml.j2').render(
-        notice_group_name=f"[{app_code}] {_('通知组')}", receivers=bk_app.get_developers()
-    )
-    return init_rule_configs
+    notice_group_config = {
+        'notice/default_notice.yaml': j2_env.get_template('notice.yaml.j2').render(
+            notice_group_name=f"[{app_code}] {_('通知组')}", receivers=bk_app.get_developers()
+        )
+    }
+
+    return init_rule_configs, notice_group_config
 
 
 @pytest.fixture

--- a/apiserver/paasng/tests/monitoring/alert_rules/test_api.py
+++ b/apiserver/paasng/tests/monitoring/alert_rules/test_api.py
@@ -20,7 +20,6 @@ import pytest
 
 from paasng.monitoring.monitor.alert_rules.config.constants import DEFAULT_RULE_CONFIGS
 from paasng.monitoring.monitor.alert_rules.manager import AlertRuleManager
-from paasng.monitoring.monitor.models import AppAlertRule
 
 pytestmark = pytest.mark.django_db(databases=['default', 'workloads'])
 
@@ -41,16 +40,6 @@ class TestAlertRulesView:
             f'/api/monitor/applications/{bk_app.code}/modules/{bk_module.name}/alert_rules/?alert_code=ddd'
         )
         assert len(resp.data) == 0
-
-    def test_update_rule(self, api_client, bk_app):
-        threshold_expr = '> 10 < 50'
-        rule_obj = AppAlertRule.objects.all()[0]
-        resp = api_client.put(
-            f'/api/monitor/applications/{bk_app.code}/alert_rules/{rule_obj.id}/',
-            {'threshold_expr': threshold_expr, 'receivers': rule_obj.receivers, 'enabled': rule_obj.enabled},
-        )
-        assert resp.status_code == 200
-        assert AppAlertRule.objects.get(id=rule_obj.id).threshold_expr == threshold_expr
 
     def test_list_supported_alert_rules(self, api_client):
         resp = api_client.get('/api/monitor/supported_alert_rules/')


### PR DESCRIPTION
对接蓝鲸监控命名空间：
- 将告警规则增量初始化到 SaaS 应用空间
- 使用监控网关的 as_code_import_config API 下发告警规则
- 将告警规则与告警通知组进行解耦，以支持应用成员变更时，通知组的人员变更
