### PR TITLE
refactor: hide deprecated cpu/memory/imagePullPolicy when get BkApp yaml

### DIFF
--- a/apiserver/paasng/paas_wl/bk_app/cnative/specs/crd/bk_app.py
+++ b/apiserver/paasng/paas_wl/bk_app/cnative/specs/crd/bk_app.py
@@ -68,13 +68,13 @@ class BkAppProcess(BaseModel):
     autoscaling: Optional[AutoscalingSpec] = None
 
     # Deprecated: use resQuotaPlan instead in v1alpha2
-    cpu: str = DEFAULT_PROC_CPU
+    cpu: Optional[str] = None
     # Deprecated: use resQuotaPlan instead in v1alpha2
-    memory: str = DEFAULT_PROC_MEM
+    memory: Optional[str] = None
     # Deprecated: use spec.build.image instead in v1alpha2
     image: Optional[str] = None
     # Deprecated: use spec.build.imagePullPolicy instead in v1alpha2
-    imagePullPolicy: Optional[str] = ImagePullPolicy.IF_NOT_PRESENT
+    imagePullPolicy: Optional[str] = None
 
 
 class Hook(BaseModel):

--- a/apiserver/paasng/paas_wl/bk_app/cnative/specs/procs/quota.py
+++ b/apiserver/paasng/paas_wl/bk_app/cnative/specs/procs/quota.py
@@ -91,9 +91,6 @@ class ResourceQuotaReader:
         if self.res.apiVersion == ApiVersion.V1ALPHA2:
             return self.from_v1alpha2_bkapp()
 
-        if self.res.apiVersion == ApiVersion.V1ALPHA1:
-            return self.from_v1alpha1_bkapp()
-
         raise ValueError(f"Unsupported api version: {self.res.apiVersion}")
 
     def from_v1alpha2_bkapp(self) -> Dict[str, ResourceQuota]:
@@ -107,6 +104,3 @@ class ResourceQuotaReader:
         return {
             p.name: PLAN_TO_LIMIT_QUOTA_MAP[p.resQuotaPlan or ResQuotaPlan.P_DEFAULT] for p in self.res.spec.processes
         }
-
-    def from_v1alpha1_bkapp(self) -> Dict[str, ResourceQuota]:
-        return {p.name: ResourceQuota(cpu=p.cpu, memory=p.memory) for p in self.res.spec.processes}

--- a/apiserver/paasng/paas_wl/bk_app/cnative/specs/procs/quota.py
+++ b/apiserver/paasng/paas_wl/bk_app/cnative/specs/procs/quota.py
@@ -91,6 +91,9 @@ class ResourceQuotaReader:
         if self.res.apiVersion == ApiVersion.V1ALPHA2:
             return self.from_v1alpha2_bkapp()
 
+        if self.res.apiVersion == ApiVersion.V1ALPHA1:
+            return self.from_v1alpha1_bkapp()
+
         raise ValueError(f"Unsupported api version: {self.res.apiVersion}")
 
     def from_v1alpha2_bkapp(self) -> Dict[str, ResourceQuota]:
@@ -104,3 +107,6 @@ class ResourceQuotaReader:
         return {
             p.name: PLAN_TO_LIMIT_QUOTA_MAP[p.resQuotaPlan or ResQuotaPlan.P_DEFAULT] for p in self.res.spec.processes
         }
+
+    def from_v1alpha1_bkapp(self) -> Dict[str, ResourceQuota]:
+        return {p.name: ResourceQuota(cpu=p.cpu or '', memory=p.memory or '') for p in self.res.spec.processes}

--- a/apiserver/paasng/paasng/platform/bkapp_model/manifest.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/manifest.py
@@ -266,7 +266,7 @@ class ProcessesManifestConstructor(ManifestConstructor):
         for limit_memory, quota_plan in quota_plan_memory:
             if limit_memory >= expected_limit_memory:
                 return quota_plan
-        return quota_plan_memory[-1][0]
+        return quota_plan_memory[-1][1]
 
     @staticmethod
     def get_command_and_args(module: Module, process_spec: ModuleProcessSpec) -> Tuple[List[str], List[str]]:

--- a/apiserver/paasng/paasng/platform/bkapp_model/views.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/views.py
@@ -44,7 +44,7 @@ from paasng.platform.bkapp_model.serializers import (
     default_scaling_config,
 )
 from paasng.platform.bkapp_model.utils import get_image_info
-from paasng.platform.engine.constants import AppEnvName
+from paasng.platform.engine.constants import AppEnvName, ImagePullPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +173,7 @@ class ModuleProcessSpecViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
                 args=proc_spec["args"],
                 targetPort=proc_spec.get("port", None),
                 image=proc_spec["image"] if allow_multiple_image else "",
+                imagePullPolicy=ImagePullPolicy.IF_NOT_PRESENT,
             )
             for proc_spec in proc_specs
         ]

--- a/apiserver/paasng/tests/paas_wl/bk_app/cnative/specs/test_models.py
+++ b/apiserver/paasng/tests/paas_wl/bk_app/cnative/specs/test_models.py
@@ -57,10 +57,10 @@ class TestCreateAppResource:
                         'targetPort': None,
                         'resQuotaPlan': None,
                         'autoscaling': None,
-                        'cpu': '500m',
-                        'memory': '256Mi',
+                        'cpu': None,
+                        'memory': None,
                         'image': None,
-                        'imagePullPolicy': 'IfNotPresent',
+                        'imagePullPolicy': None,
                     }
                 ],
                 'hooks': None,

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/test_manifest.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/test_manifest.py
@@ -197,10 +197,10 @@ class TestProcessesManifestConstructor:
                     "targetPort": 8000,
                     "resQuotaPlan": "default",
                     "autoscaling": None,
-                    "cpu": "500m",
-                    "memory": "256Mi",
+                    "cpu": None,
+                    "memory": None,
                     "image": None,
-                    "imagePullPolicy": "IfNotPresent",
+                    "imagePullPolicy": None,
                 }
             ],
             "envOverlay": {


### PR DESCRIPTION
获取 BkApp yaml 的接口中，隐藏待废弃的 cpu/memory 等字段