### PR TITLE
fix: 创建应用->进程配置与钩子命令无需判断应用类型

### DIFF
--- a/webfe/package_vue/src/views/dev-center/app/engine/cloud-deployment/deploy-hook.vue
+++ b/webfe/package_vue/src/views/dev-center/app/engine/cloud-deployment/deploy-hook.vue
@@ -9,7 +9,7 @@
   >
     <!-- 若托管方式为源码&镜像，钩子命令页面都为当前空页面状态 -->
     <section
-      v-if="!isCustomImage"
+      v-if="!isCustomImage && !isCreate"
       style="margin-top: 38px;"
     >
       <bk-exception

--- a/webfe/package_vue/src/views/dev-center/app/engine/cloud-deployment/deploy-process.vue
+++ b/webfe/package_vue/src/views/dev-center/app/engine/cloud-deployment/deploy-process.vue
@@ -9,7 +9,7 @@
   >
     <!-- 若托管方式为源码&镜像，进程配置页面都为当前空页面状态 -->
     <section
-      v-if="!isCustomImage"
+      v-if="!isCustomImage && !isCreate"
       style="margin-top: 38px;"
     >
       <bk-exception


### PR DESCRIPTION
- 创建应用->进程配置与钩子命令无需判断应用类型