### PR TITLE
refactor: use bkapp_spec instead of manifest in create cnative app api

### DIFF
--- a/apiserver/paasng/paasng/platform/applications/serializers/__init__.py
+++ b/apiserver/paasng/paasng/platform/applications/serializers/__init__.py
@@ -42,7 +42,7 @@ from .app import (
     SysThirdPartyApplicationSLZ,
     UpdateApplicationSLZ,
 )
-from .cnative import CloudNativeParamsSLZ, CreateCloudNativeAppSLZ
+from .cnative import CreateCloudNativeAppSLZ
 from .fields import AppIDField, ApplicationField, AppNameField
 from .light_app import LightAppCreateSLZ, LightAppDeleteSLZ, LightAppEditSLZ, LightAppQuerySLZ
 from .member_role import ApplicationMemberRoleOnlySLZ, ApplicationMemberSLZ, RoleField
@@ -73,7 +73,6 @@ __all__ = [
     "SearchApplicationSLZ",
     "SysThirdPartyApplicationSLZ",
     "UpdateApplicationSLZ",
-    "CloudNativeParamsSLZ",
     "CreateCloudNativeAppSLZ",
     "AppIDField",
     "ApplicationField",

--- a/apiserver/paasng/paasng/platform/applications/serializers/cnative.py
+++ b/apiserver/paasng/paasng/platform/applications/serializers/cnative.py
@@ -17,81 +17,32 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 from django.utils.translation import gettext_lazy as _
-from pydantic import ValidationError as PDValidationError
-from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from paas_wl.bk_app.cnative.specs.constants import ApiVersion
-from paas_wl.bk_app.cnative.specs.crd.bk_app import BkAppResource
-from paas_wl.bk_app.cnative.specs.models import to_error_string
-from paas_wl.workloads.images.serializers import ImageCredentialSLZ
-from paasng.platform.modules.constants import SourceOrigin
-from paasng.platform.modules.serializers import (
-    CreateModuleBuildConfigSLZ,
-    ModuleSourceConfigSLZ,
-    validate_build_method,
-)
+from paasng.platform.engine.constants import RuntimeType
+from paasng.platform.modules.serializers import BkAppSpecSLZ, ModuleSourceConfigSLZ, validate_build_method
 
 from .mixins import AdvancedCreationParamsMixin, AppBasicInfoMixin
-
-
-class CloudNativeParamsSLZ(serializers.Serializer):
-    """创建云原生应用的详细参数"""
-
-    image = serializers.CharField(label=_('容器镜像地址'), required=True)
-    command = serializers.ListField(help_text=_('启动命令'), child=serializers.CharField(), required=False, default=list)
-    args = serializers.ListField(help_text=_('命令参数'), child=serializers.CharField(), required=False, default=list)
-    target_port = serializers.IntegerField(label=_('容器端口'), required=False)
-    # 在前端页面调整完成前，先保持默认值为 v1alpha1 以兼容现有逻辑
-    api_version = serializers.CharField(label=_('API版本'), required=False, default=ApiVersion.V1ALPHA1.value)
 
 
 class CreateCloudNativeAppSLZ(AppBasicInfoMixin):
     """创建云原生架构应用的表单"""
 
-    # [Deprecated] cloud_native_params is deprecated, use param manifest instead
-    cloud_native_params = CloudNativeParamsSLZ(label=_('云原生应用参数'), required=False)
+    source_config = ModuleSourceConfigSLZ(required=True, help_text=_('源码/镜像配置'))
+    bkapp_spec = BkAppSpecSLZ()
     advanced_options = AdvancedCreationParamsMixin(required=False)
 
-    source_config = ModuleSourceConfigSLZ(required=False, help_text=_('源码配置'))
-    image_credentials = ImageCredentialSLZ(required=False, help_text=_('镜像凭证信息'))
-    build_config = CreateModuleBuildConfigSLZ(required=False, help_text=_('构建配置'))
-    manifest = serializers.JSONField(required=False, help_text=_('云原生应用 manifest'))
-
     def validate(self, attrs):
-        super().validate(attrs)
+        attrs = super().validate(attrs)
 
-        # 兼容旧逻辑，支持仅传 cloud_native_params 即可创建应用
-        if attrs.get('cloud_native_params'):
-            return attrs
+        source_config = attrs['source_config']
+        build_config = attrs['bkapp_spec']['build_config']
 
-        source_cfg = attrs.get('source_config')
-        if not source_cfg:
-            raise ValidationError(_('需要指定 源码配置'))
+        validate_build_method(build_config.build_method, source_config['source_origin'])
 
-        build_config = attrs.get('build_config')
-        if not build_config:
-            raise ValidationError("missing build_config field")
+        if build_config.build_method == RuntimeType.CUSTOM_IMAGE and build_config['image'] != source_config.get(
+            'source_repo_url'
+        ):
+            raise ValidationError('image is not consistent with source_repo_url')
 
-        source_origin = source_cfg['source_origin']
-        validate_build_method(build_config.build_method, source_origin)
-
-        if manifest := attrs.get('manifest'):
-            # 检查 source_config 中 source_origin 类型必须为 CNATIVE_IMAGE
-            if source_origin != SourceOrigin.CNATIVE_IMAGE:
-                raise ValidationError(_('托管模式为仅镜像时，source_origin 必须为 CNATIVE_IMAGE'))
-
-            try:
-                bkapp_res = BkAppResource(**manifest)
-            except PDValidationError as e:
-                raise ValidationError(to_error_string(e))
-
-            if bkapp_res.apiVersion != ApiVersion.V1ALPHA2:
-                raise ValidationError(_('请使用 BkApp v1alpha2 版本'))
-
-            if bkapp_res.metadata.name != attrs["code"]:
-                raise ValidationError(_("Manifest 中定义的应用模型名称与应用ID不一致"))
-
-            if bkapp_res.spec.build is None or bkapp_res.spec.build.image != source_cfg['source_repo_url']:
-                raise ValidationError(_('Manifest 中定义的镜像信息与 source_repo_url 不一致'))
         return attrs

--- a/apiserver/paasng/paasng/platform/applications/serializers/cnative.py
+++ b/apiserver/paasng/paasng/platform/applications/serializers/cnative.py
@@ -40,9 +40,10 @@ class CreateCloudNativeAppSLZ(AppBasicInfoMixin):
 
         validate_build_method(build_config.build_method, source_config['source_origin'])
 
-        if build_config.build_method == RuntimeType.CUSTOM_IMAGE and build_config.image != source_config.get(
-            'source_repo_url'
+        if (
+            build_config.build_method == RuntimeType.CUSTOM_IMAGE
+            and build_config.image_repository != source_config.get('source_repo_url')
         ):
-            raise ValidationError('image is not consistent with source_repo_url')
+            raise ValidationError('image_repository is not consistent with source_repo_url')
 
         return attrs

--- a/apiserver/paasng/paasng/platform/applications/serializers/cnative.py
+++ b/apiserver/paasng/paasng/platform/applications/serializers/cnative.py
@@ -40,7 +40,7 @@ class CreateCloudNativeAppSLZ(AppBasicInfoMixin):
 
         validate_build_method(build_config.build_method, source_config['source_origin'])
 
-        if build_config.build_method == RuntimeType.CUSTOM_IMAGE and build_config['image'] != source_config.get(
+        if build_config.build_method == RuntimeType.CUSTOM_IMAGE and build_config.image != source_config.get(
             'source_repo_url'
         ):
             raise ValidationError('image is not consistent with source_repo_url')

--- a/apiserver/paasng/paasng/platform/applications/views.py
+++ b/apiserver/paasng/paasng/platform/applications/views.py
@@ -506,7 +506,7 @@ class ApplicationCreateViewSet(viewsets.ViewSet):
         module = create_default_module(application, **module_src_cfg)
 
         # 初始化应用镜像凭证信息
-        if image_credential := params['bkapp_spec']['build_config'].get('image_credential'):
+        if image_credential := params['bkapp_spec']['build_config'].image_credential:
             self._init_image_credential(application, image_credential)
 
         source_init_result = init_module_in_view(

--- a/apiserver/paasng/paasng/platform/applications/views.py
+++ b/apiserver/paasng/paasng/platform/applications/views.py
@@ -106,7 +106,6 @@ from paasng.platform.applications.utils import (
 )
 from paasng.platform.bk_lesscode.client import make_bk_lesscode_client
 from paasng.platform.bk_lesscode.exceptions import LessCodeApiError, LessCodeGatewayServiceError
-from paasng.platform.bkapp_model.services import initialize_simple
 from paasng.platform.declarative.exceptions import ControllerError, DescriptionValidationError
 from paasng.platform.mgrlegacy.constants import LegacyAppState
 from paasng.platform.modules.constants import ExposedURLType, ModuleName, SourceOrigin
@@ -470,21 +469,13 @@ class ApplicationCreateViewSet(viewsets.ViewSet):
     @transaction.atomic
     @swagger_auto_schema(request_body=slzs.CreateCloudNativeAppSLZ, tags=["创建应用"])
     def create_cloud_native(self, request):
-        """[API] 创建云原生架构应用
-
-        `cloud_native_params` 为 object 类型，各字段说明：
-
-        - `image`: string | 必填 | 容器镜像地址，
-        - `command`：array[string] | 选填 | 启动命令列表，例如 ["/bin/bash"]
-        - `args`：array[string] | 选填 | 命令参数列表，例如 ["-name", "demo"]
-        - `target_port`：integer | 选填 | 容器端口
-        """
+        """[API] 创建云原生架构应用"""
         if not AccountFeatureFlag.objects.has_feature(request.user, AFF.ALLOW_CREATE_CLOUD_NATIVE_APP):
             raise ValidationError(_('你无法创建云原生应用'))
 
         serializer = slzs.CreateCloudNativeAppSLZ(data=request.data)
         serializer.is_valid(raise_exception=True)
-        params = serializer.data
+        params = serializer.validated_data
 
         advanced_options = params.get('advanced_options', {})
         cluster_name = None
@@ -494,15 +485,15 @@ class ApplicationCreateViewSet(viewsets.ViewSet):
             cluster_name = advanced_options.get('cluster_name')
 
         module_src_cfg: Dict[str, Any] = {"source_origin": SourceOrigin.CNATIVE_IMAGE}
-        if source_config := params.get('source_config'):
-            source_origin = SourceOrigin(source_config['source_origin'])
-            self._ensure_source_origin_available(request.user, source_origin)
+        source_config = params["source_config"]
+        source_origin = SourceOrigin(source_config['source_origin'])
+        self._ensure_source_origin_available(request.user, source_origin)
 
-            module_src_cfg['source_origin'] = source_origin
-            # 如果指定模板信息，则需要提取并保存
-            if tmpl_name := source_config['source_init_template']:
-                tmpl = Template.objects.get(name=tmpl_name, type=TemplateType.NORMAL)
-                module_src_cfg.update({'language': tmpl.language, 'source_init_template': tmpl_name})
+        module_src_cfg['source_origin'] = source_origin
+        # 如果指定模板信息，则需要提取并保存
+        if tmpl_name := source_config['source_init_template']:
+            tmpl = Template.objects.get(name=tmpl_name, type=TemplateType.NORMAL)
+            module_src_cfg.update({'language': tmpl.language, 'source_init_template': tmpl_name})
 
         application = create_application(
             region=params["region"],
@@ -515,24 +506,18 @@ class ApplicationCreateViewSet(viewsets.ViewSet):
         module = create_default_module(application, **module_src_cfg)
 
         # 初始化应用镜像凭证信息
-        if image_credentials := params.get('image_credentials'):
+        if image_credentials := params['bkapp_spec'].get('image_credentials'):
             self._init_image_credentials(application, image_credentials)
 
-        source_init_result = None
-        if cloud_native_params := params.get('cloud_native_params'):
-            initialize_simple(module=module, cluster_name=cluster_name, **cloud_native_params)
-        else:
-            source_config = params["source_config"]
-            source_init_result = init_module_in_view(
-                module,
-                repo_type=source_config.get('source_control_type'),
-                repo_url=source_config.get('source_repo_url'),
-                repo_auth_info=source_config.get('source_repo_auth_info'),
-                source_dir=source_config.get('source_dir', ''),
-                cluster_name=cluster_name,
-                manifest=params.get('manifest'),
-                build_config=serializer.validated_data['build_config'],
-            ).source_init_result
+        source_init_result = init_module_in_view(
+            module,
+            repo_type=source_config.get('source_control_type'),
+            repo_url=source_config.get('source_repo_url'),
+            repo_auth_info=source_config.get('source_repo_auth_info'),
+            source_dir=source_config.get('source_dir', ''),
+            cluster_name=cluster_name,
+            bkapp_spec=params['bkapp_spec'],
+        ).source_init_result
 
         https_enabled = self._get_cluster_entrance_https_enabled(
             module.region, cluster_name, ExposedURLType(module.exposed_url_type)

--- a/apiserver/paasng/paasng/platform/applications/views.py
+++ b/apiserver/paasng/paasng/platform/applications/views.py
@@ -506,8 +506,8 @@ class ApplicationCreateViewSet(viewsets.ViewSet):
         module = create_default_module(application, **module_src_cfg)
 
         # 初始化应用镜像凭证信息
-        if image_credentials := params['bkapp_spec'].get('image_credentials'):
-            self._init_image_credentials(application, image_credentials)
+        if image_credential := params['bkapp_spec']['build_config'].get('image_credential'):
+            self._init_image_credential(application, image_credential)
 
         source_init_result = init_module_in_view(
             module,
@@ -682,9 +682,9 @@ class ApplicationCreateViewSet(viewsets.ViewSet):
             if not AccountFeatureFlag.objects.has_feature(user, AFF.ALLOW_CHOOSE_SOURCE_ORIGIN):
                 raise ValidationError(_('你无法使用非默认的源码来源'))
 
-    def _init_image_credentials(self, application: Application, image_credentials: Dict):
+    def _init_image_credential(self, application: Application, image_credential: Dict):
         try:
-            AppUserCredential.objects.create(application_id=application.id, **image_credentials)
+            AppUserCredential.objects.create(application_id=application.id, **image_credential)
         except DbIntegrityError:
             raise error_codes.CREATE_CREDENTIALS_FAILED.f(_("同名凭证已存在"))
 

--- a/apiserver/paasng/paasng/platform/bkapp_model/importer/serializers.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/importer/serializers.py
@@ -162,6 +162,7 @@ class ProcessInputSLZ(serializers.Serializer):
     args = serializers.ListField(child=serializers.CharField(), allow_null=True, default=None)
     autoscaling = AutoscalingSpecInputSLZ(allow_null=True, default=None)
 
+    # TODO 删除 v1alpha1 的配置
     # v1alpha1
     image = serializers.CharField(allow_null=True, default=None, allow_blank=True)
     imagePullPolicy = serializers.ChoiceField(choices=ImagePullPolicy.get_choices(), allow_null=True, default=None)

--- a/apiserver/paasng/paasng/platform/modules/entities.py
+++ b/apiserver/paasng/paasng/platform/modules/entities.py
@@ -36,6 +36,7 @@ class BuildConfig:
     build_method: RuntimeType
     tag_options: ImageTagOptions
 
+    image: Optional[str] = None
     dockerfile_path: Optional[str] = None
     docker_build_args: Optional[Dict] = None
 

--- a/apiserver/paasng/paasng/platform/modules/entities.py
+++ b/apiserver/paasng/paasng/platform/modules/entities.py
@@ -36,7 +36,9 @@ class BuildConfig:
     build_method: RuntimeType
     tag_options: ImageTagOptions
 
-    image: Optional[str] = None
+    image_repository: Optional[str] = None
+    image_credential: Optional[Dict] = None
+
     dockerfile_path: Optional[str] = None
     docker_build_args: Optional[Dict] = None
 

--- a/apiserver/paasng/paasng/platform/modules/serializers.py
+++ b/apiserver/paasng/paasng/platform/modules/serializers.py
@@ -306,11 +306,9 @@ class BkAppSpecSLZ(serializers.Serializer):
         build_config = attrs['build_config']
         if build_config.build_method == RuntimeType.CUSTOM_IMAGE:
             if not attrs.get('processes'):
-                raise ValidationError(
-                    'cloud-native application module from custom image require valid processes param'
-                )
+                raise ValidationError('image-based cloud-native application module requires a processes parameter')
             if not build_config.image:
-                raise ValidationError('cloud-native application module from custom image require valid image param')
+                raise ValidationError('image-based cloud-native application module requires a image parameter')
 
         return attrs
 
@@ -367,7 +365,7 @@ class CreateCNativeModuleSLZ(serializers.Serializer):
 
         validate_build_method(build_config.build_method, source_config['source_origin'])
 
-        if build_config.build_method == RuntimeType.CUSTOM_IMAGE and build_config['image'] != source_config.get(
+        if build_config.build_method == RuntimeType.CUSTOM_IMAGE and build_config.image != source_config.get(
             'source_repo_url'
         ):
             raise ValidationError('image is not consistent with source_repo_url')

--- a/apiserver/paasng/paasng/platform/modules/serializers.py
+++ b/apiserver/paasng/paasng/platform/modules/serializers.py
@@ -22,17 +22,13 @@ from typing import Dict, Optional
 import cattr
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import gettext_lazy as _
-from pydantic import ValidationError as PDValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from paas_wl.bk_app.cnative.specs.constants import ApiVersion
-from paas_wl.bk_app.cnative.specs.crd.bk_app import BkAppResource
-from paas_wl.bk_app.cnative.specs.models import to_error_string
-from paas_wl.core.resource import CNativeBkAppNameGenerator
 from paas_wl.infras.cluster.serializers import ClusterSLZ
 from paas_wl.infras.cluster.shim import EnvClusterService
 from paas_wl.workloads.images.serializers import ImageCredentialSLZ
+from paasng.platform.bkapp_model.importer.serializers import EnvOverlayInputSLZ, HooksInputSLZ, ProcessInputSLZ
 from paasng.platform.engine.constants import RuntimeType
 from paasng.platform.modules import entities
 from paasng.platform.modules.constants import DeployHookType, SourceOrigin
@@ -272,11 +268,11 @@ class ModuleSourceConfigSLZ(serializers.Serializer):
 
 
 class CreateModuleBuildConfigSLZ(serializers.Serializer):
-    """创建模块构建信息"""
+    """Serializer for create module build config"""
 
     build_method = serializers.ChoiceField(help_text="构建方式", choices=RuntimeType.get_choices(), required=True)
     tag_options = ImageTagOptionsSLZ(help_text="镜像 Tag 规则", required=False)
-
+    image = serializers.CharField(required=False)
     # docker build 相关字段
     dockerfile_path = serializers.CharField(help_text="Dockerfile 路径", allow_null=True, required=False)
     docker_build_args = serializers.DictField(
@@ -291,7 +287,32 @@ class CreateModuleBuildConfigSLZ(serializers.Serializer):
             tag_options=data.get("tag_options", ImageTagOptions()),
             dockerfile_path=data.get('dockerfile_path'),
             docker_build_args=data.get('docker_build_args'),
+            image=data.get('image'),
         )
+
+
+class BkAppSpecSLZ(serializers.Serializer):
+    """Serializer for create bkapp spec of module"""
+
+    build_config = CreateModuleBuildConfigSLZ(required=True, help_text=_('构建配置'))
+    image_credentials = ImageCredentialSLZ(required=False, help_text=_('镜像凭证信息'))
+    processes = serializers.ListField(child=ProcessInputSLZ(), required=False)
+    hooks = HooksInputSLZ(allow_null=True, default=None)
+    envOverlay = EnvOverlayInputSLZ(required=False)
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+
+        build_config = attrs['build_config']
+        if build_config.build_method == RuntimeType.CUSTOM_IMAGE:
+            if not attrs.get('processes'):
+                raise ValidationError(
+                    'cloud-native application module from custom image require valid processes param'
+                )
+            if not build_config.image:
+                raise ValidationError('cloud-native application module from custom image require valid image param')
+
+        return attrs
 
 
 class ModuleBuildConfigSLZ(serializers.Serializer):
@@ -338,36 +359,18 @@ class CreateCNativeModuleSLZ(serializers.Serializer):
 
     name = ModuleNameField()
     source_config = ModuleSourceConfigSLZ(required=True, help_text=_('源码配置'))
-    image_credentials = ImageCredentialSLZ(required=False, help_text=_('镜像凭证信息'))
-    build_config = CreateModuleBuildConfigSLZ(required=True, help_text=_('构建配置'))
-    manifest = serializers.JSONField(required=False, help_text=_('云原生应用 manifest'))
+    bkapp_spec = BkAppSpecSLZ()
 
     def validate(self, attrs):
-        application = self.context["application"]
-        source_cfg = attrs["source_config"]
+        source_config = attrs["source_config"]
+        build_config = attrs['bkapp_spec']['build_config']
 
-        validate_build_method(attrs["build_config"].build_method, source_cfg['source_origin'])
+        validate_build_method(build_config.build_method, source_config['source_origin'])
 
-        if manifest := attrs.get('manifest'):
-            # 检查 source_config 中 source_origin 类型必须为 CNATIVE_IMAGE
-            if source_cfg['source_origin'] != SourceOrigin.CNATIVE_IMAGE:
-                raise ValidationError(_('托管模式为仅镜像时，source_origin 必须为 CNATIVE_IMAGE'))
-
-            try:
-                bkapp_res = BkAppResource(**manifest)
-            except PDValidationError as e:
-                raise ValidationError(to_error_string(e))
-
-            if bkapp_res.apiVersion != ApiVersion.V1ALPHA2:
-                raise ValidationError(_('请使用 BkApp v1alpha2 以支持多模块'))
-
-            if bkapp_res.metadata.name != CNativeBkAppNameGenerator.make_name(
-                app_code=application.code, module_name=attrs["name"]
-            ):
-                raise ValidationError(_("Manifest 中定义的应用模型名称与模块信息不一致"))
-
-            if bkapp_res.spec.build is None or bkapp_res.spec.build.image != source_cfg['source_repo_url']:
-                raise ValidationError(_('Manifest 中定义的镜像信息与 source_repo_url 不一致'))
+        if build_config.build_method == RuntimeType.CUSTOM_IMAGE and build_config['image'] != source_config.get(
+            'source_repo_url'
+        ):
+            raise ValidationError('image is not consistent with source_repo_url')
 
         return attrs
 

--- a/apiserver/paasng/paasng/platform/modules/views.py
+++ b/apiserver/paasng/paasng/platform/modules/views.py
@@ -263,7 +263,7 @@ class ModuleViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
         self._ensure_source_origin_available(request.user, source_origin)
 
         # 初始化应用镜像凭证信息
-        if image_credential := data['bkapp_spec']['build_config'].get('image_credential'):
+        if image_credential := data['bkapp_spec']['build_config'].image_credential:
             self._init_image_credential(application, image_credential)
 
         module_src_cfg['source_origin'] = source_origin

--- a/apiserver/paasng/paasng/platform/modules/views.py
+++ b/apiserver/paasng/paasng/platform/modules/views.py
@@ -254,7 +254,7 @@ class ModuleViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
 
         serializer = CreateCNativeModuleSLZ(data=request.data, context={'application': application})
         serializer.is_valid(raise_exception=True)
-        data = serializer.data
+        data = serializer.validated_data
 
         module_src_cfg: Dict[str, Any] = {}
         source_config = data["source_config"]
@@ -263,7 +263,7 @@ class ModuleViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
         self._ensure_source_origin_available(request.user, source_origin)
 
         # 初始化应用镜像凭证信息
-        if image_credentials := data.get('image_credentials'):
+        if image_credentials := data['bkapp_spec'].get('image_credentials'):
             self._init_image_credentials(application, image_credentials)
 
         module_src_cfg['source_origin'] = source_origin
@@ -292,8 +292,7 @@ class ModuleViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
             repo_auth_info=source_config.get('source_repo_auth_info'),
             source_dir=source_config.get('source_dir', ''),
             cluster_name=cluster.name,
-            manifest=data.get('manifest'),
-            build_config=serializer.validated_data['build_config'],
+            bkapp_spec=data['bkapp_spec'],
         )
 
         return Response(

--- a/apiserver/paasng/paasng/platform/modules/views.py
+++ b/apiserver/paasng/paasng/platform/modules/views.py
@@ -263,8 +263,8 @@ class ModuleViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
         self._ensure_source_origin_available(request.user, source_origin)
 
         # 初始化应用镜像凭证信息
-        if image_credentials := data['bkapp_spec'].get('image_credentials'):
-            self._init_image_credentials(application, image_credentials)
+        if image_credential := data['bkapp_spec']['build_config'].get('image_credential'):
+            self._init_image_credential(application, image_credential)
 
         module_src_cfg['source_origin'] = source_origin
         # 如果指定模板信息，则需要提取并保存
@@ -317,9 +317,9 @@ class ModuleViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
             if not AccountFeatureFlag.objects.has_feature(user, AFF.ALLOW_CHOOSE_SOURCE_ORIGIN):
                 raise ValidationError(_('你无法使用非默认的源码来源'))
 
-    def _init_image_credentials(self, application: Application, image_credentials: Dict):
+    def _init_image_credential(self, application: Application, image_credential: Dict):
         try:
-            AppUserCredential.objects.create(application_id=application.id, **image_credentials)
+            AppUserCredential.objects.create(application_id=application.id, **image_credential)
         except DbIntegrityError:
             raise error_codes.CREATE_CREDENTIALS_FAILED.f(_("同名凭证已存在"))
 

--- a/apiserver/paasng/tests/api/test_applications.py
+++ b/apiserver/paasng/tests/api/test_applications.py
@@ -475,19 +475,18 @@ class TestCreateCloudNativeApp:
                 "region": settings.DEFAULT_REGION_NAME,
                 "code": f'uta-{random_suffix}',
                 "name": f'uta-{random_suffix}',
+                "bkapp_spec": {
+                    "build_config": {"build_method": "custom_image", "image": "strm/helloworld-http"},
+                    'processes': [{"name": "web", "replicas": 1}],
+                },
                 "source_config": {
                     "source_origin": SourceOrigin.CNATIVE_IMAGE,
                     "source_repo_url": "strm/helloworld-http",
                 },
-                "build_config": {"build_method": "custom_image"},
                 "manifest": {
-                    "apiVersion": "paas.bk.tencent.com/v1alpha2",
-                    "kind": "BkApp",
-                    "metadata": {"name": f"uta-{random_suffix}", "generation": 0, "annotations": {}},
                     "spec": {
                         "build": {"image": "strm/helloworld-http", "imagePullPolicy": "IfNotPresent"},
                         "processes": [{"name": "web", "replicas": 1}],
-                        "configuration": {"env": []},
                     },
                 },
             },
@@ -516,7 +515,7 @@ class TestCreateCloudNativeApp:
                 "region": settings.DEFAULT_REGION_NAME,
                 "code": f'uta-{random_suffix}',
                 "name": f'uta-{random_suffix}',
-                "build_config": {"build_method": "buildpack"},
+                "bkapp_spec": {"build_config": {"build_method": "buildpack"}},
                 "source_config": {
                     "source_init_template": settings.DUMMY_TEMPLATE_NAME,
                     "source_origin": SourceOrigin.AUTHORIZED_VCS,
@@ -540,7 +539,7 @@ class TestCreateCloudNativeApp:
                 "region": settings.DEFAULT_REGION_NAME,
                 "code": f'uta-{random_suffix}',
                 "name": f'uta-{random_suffix}',
-                "build_config": {"build_method": "dockerfile", "dockerfile_path": "Dockerfile"},
+                "bkapp_spec": {"build_config": {"build_method": "dockerfile", "dockerfile_path": "Dockerfile"}},
                 "source_config": {
                     "source_init_template": "docker",
                     "source_origin": SourceOrigin.AUTHORIZED_VCS,

--- a/apiserver/paasng/tests/api/test_applications.py
+++ b/apiserver/paasng/tests/api/test_applications.py
@@ -466,24 +466,6 @@ class TestCreateCloudNativeApp:
         settings.CLOUD_NATIVE_APP_DEFAULT_CLUSTER = CLUSTER_NAME_FOR_TESTING
         AccountFeatureFlag.objects.set_feature(bk_user, AFF.ALLOW_CREATE_CLOUD_NATIVE_APP, True)
 
-    def test_legacy(self, api_client):
-        """现存的云原生应用创建（cloud_native_params）"""
-
-        random_suffix = generate_random_string(length=6)
-        response = api_client.post(
-            '/api/bkapps/cloud-native/',
-            data={
-                'region': settings.DEFAULT_REGION_NAME,
-                'code': f'uta-{random_suffix}',
-                'name': f'uta-{random_suffix}',
-                'cloud_native_params': {
-                    'image': 'nginx:alpine',
-                },
-            },
-        )
-        assert response.status_code == 201, f'error: {response.json()["detail"]}'
-        assert response.json()['application']['type'] == 'cloud_native'
-
     def test_create_with_manifest(self, api_client):
         """托管方式：仅镜像（提供 manifest）"""
         random_suffix = generate_random_string(length=6)

--- a/apiserver/paasng/tests/api/test_applications.py
+++ b/apiserver/paasng/tests/api/test_applications.py
@@ -30,8 +30,11 @@ from paasng.misc.operations.constant import OperationType
 from paasng.misc.operations.models import Operation
 from paasng.platform.applications.constants import ApplicationRole
 from paasng.platform.applications.models import Application
+from paasng.platform.bkapp_model.models import ModuleProcessSpec
 from paasng.platform.declarative.handlers import get_desc_handler
 from paasng.platform.modules.constants import SourceOrigin
+from paasng.platform.modules.models import BuildConfig
+from paasng.platform.modules.models.module import Module
 from paasng.platform.sourcectl.connector import IntegratedSvnAppRepoConnector, SourceSyncResult
 from paasng.utils.basic import get_username_by_bkpaas_user_id
 from paasng.utils.error_codes import error_codes
@@ -466,9 +469,10 @@ class TestCreateCloudNativeApp:
         settings.CLOUD_NATIVE_APP_DEFAULT_CLUSTER = CLUSTER_NAME_FOR_TESTING
         AccountFeatureFlag.objects.set_feature(bk_user, AFF.ALLOW_CREATE_CLOUD_NATIVE_APP, True)
 
-    def test_create_with_manifest(self, api_client):
-        """托管方式：仅镜像（提供 manifest）"""
+    def test_create_with_image(self, api_client):
+        """托管方式：仅镜像"""
         random_suffix = generate_random_string(length=6)
+        image_repository = "strm/helloworld-http"
         response = api_client.post(
             "/api/bkapps/cloud-native/",
             data={
@@ -476,18 +480,21 @@ class TestCreateCloudNativeApp:
                 "code": f'uta-{random_suffix}',
                 "name": f'uta-{random_suffix}',
                 "bkapp_spec": {
-                    "build_config": {"build_method": "custom_image", "image": "strm/helloworld-http"},
-                    'processes': [{"name": "web", "replicas": 1}],
+                    "build_config": {"build_method": "custom_image", "image_repository": image_repository},
+                    'processes': [
+                        {
+                            "name": "web",
+                            "command": ["bash", "/app/start_web.sh"],
+                            "env_overlay": {
+                                'stag': {'environment_name': 'stag', 'target_replicas': 1, 'plan_name': '2C1G'},
+                                'prod': {'environment_name': 'prod', 'target_replicas': 2, 'plan_name': '2C1G'},
+                            },
+                        }
+                    ],
                 },
                 "source_config": {
                     "source_origin": SourceOrigin.CNATIVE_IMAGE,
-                    "source_repo_url": "strm/helloworld-http",
-                },
-                "manifest": {
-                    "spec": {
-                        "build": {"image": "strm/helloworld-http", "imagePullPolicy": "IfNotPresent"},
-                        "processes": [{"name": "web", "replicas": 1}],
-                    },
+                    "source_repo_url": image_repository,
                 },
             },
         )
@@ -496,6 +503,15 @@ class TestCreateCloudNativeApp:
         assert app_data['type'] == 'cloud_native'
         assert app_data['modules'][0]['web_config']['build_method'] == 'custom_image'
         assert app_data['modules'][0]['web_config']['artifact_type'] == 'none'
+
+        module = Module.objects.get(id=app_data['modules'][0]['id'])
+        cfg = BuildConfig.objects.get_or_create_by_module(module)
+        assert cfg.image_repository == image_repository
+        process_spec = ModuleProcessSpec.objects.get(module=module, name='web')
+        assert process_spec.image is None
+        assert process_spec.command == ["bash", "/app/start_web.sh"]
+        assert process_spec.get_target_replicas('stag') == 1
+        assert process_spec.get_target_replicas('prod') == 2
 
     @mock.patch('paasng.platform.modules.helpers.ModuleRuntimeBinder')
     @mock.patch('paasng.platform.engine.configurations.building.ModuleRuntimeManager')

--- a/apiserver/paasng/tests/api/test_applications.py
+++ b/apiserver/paasng/tests/api/test_applications.py
@@ -472,6 +472,7 @@ class TestCreateCloudNativeApp:
     def test_create_with_image(self, api_client):
         """托管方式：仅镜像"""
         random_suffix = generate_random_string(length=6)
+        image_credential_name = generate_random_string(length=6)
         image_repository = "strm/helloworld-http"
         response = api_client.post(
             "/api/bkapps/cloud-native/",
@@ -480,7 +481,11 @@ class TestCreateCloudNativeApp:
                 "code": f'uta-{random_suffix}',
                 "name": f'uta-{random_suffix}',
                 "bkapp_spec": {
-                    "build_config": {"build_method": "custom_image", "image_repository": image_repository},
+                    "build_config": {
+                        "build_method": "custom_image",
+                        "image_repository": image_repository,
+                        "image_credential": {"name": image_credential_name, "password": "123456", "username": "test"},
+                    },
                     'processes': [
                         {
                             "name": "web",
@@ -510,6 +515,7 @@ class TestCreateCloudNativeApp:
         process_spec = ModuleProcessSpec.objects.get(module=module, name='web')
         assert process_spec.image is None
         assert process_spec.command == ["bash", "/app/start_web.sh"]
+        assert process_spec.image_credential_name == image_credential_name
         assert process_spec.get_target_replicas('stag') == 1
         assert process_spec.get_target_replicas('prod') == 2
 

--- a/apiserver/paasng/tests/api/test_modules.py
+++ b/apiserver/paasng/tests/api/test_modules.py
@@ -154,6 +154,7 @@ class TestCreateCloudNativeModule:
         assert cfg.image_repository == image_repository
         process_spec = ModuleProcessSpec.objects.get(module=module, name='web')
         assert process_spec.image is None
+        assert process_spec.image_credential_name is None
         assert process_spec.command == ["bash", "/app/start_web.sh"]
         assert process_spec.get_target_replicas('stag') == 1
         assert process_spec.get_target_replicas('prod') == 2

--- a/apiserver/paasng/tests/api/test_modules.py
+++ b/apiserver/paasng/tests/api/test_modules.py
@@ -128,22 +128,9 @@ class TestCreateCloudNativeModule:
                     "source_origin": SourceOrigin.CNATIVE_IMAGE,
                     "source_repo_url": "strm/helloworld-http",
                 },
-                "build_config": {
-                    "build_method": "custom_image",
-                },
-                "manifest": {
-                    "apiVersion": "paas.bk.tencent.com/v1alpha2",
-                    "kind": "BkApp",
-                    "metadata": {
-                        "name": f"{bk_cnative_app.code}-m-uta-{random_suffix}",
-                        "generation": 0,
-                        "annotations": {},
-                    },
-                    "spec": {
-                        "build": {"image": "strm/helloworld-http", "imagePullPolicy": "IfNotPresent"},
-                        "processes": [{"name": "web", "replicas": 1}],
-                        "configuration": {"env": []},
-                    },
+                "bkapp_spec": {
+                    "build_config": {"build_method": "custom_image", "image": "strm/helloworld-http"},
+                    "processes": [{"name": "web", "replicas": 1}],
                 },
             },
         )
@@ -168,9 +155,7 @@ class TestCreateCloudNativeModule:
             f"/api/bkapps/cloud-native/{bk_cnative_app.code}/modules/",
             data={
                 "name": f'uta-{random_suffix}',
-                "build_config": {
-                    "build_method": "buildpack",
-                },
+                'bkapp_spec': {"build_config": {"build_method": "buildpack"}},
                 "source_config": {
                     "source_init_template": settings.DUMMY_TEMPLATE_NAME,
                     "source_origin": SourceOrigin.AUTHORIZED_VCS,
@@ -191,9 +176,11 @@ class TestCreateCloudNativeModule:
             f"/api/bkapps/cloud-native/{bk_cnative_app.code}/modules/",
             data={
                 "name": f'uta-{random_suffix}',
-                "build_config": {
-                    "build_method": "dockerfile",
-                    'dockerfile_path': 'Dockerfile',
+                "bkapp_spec": {
+                    "build_config": {
+                        "build_method": "dockerfile",
+                        'dockerfile_path': 'Dockerfile',
+                    }
                 },
                 "source_config": {
                     "source_init_template": "docker",


### PR DESCRIPTION
云原生应用/模块的创建接口调整：
- 去除依赖 BkApp 模型(版本)的 manifest 参数，由 bkapp_spec 替换 