### PR TITLE
bugfix: 实现将增强服务配置注入到 bkapp manifest 的逻辑

### DIFF
--- a/apiserver/paasng/paas_wl/cnative/specs/addons.py
+++ b/apiserver/paasng/paas_wl/cnative/specs/addons.py
@@ -32,20 +32,7 @@ def inject_to_app_resource(env: ModuleEnvironment, app_resource: bk_app.BkAppRes
 
     if app_resource.apiVersion == ApiVersion.V1ALPHA2:
         # inject addons services to specs
-        predefined_addons = app_resource.spec.addons
-        addons = [
-            bk_app.BkAppAddon(
-                name=name,
-            )
-            for name in bound_addon_names
-        ]
-
-        if predefined_addons and ({svc.name for svc in predefined_addons} - set(bound_addon_names)):
-            # manifest 中声明的增强服务列表与在 v3 上启用的列表不一致, 可能是通过 cli 触发部署且需要打开增强服务
-            # 目前的策略是合并 addons 列表
-            # TODO: 讨论是否需要兼容 cli 更新的情况
-            for svc in predefined_addons:
-                if svc.name in bound_addon_names:
-                    continue
-                addons.append(svc)
-        app_resource.spec.addons = addons
+        predefined_addons_names = {svc.name for svc in app_resource.spec.addons}
+        for svc_name in bound_addon_names:
+            if svc_name not in predefined_addons_names:
+                app_resource.spec.addons.append(bk_app.BkAppAddon(name=svc_name))

--- a/apiserver/paasng/paas_wl/cnative/specs/addons.py
+++ b/apiserver/paasng/paas_wl/cnative/specs/addons.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+import json
+
+from paas_wl.cnative.specs.constants import BKPAAS_ADDONS_ANNO_KEY, ApiVersion
+from paas_wl.cnative.specs.crd import bk_app
+from paasng.dev_resources.servicehub.manager import mixed_service_mgr
+from paasng.platform.applications.models import ModuleEnvironment
+
+
+def inject_to_app_resource(env: ModuleEnvironment, app_resource: bk_app.BkAppResource):
+    """将 增强服务(addon) 配置注入到 BkAppResource 模型中"""
+    # inject addons services to annotations for legacy version manifest
+    bound_addon_names = [svc.name for svc in mixed_service_mgr.list_binded(env.module)]
+    app_resource.metadata.annotations[BKPAAS_ADDONS_ANNO_KEY] = json.dumps(bound_addon_names)
+
+    if app_resource.apiVersion == ApiVersion.V1ALPHA2:
+        # inject addons services to specs
+        predefined_addons = app_resource.spec.addons
+        addons = [
+            bk_app.BkAppAddon(
+                name=name,
+            )
+            for name in bound_addon_names
+        ]
+
+        if predefined_addons and ({svc.name for svc in predefined_addons} - set(bound_addon_names)):
+            # manifest 中声明的增强服务列表与在 v3 上启用的列表不一致, 可能是通过 cli 触发部署且需要打开增强服务
+            # 目前的策略是合并 addons 列表
+            # TODO: 讨论是否需要兼容 cli 更新的情况
+            for svc in predefined_addons:
+                if svc.name in bound_addon_names:
+                    continue
+                addons.append(svc)
+        app_resource.spec.addons = addons

--- a/apiserver/paasng/tests/paas_wl/cnative/specs/test_addons.py
+++ b/apiserver/paasng/tests/paas_wl/cnative/specs/test_addons.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+import json
+from unittest import mock
+
+import pytest
+
+from paas_wl.cnative.specs.addons import inject_to_app_resource
+from paas_wl.cnative.specs.constants import BKPAAS_ADDONS_ANNO_KEY
+from paas_wl.cnative.specs.crd.bk_app import ApiVersion, BkAppAddon, BkAppAddonSpec, BkAppResource
+
+pytestmark = pytest.mark.django_db(databases=['default', 'workloads'])
+
+
+@pytest.fixture()
+def mock_service_mgr(request):
+    def fake_list_binded(module):
+        return [type("", (), dict(name=name)) for name in request.param]
+
+    with mock.patch("paas_wl.cnative.specs.addons.mixed_service_mgr.list_binded") as list_binded:
+        list_binded.side_effect = fake_list_binded
+        yield request.param
+
+
+@pytest.mark.parametrize(
+    "mock_service_mgr, manifest, expected_addons",
+    [
+        (
+            ["mysql", "rabbitmq"],
+            BkAppResource(
+                apiVersion=ApiVersion.V1ALPHA1,
+                metadata={"name": "foo"},
+                spec={},
+            ),
+            [],
+        ),
+        (
+            ["mysql", "rabbitmq"],
+            BkAppResource(
+                apiVersion=ApiVersion.V1ALPHA2,
+                metadata={"name": "foo"},
+                spec={},
+            ),
+            [BkAppAddon(name='mysql', specs=[]), BkAppAddon(name='rabbitmq', specs=[])],
+        ),
+        (
+            ["mysql", "rabbitmq"],
+            BkAppResource(
+                apiVersion=ApiVersion.V1ALPHA2,
+                metadata={"name": "foo"},
+                spec={"addons": [{"name": "redis"}]},
+            ),
+            [
+                BkAppAddon(name='redis', specs=[]),
+                BkAppAddon(name='mysql', specs=[]),
+                BkAppAddon(name='rabbitmq', specs=[]),
+            ],
+        ),
+        (
+            ["mysql", "rabbitmq"],
+            BkAppResource(
+                apiVersion=ApiVersion.V1ALPHA2,
+                metadata={"name": "foo"},
+                spec={"addons": [{"name": "mysql"}]},
+            ),
+            [
+                BkAppAddon(name='mysql', specs=[]),
+                BkAppAddon(name='rabbitmq', specs=[]),
+            ],
+        ),
+        (
+            ["mysql", "rabbitmq"],
+            BkAppResource(
+                apiVersion=ApiVersion.V1ALPHA2,
+                metadata={"name": "foo"},
+                spec={"addons": [{"name": "mysql", "specs": [{"name": "version", "value": "5.7"}]}]},
+            ),
+            [
+                BkAppAddon(name='mysql', specs=[BkAppAddonSpec(name='version', value='5.7')]),
+                BkAppAddon(name='rabbitmq', specs=[]),
+            ],
+        ),
+    ],
+    indirect=["mock_service_mgr"],
+)
+def test_inject_to_app_resource(bk_stag_env, mock_service_mgr, manifest: BkAppResource, expected_addons):
+    inject_to_app_resource(bk_stag_env, manifest)
+
+    assert manifest.metadata.annotations[BKPAAS_ADDONS_ANNO_KEY] == json.dumps(mock_service_mgr)
+    assert manifest.spec.addons == expected_addons


### PR DESCRIPTION
目前如果不往 spec 里写 addon 列表，会导致不注入增强服务的环境变量