### PR TITLE
refactor: increase the default memory limit and remove the 2C cpu plan

### DIFF
--- a/apiserver/paasng/paas_wl/bk_app/cnative/specs/constants.py
+++ b/apiserver/paasng/paas_wl/bk_app/cnative/specs/constants.py
@@ -21,10 +21,10 @@ from django.utils.translation import gettext_lazy as _
 
 # Default resource limitations for each process
 DEFAULT_PROC_CPU = '4000m'
-DEFAULT_PROC_MEM = '768Mi'
+DEFAULT_PROC_MEM = '1024Mi'
 # Default resource request for each process
 DEFAULT_PROC_CPU_REQUEST = '200m'
-DEFAULT_PROC_MEM_REQUEST = '192Mi'
+DEFAULT_PROC_MEM_REQUEST = '256Mi'
 
 DEFAULT_PROCESS_NAME = 'web'
 

--- a/apiserver/paasng/paas_wl/bk_app/cnative/specs/constants.py
+++ b/apiserver/paasng/paas_wl/bk_app/cnative/specs/constants.py
@@ -20,11 +20,11 @@ from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
 
 # Default resource limitations for each process
-DEFAULT_PROC_CPU = '500m'
-DEFAULT_PROC_MEM = '256Mi'
+DEFAULT_PROC_CPU = '4000m'
+DEFAULT_PROC_MEM = '768Mi'
 # Default resource request for each process
-DEFAULT_PROC_CPU_REQUEST = '125m'
-DEFAULT_PROC_MEM_REQUEST = '126Mi'
+DEFAULT_PROC_CPU_REQUEST = '200m'
+DEFAULT_PROC_MEM_REQUEST = '192Mi'
 
 DEFAULT_PROCESS_NAME = 'web'
 
@@ -139,10 +139,6 @@ class ResQuotaPlan(str, StructuredEnum):
     """ResQuotaPlan is used to specify process resource quota"""
 
     P_DEFAULT = EnumField("default", label="default")
-    P_1C512M = EnumField("1C512M", label="1C512M")
-    P_2C1G = EnumField("2C1G", label="2C1G")
-    P_2C2G = EnumField("2C2G", label="2C2G")
-    P_2C4G = EnumField("2C4G", label="2C4G")
     P_4C1G = EnumField("4C1G", label="4C1G")
     P_4C2G = EnumField("4C2G", label="4C2G")
     P_4C4G = EnumField("4C4G", label="4C4G")

--- a/apiserver/paasng/paas_wl/bk_app/cnative/specs/procs/quota.py
+++ b/apiserver/paasng/paas_wl/bk_app/cnative/specs/procs/quota.py
@@ -39,28 +39,20 @@ PLAN_TO_LIMIT_QUOTA_MAP = {
         cpu=DEFAULT_PROC_CPU,
         memory=DEFAULT_PROC_MEM,
     ),
-    ResQuotaPlan.P_1C512M: ResourceQuota(cpu="1000m", memory="512Mi"),
-    ResQuotaPlan.P_2C1G: ResourceQuota(cpu="2000m", memory="1024Mi"),
-    ResQuotaPlan.P_2C2G: ResourceQuota(cpu="2000m", memory="2048Mi"),
-    ResQuotaPlan.P_2C4G: ResourceQuota(cpu="2000m", memory="4096Mi"),
     ResQuotaPlan.P_4C1G: ResourceQuota(cpu="4000m", memory="1024Mi"),
     ResQuotaPlan.P_4C2G: ResourceQuota(cpu="4000m", memory="2048Mi"),
     ResQuotaPlan.P_4C4G: ResourceQuota(cpu="4000m", memory="4096Mi"),
 }
 
 # 资源配额方案到资源请求的映射表
-# CPU REQUEST = CPU LIMIT / 4
-# MEMORY REQUEST = MEMORY LIMIT / 2
+# CPU REQUEST = 200m
+# MEMORY REQUEST 的计算规则: 当 Limits 大于等于 2048 Mi 时，值为 Limits 的 1/2; 当 Limits 小于 2048 Mi 时，值为 Limits 的 1/4
 PLAN_TO_REQUEST_QUOTA_MAP = {
     ResQuotaPlan.P_DEFAULT: ResourceQuota(
         cpu=DEFAULT_PROC_CPU_REQUEST,
         memory=DEFAULT_PROC_MEM_REQUEST,
     ),
-    ResQuotaPlan.P_1C512M: ResourceQuota(cpu="256m", memory="256Mi"),
-    ResQuotaPlan.P_2C1G: ResourceQuota(cpu="512m", memory="512Mi"),
-    ResQuotaPlan.P_2C2G: ResourceQuota(cpu="512m", memory="1024Mi"),
-    ResQuotaPlan.P_2C4G: ResourceQuota(cpu="512m", memory="2048Mi"),
-    ResQuotaPlan.P_4C1G: ResourceQuota(cpu="1000m", memory="512Mi"),
-    ResQuotaPlan.P_4C2G: ResourceQuota(cpu="1000m", memory="1024Mi"),
-    ResQuotaPlan.P_4C4G: ResourceQuota(cpu="1000m", memory="2048Mi"),
+    ResQuotaPlan.P_4C1G: ResourceQuota(cpu="200m", memory="256Mi"),
+    ResQuotaPlan.P_4C2G: ResourceQuota(cpu="200m", memory="1024Mi"),
+    ResQuotaPlan.P_4C4G: ResourceQuota(cpu="200m", memory="2048Mi"),
 }

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/importer/test_env_overlays.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/importer/test_env_overlays.py
@@ -44,7 +44,7 @@ class Test__import_env_overlays:
             proc_spec=proc_celery,
             environment_name="prod",
             target_replicas=1,
-            plan_name=ResQuotaPlan.P_2C2G,
+            plan_name=ResQuotaPlan.P_4C2G,
             autoscaling=False,
         )
 

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/test_manifest.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/test_manifest.py
@@ -238,7 +238,7 @@ class TestProcessesManifestConstructor:
                         "envName": "stag",
                         "process": "web",
                         # The plan name should have been transformed.
-                        "plan": "2C1G",
+                        "plan": "4C1G",
                     }
                 ],
             },

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/test_manifest.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/test_manifest.py
@@ -161,7 +161,7 @@ class TestProcessesManifestConstructor:
         "plan_name, expected",
         [
             ("", ResQuotaPlan.P_DEFAULT),
-            (settings.DEFAULT_PROC_SPEC_PLAN, ResQuotaPlan.P_4C1G),
+            (settings.DEFAULT_PROC_SPEC_PLAN, ResQuotaPlan.P_DEFAULT),
             (settings.PREMIUM_PROC_SPEC_PLAN, ResQuotaPlan.P_4C2G),
             # Memory 稀缺性比 CPU 要高, 转换时只关注 Memory
             (settings.ULTIMATE_PROC_SPEC_PLAN, ResQuotaPlan.P_4C4G),
@@ -238,7 +238,7 @@ class TestProcessesManifestConstructor:
                         "envName": "stag",
                         "process": "web",
                         # The plan name should have been transformed.
-                        "plan": "4C1G",
+                        "plan": "default",
                     }
                 ],
             },

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/test_manifest.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/test_manifest.py
@@ -161,11 +161,11 @@ class TestProcessesManifestConstructor:
         "plan_name, expected",
         [
             ("", ResQuotaPlan.P_DEFAULT),
-            (settings.DEFAULT_PROC_SPEC_PLAN, ResQuotaPlan.P_2C1G),
-            (settings.PREMIUM_PROC_SPEC_PLAN, ResQuotaPlan.P_2C2G),
+            (settings.DEFAULT_PROC_SPEC_PLAN, ResQuotaPlan.P_4C1G),
+            (settings.PREMIUM_PROC_SPEC_PLAN, ResQuotaPlan.P_4C2G),
             # Memory 稀缺性比 CPU 要高, 转换时只关注 Memory
-            (settings.ULTIMATE_PROC_SPEC_PLAN, ResQuotaPlan.P_2C4G),
-            (ResQuotaPlan.P_2C1G, ResQuotaPlan.P_2C1G),
+            (settings.ULTIMATE_PROC_SPEC_PLAN, ResQuotaPlan.P_4C4G),
+            (ResQuotaPlan.P_4C1G, ResQuotaPlan.P_4C1G),
         ],
     )
     def test_get_quota_plan(self, plan_name, expected):

--- a/operator/api/v1alpha1/bkapp_conversion_test.go
+++ b/operator/api/v1alpha1/bkapp_conversion_test.go
@@ -73,7 +73,7 @@ var _ = Describe("test conversion back and forth", func() {
 						{
 							EnvName: "stag",
 							Process: "web",
-							Plan:    paasv1alpha2.ResQuotaPlan2C1G,
+							Plan:    paasv1alpha2.ResQuotaPlan4C1G,
 						},
 					},
 					EnvVariables: []EnvVarOverlay{
@@ -177,7 +177,7 @@ var _ = Describe("test conversion back and forth", func() {
 						{
 							EnvName: "stag",
 							Process: "web",
-							Plan:    paasv1alpha2.ResQuotaPlan2C1G,
+							Plan:    paasv1alpha2.ResQuotaPlan4C1G,
 						},
 					},
 					EnvVariables: []paasv1alpha2.EnvVarOverlay{

--- a/operator/api/v1alpha2/bkapp_types.go
+++ b/operator/api/v1alpha2/bkapp_types.go
@@ -192,7 +192,7 @@ type Mount struct {
 type ResQuotaPlan string
 
 const (
-	// ResQuotaPlanDefault is default quota plan，means 2000m cpu & 768Mi memory
+	// ResQuotaPlanDefault is default quota plan，means 4000m cpu & 1024Mi memory
 	ResQuotaPlanDefault ResQuotaPlan = "default"
 
 	// ResQuotaPlan4C1G means 4 cpu & 1Gi memory

--- a/operator/api/v1alpha2/bkapp_types.go
+++ b/operator/api/v1alpha2/bkapp_types.go
@@ -192,20 +192,8 @@ type Mount struct {
 type ResQuotaPlan string
 
 const (
-	// ResQuotaPlanDefault is default quota plan，means 500m cpu & 256Mi memory
+	// ResQuotaPlanDefault is default quota plan，means 2000m cpu & 768Mi memory
 	ResQuotaPlanDefault ResQuotaPlan = "default"
-
-	// ResQuotaPlan1C512M means 1 cpu & 512Mi memory
-	ResQuotaPlan1C512M ResQuotaPlan = "1C512M"
-
-	// ResQuotaPlan2C1G means 2 cpu & 1Gi memory
-	ResQuotaPlan2C1G ResQuotaPlan = "2C1G"
-
-	// ResQuotaPlan2C2G means 2 cpu & 2Gi memory
-	ResQuotaPlan2C2G ResQuotaPlan = "2C2G"
-
-	// ResQuotaPlan2C4G means 2 cpu & 4Gi memory
-	ResQuotaPlan2C4G ResQuotaPlan = "2C4G"
 
 	// ResQuotaPlan4C1G means 4 cpu & 1Gi memory
 	ResQuotaPlan4C1G ResQuotaPlan = "4C1G"

--- a/operator/api/v1alpha2/bkapp_webhook_test.go
+++ b/operator/api/v1alpha2/bkapp_webhook_test.go
@@ -221,7 +221,7 @@ var _ = Describe("test webhook.Validator", func() {
 		It("resource quota plan unsupported", func() {
 			bkapp.Spec.Processes[0].ResQuotaPlan = "fake"
 			err := bkapp.ValidateCreate()
-			Expect(err.Error()).To(ContainSubstring("supported values: \"default\", \"1C512M\""))
+			Expect(err.Error()).To(ContainSubstring("supported values: \"default\", \"4C1G\""))
 		})
 	})
 
@@ -448,7 +448,7 @@ var _ = Describe("test webhook.Validator", func() {
 					{EnvName: "stag", Process: "web", Count: 1},
 				},
 				ResQuotas: []paasv1alpha2.ResQuotaOverlay{
-					{EnvName: "prod", Process: "web", Plan: paasv1alpha2.ResQuotaPlan2C1G},
+					{EnvName: "prod", Process: "web", Plan: paasv1alpha2.ResQuotaPlan4C1G},
 				},
 				EnvVariables: []paasv1alpha2.EnvVarOverlay{
 					{EnvName: "stag", Name: "foo", Value: "foo-value"},
@@ -492,14 +492,14 @@ var _ = Describe("test webhook.Validator", func() {
 		})
 		It("[resQuota] invalid envName", func() {
 			bkapp.Spec.EnvOverlay.ResQuotas = []paasv1alpha2.ResQuotaOverlay{
-				{EnvName: "invalid-env", Process: "web", Plan: paasv1alpha2.ResQuotaPlan2C1G},
+				{EnvName: "invalid-env", Process: "web", Plan: paasv1alpha2.ResQuotaPlan4C1G},
 			}
 			err := bkapp.ValidateCreate()
 			Expect(err.Error()).To(ContainSubstring("envName is invalid"))
 		})
 		It("[resQuota] invalid process name", func() {
 			bkapp.Spec.EnvOverlay.ResQuotas = []paasv1alpha2.ResQuotaOverlay{
-				{EnvName: "stag", Process: "invalid-proc", Plan: paasv1alpha2.ResQuotaPlan2C1G},
+				{EnvName: "stag", Process: "invalid-proc", Plan: paasv1alpha2.ResQuotaPlan4C1G},
 			}
 			err := bkapp.ValidateCreate()
 			Expect(err.Error()).To(ContainSubstring("process name is invalid"))
@@ -509,7 +509,7 @@ var _ = Describe("test webhook.Validator", func() {
 				{EnvName: "stag", Process: "web", Plan: "invalid-plan"},
 			}
 			err := bkapp.ValidateCreate()
-			Expect(err.Error()).To(ContainSubstring("supported values: \"default\", \"1C512M\""))
+			Expect(err.Error()).To(ContainSubstring("supported values: \"default\", \"4C1G\""))
 		})
 		It("[envVariables] invalid envName", func() {
 			bkapp.Spec.EnvOverlay.EnvVariables = []paasv1alpha2.EnvVarOverlay{

--- a/operator/api/v1alpha2/constants.go
+++ b/operator/api/v1alpha2/constants.go
@@ -124,10 +124,6 @@ var AllowedScalingPolicies = []ScalingPolicy{ScalingPolicyDefault}
 // AllowedResQuotaPlans 允许使用的资源配额方案
 var AllowedResQuotaPlans = []ResQuotaPlan{
 	ResQuotaPlanDefault,
-	ResQuotaPlan1C512M,
-	ResQuotaPlan2C1G,
-	ResQuotaPlan2C2G,
-	ResQuotaPlan2C4G,
 	ResQuotaPlan4C1G,
 	ResQuotaPlan4C2G,
 	ResQuotaPlan4C4G,

--- a/operator/pkg/config/config.go
+++ b/operator/pkg/config/config.go
@@ -49,7 +49,7 @@ func (d defaultConfig) GetProcDefaultCpuLimits() string {
 }
 
 func (d defaultConfig) GetProcDefaultMemLimits() string {
-	return "768Mi"
+	return "1Gi"
 }
 
 func (d defaultConfig) GetIngressClassName() string {

--- a/operator/pkg/config/config.go
+++ b/operator/pkg/config/config.go
@@ -45,11 +45,11 @@ func (d defaultConfig) GetProcMaxReplicas() int32 {
 }
 
 func (d defaultConfig) GetProcDefaultCpuLimits() string {
-	return "1"
+	return "4"
 }
 
 func (d defaultConfig) GetProcDefaultMemLimits() string {
-	return "1Gi"
+	return "768Mi"
 }
 
 func (d defaultConfig) GetIngressClassName() string {

--- a/operator/pkg/controllers/resources/deployment_test.go
+++ b/operator/pkg/controllers/resources/deployment_test.go
@@ -250,14 +250,14 @@ var _ = Describe("Test build deployments from BkApp", func() {
 
 			// Check resource requirements for "web"
 			cWebRes := GetWantedDeploys(bkapp)[0].Spec.Template.Spec.Containers[0].Resources
-			Expect(cWebRes.Requests.Cpu().String()).To(Equal("250m"))
+			Expect(cWebRes.Requests.Cpu().String()).To(Equal("200m"))
 			Expect(cWebRes.Limits.Cpu().String()).To(Equal("1"))
-			Expect(cWebRes.Requests.Memory().String()).To(Equal("512Mi"))
+			Expect(cWebRes.Requests.Memory().String()).To(Equal("256Mi"))
 			Expect(cWebRes.Limits.Memory().String()).To(Equal("1Gi"))
 
 			// Check resource requirements for "worker"
 			cWorkerRes := GetWantedDeploys(bkapp)[1].Spec.Template.Spec.Containers[0].Resources
-			Expect(cWorkerRes.Requests.Cpu().String()).To(Equal("500m"))
+			Expect(cWorkerRes.Requests.Cpu().String()).To(Equal("200m"))
 			Expect(cWorkerRes.Limits.Cpu().String()).To(Equal("2"))
 			Expect(cWorkerRes.Requests.Memory().String()).To(Equal("1Gi"))
 			Expect(cWorkerRes.Limits.Memory().String()).To(Equal("2Gi"))

--- a/operator/pkg/controllers/resources/env_overlay_test.go
+++ b/operator/pkg/controllers/resources/env_overlay_test.go
@@ -230,9 +230,9 @@ var _ = Describe("Environment overlay related functions", func() {
 		It("Get Default", func() {
 			resReq := NewProcResourcesGetter(bkapp).Default()
 			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("200m"))).To(BeTrue())
-			Expect(resReq.Requests.Memory().Equal(resource.MustParse("192Mi"))).To(BeTrue())
+			Expect(resReq.Requests.Memory().Equal(resource.MustParse("256Mi"))).To(BeTrue())
 			Expect(resReq.Limits.Cpu().Equal(resource.MustParse("4"))).To(BeTrue())
-			Expect(resReq.Limits.Memory().Equal(resource.MustParse("768Mi"))).To(BeTrue())
+			Expect(resReq.Limits.Memory().Equal(resource.MustParse("1024Mi"))).To(BeTrue())
 		})
 
 		It("Get Legacy", func() {
@@ -271,9 +271,9 @@ var _ = Describe("Environment overlay related functions", func() {
 
 			resReq, _ := getter.GetByProc("web")
 			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("200m"))).To(BeTrue())
-			Expect(resReq.Requests.Memory().Equal(resource.MustParse("192Mi"))).To(BeTrue())
+			Expect(resReq.Requests.Memory().Equal(resource.MustParse("256Mi"))).To(BeTrue())
 			Expect(resReq.Limits.Cpu().Equal(resource.MustParse("4"))).To(BeTrue())
-			Expect(resReq.Limits.Memory().Equal(resource.MustParse("768Mi"))).To(BeTrue())
+			Expect(resReq.Limits.Memory().Equal(resource.MustParse("1024Mi"))).To(BeTrue())
 
 			resReq, _ = getter.GetByProc("worker")
 			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("200m"))).To(BeTrue())

--- a/operator/pkg/controllers/resources/env_overlay_test.go
+++ b/operator/pkg/controllers/resources/env_overlay_test.go
@@ -229,10 +229,10 @@ var _ = Describe("Environment overlay related functions", func() {
 	Context("Test ProcResourcesGetter", func() {
 		It("Get Default", func() {
 			resReq := NewProcResourcesGetter(bkapp).Default()
-			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("250m"))).To(BeTrue())
-			Expect(resReq.Requests.Memory().Equal(resource.MustParse("512Mi"))).To(BeTrue())
-			Expect(resReq.Limits.Cpu().Equal(resource.MustParse("1"))).To(BeTrue())
-			Expect(resReq.Limits.Memory().Equal(resource.MustParse("1Gi"))).To(BeTrue())
+			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("200m"))).To(BeTrue())
+			Expect(resReq.Requests.Memory().Equal(resource.MustParse("192Mi"))).To(BeTrue())
+			Expect(resReq.Limits.Cpu().Equal(resource.MustParse("4"))).To(BeTrue())
+			Expect(resReq.Limits.Memory().Equal(resource.MustParse("768Mi"))).To(BeTrue())
 		})
 
 		It("Get Legacy", func() {
@@ -243,7 +243,7 @@ var _ = Describe("Environment overlay related functions", func() {
 			)
 			getter := NewProcResourcesGetter(bkapp)
 			resReq, _ := getter.GetByProc("web")
-			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("500m"))).To(BeTrue())
+			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("200m"))).To(BeTrue())
 			Expect(resReq.Requests.Memory().Equal(resource.MustParse("1Gi"))).To(BeTrue())
 			Expect(resReq.Limits.Cpu().Equal(resource.MustParse("2"))).To(BeTrue())
 			Expect(resReq.Limits.Memory().Equal(resource.MustParse("2Gi"))).To(BeTrue())
@@ -253,15 +253,15 @@ var _ = Describe("Environment overlay related functions", func() {
 			bkapp.SetAnnotations(map[string]string{paasv1alpha2.EnvironmentKey: "stag"})
 			bkapp.Spec.EnvOverlay = &paasv1alpha2.AppEnvOverlay{
 				ResQuotas: []paasv1alpha2.ResQuotaOverlay{
-					{EnvName: "stag", Process: "web", Plan: paasv1alpha2.ResQuotaPlan2C1G},
+					{EnvName: "stag", Process: "web", Plan: paasv1alpha2.ResQuotaPlan4C1G},
 				},
 			}
 			getter := NewProcResourcesGetter(bkapp)
 
 			resReq, _ := getter.GetByProc("web")
-			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("500m"))).To(BeTrue())
-			Expect(resReq.Requests.Memory().Equal(resource.MustParse("512Mi"))).To(BeTrue())
-			Expect(resReq.Limits.Cpu().Equal(resource.MustParse("2"))).To(BeTrue())
+			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("200m"))).To(BeTrue())
+			Expect(resReq.Requests.Memory().Equal(resource.MustParse("256Mi"))).To(BeTrue())
+			Expect(resReq.Limits.Cpu().Equal(resource.MustParse("4"))).To(BeTrue())
 			Expect(resReq.Limits.Memory().Equal(resource.MustParse("1Gi"))).To(BeTrue())
 		})
 
@@ -270,13 +270,13 @@ var _ = Describe("Environment overlay related functions", func() {
 			getter := NewProcResourcesGetter(bkapp)
 
 			resReq, _ := getter.GetByProc("web")
-			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("250m"))).To(BeTrue())
-			Expect(resReq.Requests.Memory().Equal(resource.MustParse("512Mi"))).To(BeTrue())
-			Expect(resReq.Limits.Cpu().Equal(resource.MustParse("1"))).To(BeTrue())
-			Expect(resReq.Limits.Memory().Equal(resource.MustParse("1Gi"))).To(BeTrue())
+			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("200m"))).To(BeTrue())
+			Expect(resReq.Requests.Memory().Equal(resource.MustParse("192Mi"))).To(BeTrue())
+			Expect(resReq.Limits.Cpu().Equal(resource.MustParse("4"))).To(BeTrue())
+			Expect(resReq.Limits.Memory().Equal(resource.MustParse("768Mi"))).To(BeTrue())
 
 			resReq, _ = getter.GetByProc("worker")
-			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("1"))).To(BeTrue())
+			Expect(resReq.Requests.Cpu().Equal(resource.MustParse("200m"))).To(BeTrue())
 			Expect(resReq.Requests.Memory().Equal(resource.MustParse("1Gi"))).To(BeTrue())
 			Expect(resReq.Limits.Cpu().Equal(resource.MustParse("4"))).To(BeTrue())
 			Expect(resReq.Limits.Memory().Equal(resource.MustParse("2Gi"))).To(BeTrue())


### PR DESCRIPTION
配额调整
- 调大了默认 limits 4C/768Mi, 去掉了 2C 套餐
-  mem requests 规则按照 Limit的 1/2 和 1/4, 小于 2048Mi 的按照 1/4 算