### PR TITLE
refactor: update condition AppProgressing & AppAvailable transition

### DIFF
--- a/operator/controllers/bkapp_controller_test.go
+++ b/operator/controllers/bkapp_controller_test.go
@@ -284,7 +284,8 @@ var _ = Describe("", func() {
 		}, timeout, interval).Should(BeTrue())
 
 		condAvailable = apimeta.FindStatusCondition(createdBkApp.Status.Conditions, paasv1alpha2.AppAvailable)
-		Expect(condAvailable.Status).To(Equal(metav1.ConditionUnknown))
+		// 上一个部署后, AppAvailable 的 status 是 True
+		Expect(condAvailable.Status).To(Equal(metav1.ConditionTrue))
 		Expect(podCounter()).To(Equal(2))
 
 		By("By update the pre-release-hook pod Status.Phase to Running to block the BkApp finalizer", func() {

--- a/operator/pkg/controllers/reconcilers/deploy_action.go
+++ b/operator/pkg/controllers/reconcilers/deploy_action.go
@@ -113,24 +113,20 @@ func (r *DeployActionReconciler) validateNoRunningHooks(ctx context.Context, bka
 func SetDefaultConditions(bkapp *paasv1alpha2.BkApp) {
 	status := &bkapp.Status
 
-	availableMessage := "rolling upgrade"
-	availableStatus := metav1.ConditionUnknown
 	latestAvailableCond := apimeta.FindStatusCondition(status.Conditions, paasv1alpha2.AppAvailable)
 	if latestAvailableCond == nil {
-		availableMessage = "First time deployment, service unavailable"
-		availableStatus = metav1.ConditionFalse
+		apimeta.SetStatusCondition(&status.Conditions, metav1.Condition{
+			Type:               paasv1alpha2.AppAvailable,
+			Status:             metav1.ConditionFalse,
+			Reason:             "NewDeploy",
+			Message:            "First time deployment, service unavailable",
+			ObservedGeneration: bkapp.Generation,
+		})
 	}
 
 	apimeta.SetStatusCondition(&status.Conditions, metav1.Condition{
-		Type:               paasv1alpha2.AppAvailable,
-		Status:             availableStatus,
-		Reason:             "NewDeploy",
-		Message:            availableMessage,
-		ObservedGeneration: bkapp.Generation,
-	})
-	apimeta.SetStatusCondition(&status.Conditions, metav1.Condition{
 		Type:               paasv1alpha2.AppProgressing,
-		Status:             metav1.ConditionTrue,
+		Status:             metav1.ConditionUnknown,
 		Reason:             "NewDeploy",
 		ObservedGeneration: bkapp.Generation,
 	})

--- a/operator/pkg/controllers/reconcilers/deployments.go
+++ b/operator/pkg/controllers/reconcilers/deployments.go
@@ -146,7 +146,7 @@ func (r *DeploymentReconciler) updateCondition(ctx context.Context, bkapp *paasv
 			Type:               paasv1alpha2.AppAvailable,
 			Status:             metav1.ConditionFalse,
 			Reason:             "Teardown",
-			Message:            "no running processes",
+			Message:            "No running processes",
 			ObservedGeneration: bkapp.Generation,
 		})
 		return nil
@@ -193,6 +193,7 @@ func (r *DeploymentReconciler) updateCondition(ctx context.Context, bkapp *paasv
 				Type:               paasv1alpha2.AppAvailable,
 				Status:             metav1.ConditionTrue,
 				Reason:             "AppAvailable",
+				Message:            "Rolling upgrade",
 				ObservedGeneration: bkapp.Generation,
 			})
 		} else {

--- a/operator/pkg/controllers/reconcilers/hooks.go
+++ b/operator/pkg/controllers/reconcilers/hooks.go
@@ -186,6 +186,15 @@ func (r *HookReconciler) UpdateStatus(
 	timeoutThreshold time.Duration,
 ) error {
 	bkapp.Status.SetHookStatus(*instance.Status)
+
+	hookCond := apimeta.FindStatusCondition(bkapp.Status.Conditions, paasv1alpha2.HooksFinished)
+	var observedGeneration int64
+	if hookCond != nil {
+		observedGeneration = hookCond.ObservedGeneration
+	} else {
+		observedGeneration = bkapp.Generation
+	}
+
 	switch {
 	case instance.Timeout(timeoutThreshold):
 		bkapp.Status.Phase = paasv1alpha2.AppFailed
@@ -197,15 +206,19 @@ func (r *HookReconciler) UpdateStatus(
 				"PreReleaseHook execute timeout, last message: %s",
 				instance.Status.Message,
 			),
-			ObservedGeneration: bkapp.Generation,
+			ObservedGeneration: observedGeneration,
 		})
+		r.updateAppProgressingStatus(bkapp, metav1.ConditionFalse)
+
 	case instance.Succeeded():
 		apimeta.SetStatusCondition(&bkapp.Status.Conditions, metav1.Condition{
 			Type:               paasv1alpha2.HooksFinished,
 			Status:             metav1.ConditionTrue,
 			Reason:             "Finished",
-			ObservedGeneration: bkapp.Generation,
+			ObservedGeneration: observedGeneration,
 		})
+		r.updateAppProgressingStatus(bkapp, metav1.ConditionTrue)
+
 	case instance.Failed():
 		bkapp.Status.Phase = paasv1alpha2.AppFailed
 		apimeta.SetStatusCondition(&bkapp.Status.Conditions, metav1.Condition{
@@ -213,10 +226,25 @@ func (r *HookReconciler) UpdateStatus(
 			Status:             metav1.ConditionFalse,
 			Reason:             "Failed",
 			Message:            fmt.Sprintf("PreReleaseHook fail to succeed: %s", instance.Status.Message),
+			ObservedGeneration: observedGeneration,
+		})
+		r.updateAppProgressingStatus(bkapp, metav1.ConditionFalse)
+	}
+
+	return nil
+}
+
+func (r *HookReconciler) updateAppProgressingStatus(bkapp *paasv1alpha2.BkApp, status metav1.ConditionStatus) {
+	// 新部署时, 根据钩子执行结果, 更新 AppProgressing 的状态
+	AppProgressingCond := apimeta.FindStatusCondition(bkapp.Status.Conditions, paasv1alpha2.AppProgressing)
+	if AppProgressingCond != nil && AppProgressingCond.Status == metav1.ConditionUnknown {
+		apimeta.SetStatusCondition(&bkapp.Status.Conditions, metav1.Condition{
+			Type:               paasv1alpha2.AppProgressing,
+			Status:             status,
+			Reason:             "NewDeploy",
 			ObservedGeneration: bkapp.Generation,
 		})
 	}
-	return nil
 }
 
 // CheckAndUpdatePreReleaseHookStatus 检查并更新 PreReleaseHook 执行状态

--- a/operator/pkg/controllers/reconcilers/hooks.go
+++ b/operator/pkg/controllers/reconcilers/hooks.go
@@ -93,13 +93,21 @@ func (r *HookReconciler) Reconcile(ctx context.Context, bkapp *paasv1alpha2.BkAp
 		return r.Result.End()
 	}
 
+	hookCond := apimeta.FindStatusCondition(bkapp.Status.Conditions, paasv1alpha2.HooksFinished)
+	var observedGeneration int64
+	if hookCond != nil {
+		observedGeneration = hookCond.ObservedGeneration
+	} else {
+		observedGeneration = bkapp.Generation
+	}
 	apimeta.SetStatusCondition(&bkapp.Status.Conditions, metav1.Condition{
 		Type:               paasv1alpha2.HooksFinished,
 		Status:             metav1.ConditionUnknown,
 		Reason:             "Disabled",
 		Message:            "Pre-Release-Hook feature not turned on",
-		ObservedGeneration: bkapp.Generation,
+		ObservedGeneration: observedGeneration,
 	})
+
 	return r.Result
 }
 

--- a/operator/pkg/controllers/reconcilers/hooks.go
+++ b/operator/pkg/controllers/reconcilers/hooks.go
@@ -107,6 +107,7 @@ func (r *HookReconciler) Reconcile(ctx context.Context, bkapp *paasv1alpha2.BkAp
 		Message:            "Pre-Release-Hook feature not turned on",
 		ObservedGeneration: observedGeneration,
 	})
+	r.updateAppProgressingStatus(bkapp, metav1.ConditionTrue)
 
 	return r.Result
 }


### PR DESCRIPTION
更新 AppProgressing 和 AppAvailable 的条件流转, 目的是和 Generation 保持版本一致