### PR TITLE
fix: missing image_pull_policy from advanced_options when refactor bkapp_model

### DIFF
--- a/apiserver/paasng/paasng/platform/bkapp_model/manifest.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/manifest.py
@@ -384,13 +384,17 @@ def get_bkapp_resource(module: Module) -> BkAppResource:
 
 
 def get_bkapp_resource_for_deploy(
-    env: ModuleEnvironment, deploy_id: str, force_image: Optional[str] = None
+    env: ModuleEnvironment,
+    deploy_id: str,
+    force_image: Optional[str] = None,
+    image_pull_policy: Optional[str] = None,
 ) -> BkAppResource:
     """Get the BkApp manifest for deploy.
 
     :param env: The environment object.
     :param deploy_id: The ID of the AppModelDeploy object.
     :param force_image: If given, set the image of the application to this value.
+    :param image_pull_policy: If given, set the imagePullPolicy to this value.
     :returns: The BkApp resource that is ready for deploying.
     """
     model_res = get_bkapp_resource(env.module)
@@ -399,6 +403,11 @@ def get_bkapp_resource_for_deploy(
         if not model_res.spec.build:
             model_res.spec.build = BkAppBuildConfig()
         model_res.spec.build.image = force_image
+
+    if image_pull_policy:
+        if not model_res.spec.build:
+            model_res.spec.build = BkAppBuildConfig()
+        model_res.spec.build.imagePullPolicy = image_pull_policy
 
     # Apply other changes to the resource
     apply_env_annots(model_res, env, deploy_id=deploy_id)

--- a/apiserver/paasng/paasng/platform/engine/deploy/release/operator.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/release/operator.py
@@ -37,6 +37,7 @@ from paasng.platform.engine.constants import JobStatus
 from paasng.platform.engine.deploy.bg_wait.wait_bkapp import DeployStatusHandler, WaitAppModelReady
 from paasng.platform.engine.exceptions import StepNotInPresetListError
 from paasng.platform.engine.models import DeployPhaseTypes
+from paasng.platform.engine.models.deployment import Deployment
 from paasng.platform.engine.workflow import DeployStep
 
 logger = logging.getLogger(__name__)
@@ -117,10 +118,12 @@ def release_by_k8s_operator(
         raise
 
     try:
+        advanced_options = Deployment.objects.get(id=deployment_id).advanced_options if deployment_id else None
         bkapp_res = get_bkapp_resource_for_deploy(
             env,
             deploy_id=str(app_model_deploy.id),
             force_image=build.image if build else None,
+            image_pull_policy=advanced_options.image_pull_policy if advanced_options else None,
         )
 
         # 下发 k8s 资源前需要确保命名空间存在


### PR DESCRIPTION
修复因为重构 bkapp_model 导致丢失 image_pull_policy(advanced_options) 传入的问题