### PR TITLE
Fix: avoid rolling out deployments of all bkapps when releasing new version of operator

### DIFF
--- a/operator/api/v1alpha2/constants.go
+++ b/operator/api/v1alpha2/constants.go
@@ -94,8 +94,8 @@ const (
 	IngressClassAnnoKey = "kubernetes.io/ingress.class"
 	// DeploySkipUpdateAnnoKey 注解表示当前的进程 Deployment 资源应跳过更新
 	DeploySkipUpdateAnnoKey = "bkapp.paas.bk.tencent.com/deployment-skip-update"
-	// DeployContentHashAnnoKey 注解保存由 Operator 生成的配置内容哈希值
-	DeployContentHashAnnoKey = "bkapp.paas.bk.tencent.com/deployment-content-hash"
+	// LastSyncedSerializedBkAppAnnoKey 注解保存上一次用于同步 workloads 资源的序列化过的 BkApp 内容
+	LastSyncedSerializedBkAppAnnoKey = "bkapp.paas.bk.tencent.com/last-synced-serialized-bkapp"
 )
 
 const (

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/Tencent/bk-bcs/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler v0.0.0-20230419100919-e7fc943fe8ef
+	github.com/davecgh/go-spew v1.1.1
 	github.com/getsentry/sentry-go v0.15.0
 	github.com/google/uuid v1.3.0
 	github.com/iancoleman/strcase v0.2.0
@@ -14,6 +15,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.25.0
+	github.com/tidwall/sjson v1.2.5
 	golang.org/x/net v0.0.0-20221002022538-bcab6841153b
 	golang.org/x/time v0.0.0-20220922220347-f3bd1da661af
 	gopkg.in/inf.v0 v0.9.1
@@ -36,7 +38,6 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
@@ -64,6 +65,9 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/gjson v1.17.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -474,6 +474,16 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.17.0 h1:/Jocvlh98kcTfpN2+JzGQWQcqrPQwDrVEMApx/M5ZwM=
+github.com/tidwall/gjson v1.17.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/operator/pkg/controllers/reconcilers/deployments.go
+++ b/operator/pkg/controllers/reconcilers/deployments.go
@@ -20,13 +20,18 @@ package reconcilers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -50,43 +55,41 @@ type DeploymentReconciler struct {
 // Reconcile ...
 func (r *DeploymentReconciler) Reconcile(ctx context.Context, bkapp *paasv1alpha2.BkApp) Result {
 	log := logf.FromContext(ctx)
-
-	current, err := r.getCurrentState(ctx, bkapp)
+	deployList, err := r.getOldDeployments(ctx, bkapp)
 	if err != nil {
 		return r.Result.WithError(err)
 	}
-	expected := resources.GetWantedDeploys(bkapp)
-	if ok := svcdisc.NewWorkloadsMutator(r.Client, bkapp).ApplyToDeployments(ctx, expected); ok {
-		log.V(2).Info("Applied svc-discovery related changes to deployments.")
+
+	// Get deployments synced with the current bkapp, new deployment resource might be created and old deployments
+	// might be updated.
+	newDeployMap, err := r.getNewDeployments(ctx, bkapp, deployList)
+	if err != nil {
+		return r.Result.WithError(err)
 	}
 
-	outdated := FindExtraByName(current, expected)
-
-	if len(outdated) != 0 {
-		for _, deploy := range outdated {
-			if err = r.Client.Delete(ctx, deploy); err != nil {
-				return r.Result.WithError(err)
-			}
-		}
+	// Clean up the deployments which are not in the new deploys
+	newDeployNames := []string{}
+	for _, d := range newDeployMap {
+		newDeployNames = append(newDeployNames, d.Name)
 	}
-	for _, deploy := range expected {
-		if err = r.deploy(ctx, deploy); err != nil {
-			return r.Result.WithError(err)
-		}
+	if err = r.cleanUpDeployments(ctx, bkapp, deployList, newDeployNames); err != nil {
+		return r.Result.WithError(err)
 	}
 
+	// Modify conditions in status
 	if err = r.updateCondition(ctx, bkapp); err != nil {
 		return r.Result.WithError(err)
 	}
-	// deployment 未就绪, 下次调和循环重新更新状态
+	// The statuses of the deployments is not ready yet, reconcile later.
 	if bkapp.Status.Phase == paasv1alpha2.AppPending {
+		log.V(2).Info("bkapp is still pending, reconcile later.", "bkapp", bkapp.Name)
 		return r.Result.requeue(paasv1alpha2.DefaultRequeueAfter)
 	}
 	return r.Result
 }
 
-// 获取应用当前在集群中的状态
-func (r *DeploymentReconciler) getCurrentState(
+// get all deployment objects owned by the given bkapp
+func (r *DeploymentReconciler) getOldDeployments(
 	ctx context.Context,
 	bkapp *paasv1alpha2.BkApp,
 ) (result []*appsv1.Deployment, err error) {
@@ -101,41 +104,111 @@ func (r *DeploymentReconciler) getCurrentState(
 	return lo.ToSlicePtr(deployList.Items), nil
 }
 
-// 将给定的 deployment 发布至 k8s, 如果不存在则创建, 如果同名对象已存在且配置发生变化, 则更新
-func (r *DeploymentReconciler) deploy(ctx context.Context, deploy *appsv1.Deployment) error {
-	return UpsertObject(ctx, r.Client, deploy, r.updateHandler)
+// Get the deployments which match the given bkapp's specifications. Main behaviour:
+//
+// - Create new deployments if does not exist;
+// - Update existing deployments if the resource exists but don't match current bkapp;
+// - Use existing deployments if it match current bkapp.
+func (r *DeploymentReconciler) getNewDeployments(
+	ctx context.Context,
+	bkapp *paasv1alpha2.BkApp,
+	deployList []*appsv1.Deployment,
+) (results map[string]*appsv1.Deployment, err error) {
+	log := logf.FromContext(ctx)
+	results = make(map[string]*appsv1.Deployment)
+	existingNewDeployMap := r.findNewDeployments(ctx, bkapp, deployList)
+	for _, proc := range bkapp.Spec.Processes {
+		// Use existing deployment directly
+		if existingDeploy, exists := existingNewDeployMap[proc.Name]; exists {
+			results[proc.Name] = existingDeploy
+			continue
+		}
+
+		// The new deployment does not exist or has not been up to date, perform upsert
+		deployment, err := resources.BuildProcDeployment(bkapp, proc.Name)
+		if err != nil {
+			return nil, errors.Wrapf(err, "get new deployment error, build failed for %s:%s.", bkapp.Name, proc.Name)
+		}
+		// Apply service discovery related changes
+		if ok := svcdisc.NewWorkloadsMutator(r.Client, bkapp).ApplyToDeployment(ctx, deployment); ok {
+			log.V(2).Info("Applied svc-discovery related changes to deployments.")
+		}
+
+		if err = UpsertObject(ctx, r.Client, deployment, r.updateHandler); err != nil {
+			return nil, errors.Wrapf(err, "get new deployment error, upsert failed for %s:%s.", bkapp.Name, proc.Name)
+		}
+		results[proc.Name] = deployment
+	}
+	return results, nil
 }
 
-// updateHandler Deployment 更新策略: 除非在注解中指定了 `bkapp.paas.bk.tencent.com/deployment-skip-update`
-// （执行测试代码时会用到）, 或配置内容没有任何变化，否则总是更新
-func (r *DeploymentReconciler) updateHandler(
+// Find deployments which match the given bkapp's specifications, accept a list fo deployment objects,
+// return {process name: *deployment}.
+func (r *DeploymentReconciler) findNewDeployments(
 	ctx context.Context,
-	cli client.Client,
-	current *appsv1.Deployment,
-	want *appsv1.Deployment,
-) error {
+	bkapp *paasv1alpha2.BkApp,
+	deployList []*appsv1.Deployment,
+) map[string]*appsv1.Deployment {
 	log := logf.FromContext(ctx)
-	if current.Annotations[paasv1alpha2.DeploySkipUpdateAnnoKey] == "true" {
-		return nil
-	}
-	// Skip update if the content of deployment is not changed, unnecessary updates will trigger
-	// the reconcile loop of the BkApp again and result infinite loops.
-	if want.Annotations[paasv1alpha2.DeployContentHashAnnoKey] == current.Annotations[paasv1alpha2.DeployContentHashAnnoKey] {
-		log.V(2).Info("The content of deployment is not changed, skip update.")
-		return nil
-	}
+	results := make(map[string]*appsv1.Deployment)
+	for _, d := range deployList {
+		// Ignore deployment which does not contain the serialized bkapp in annotation, which means the object was
+		// created by legacy controller.
+		serializedBkApp, exists := d.Annotations[paasv1alpha2.LastSyncedSerializedBkAppAnnoKey]
+		if !exists {
+			log.V(2).Info("Deployment does not contain the serialized bkapp in annots.", "name", d.Name)
+			continue
+		}
+		// Decode the serialized BkApp into object
+		// TODO: Handle changes across different api versions which introduces backward-incompatible schema changes.
+		// In that case, the "converter" might be needed.
+		var syncedBkApp paasv1alpha2.BkApp
+		if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), []byte(serializedBkApp), &syncedBkApp); err != nil {
+			log.Error(err, "Unmarshal serialized bkapp failed.", "name", d.Name)
+			continue
+		}
 
-	if err := cli.Update(ctx, want); err != nil {
-		return errors.Wrapf(
-			err, "failed to update %s(%s)", want.GetObjectKind().GroupVersionKind().String(), want.GetName(),
-		)
+		givenBkApp := bkapp.DeepCopy()
+		// If the deployment ID has been changed, always treat current deployment as outdated.
+		if givenBkApp.Annotations[paasv1alpha2.DeployIDAnnoKey] != syncedBkApp.Annotations[paasv1alpha2.DeployIDAnnoKey] {
+			log.V(2).Info("Deploy ID changed, current deployment is outdated.", "name", d.Name)
+			continue
+		}
+
+		// Remove unrelated content before comparing
+		delete(givenBkApp.Annotations, paasv1alpha2.DeployIDAnnoKey)
+		delete(syncedBkApp.Annotations, paasv1alpha2.DeployIDAnnoKey)
+		if apiequality.Semantic.DeepEqual(givenBkApp.Spec, syncedBkApp.Spec) &&
+			apiequality.Semantic.DeepEqual(givenBkApp.Annotations, syncedBkApp.Annotations) {
+			procName := d.Labels[paasv1alpha2.ProcessNameKey]
+			results[procName] = d
+		}
+	}
+	return results
+}
+
+// Clean up deployments which are not needed anymore. Args:
+// - deployList: A list of deployment resources.
+// - newDeployNames: The names of deployment that are synced with the current bkapp.
+func (r *DeploymentReconciler) cleanUpDeployments(ctx context.Context,
+	bkapp *paasv1alpha2.BkApp,
+	deployList []*appsv1.Deployment,
+	newDeployNames []string,
+) error {
+	for _, d := range deployList {
+		if lo.Contains(newDeployNames, d.Name) {
+			continue
+		}
+		if err := r.Client.Delete(ctx, d); err != nil {
+			return errors.Wrapf(err, "error cleaning up deployments")
+		}
 	}
 	return nil
 }
 
 // update condition `AppAvailable`
 func (r *DeploymentReconciler) updateCondition(ctx context.Context, bkapp *paasv1alpha2.BkApp) error {
-	current, err := r.getCurrentState(ctx, bkapp)
+	current, err := r.getOldDeployments(ctx, bkapp)
 	if err != nil {
 		return err
 	}
@@ -208,6 +281,52 @@ func (r *DeploymentReconciler) updateCondition(ctx context.Context, bkapp *paasv
 				ObservedGeneration: bkapp.Generation,
 			})
 		}
+	}
+	return nil
+}
+
+// The handler for updating a deployment resource.
+func (r *DeploymentReconciler) updateHandler(
+	ctx context.Context,
+	cli client.Client,
+	current *appsv1.Deployment,
+	want *appsv1.Deployment,
+) error {
+	// Respect an annotation to skip update, useful for testing
+	if current.Annotations[paasv1alpha2.DeploySkipUpdateAnnoKey] == "true" {
+		return nil
+	}
+
+	// Only patch the serialized bkapp in annotations to avoid unnecessary updates, this happens when we upgrade
+	// the operator from an older version which does not write "last-synced-serialized-bkapp" annotation.
+	//
+	// WARNING: After the patch successfully applied, updates on the deployment will be skipped until the
+	// bkapp resource spec from the input has been changed.
+	_, currentHasBkappAnnot := current.Annotations[paasv1alpha2.LastSyncedSerializedBkAppAnnoKey]
+	if !currentHasBkappAnnot {
+		patchBody, _ := json.Marshal(map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]string{
+					paasv1alpha2.LastSyncedSerializedBkAppAnnoKey: want.Annotations[paasv1alpha2.LastSyncedSerializedBkAppAnnoKey],
+				},
+			},
+		})
+		if err := cli.Patch(ctx, current, client.RawPatch(types.MergePatchType, patchBody)); err != nil {
+			return errors.Wrapf(
+				err,
+				"patch serialized bkapp annotation for %s(%s) error.",
+				want.GetObjectKind().GroupVersionKind().String(),
+				want.GetName(),
+			)
+		}
+		return nil
+	}
+
+	// Perform the resource update
+	if err := cli.Update(ctx, want); err != nil {
+		return errors.Wrapf(
+			err, "failed to update %s(%s)", want.GetObjectKind().GroupVersionKind().String(), want.GetName(),
+		)
 	}
 	return nil
 }

--- a/operator/pkg/controllers/reconcilers/deployments_test.go
+++ b/operator/pkg/controllers/reconcilers/deployments_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Test DeploymentReconciler", func() {
 	Context("test get old deployments", func() {
 		It("no deployment", func() {
 			r := NewDeploymentReconciler(builder.Build())
-			deployList, err := r.getOldDeployments(context.Background(), bkapp)
+			deployList, err := r.getCurrentDeployments(context.Background(), bkapp)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(deployList)).To(Equal(0))
 		})
@@ -152,7 +152,7 @@ var _ = Describe("Test DeploymentReconciler", func() {
 		It("one deployment", func() {
 			client := builder.WithObjects(&fakeDeploy).Build()
 			r := NewDeploymentReconciler(client)
-			deployList, err := r.getOldDeployments(context.Background(), bkapp)
+			deployList, err := r.getCurrentDeployments(context.Background(), bkapp)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(deployList)).To(Equal(1))
 		})
@@ -171,7 +171,7 @@ var _ = Describe("Test DeploymentReconciler", func() {
 
 		// A shortcut function to get the old deployments
 		oldDeployments := func() []*appsv1.Deployment {
-			deployList, _ := r.getOldDeployments(ctx, bkapp)
+			deployList, _ := r.getCurrentDeployments(ctx, bkapp)
 			return deployList
 		}
 

--- a/operator/pkg/controllers/reconcilers/utils_test.go
+++ b/operator/pkg/controllers/reconcilers/utils_test.go
@@ -104,7 +104,10 @@ var _ = Describe("Test utils", func() {
 		b := fakeDeploy.DeepCopy()
 		b.Name = names.Deployment(bkapp, "web")
 		current := []*appsv1.Deployment{&a, b}
-		want := resources.GetWantedDeploys(bkapp)
+
+		// Wanted resource list
+		webDeploy, _ := resources.BuildProcDeployment(bkapp, "web")
+		want := []*appsv1.Deployment{webDeploy}
 
 		outdated := FindExtraByName(current, want)
 		Expect(len(outdated)).To(Equal(1))

--- a/operator/pkg/controllers/resources/deployment.go
+++ b/operator/pkg/controllers/resources/deployment.go
@@ -20,22 +20,22 @@ package resources
 
 import (
 	"fmt"
-	"hash/fnv"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/samber/lo"
+	"github.com/tidwall/sjson"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/rand"
-
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	paasv1alpha2 "bk.tencent.com/paas-app-operator/api/v1alpha2"
 	"bk.tencent.com/paas-app-operator/pkg/controllers/resources/labels"
 	"bk.tencent.com/paas-app-operator/pkg/controllers/resources/names"
-	"bk.tencent.com/paas-app-operator/pkg/utils/hash"
 	"bk.tencent.com/paas-app-operator/pkg/utils/kubetypes"
 )
 
@@ -53,89 +53,101 @@ const (
 // log is for logging in this package.
 var log = logf.Log.WithName("controllers-resources")
 
-// GetWantedDeploys 根据应用生成对应的 Deployment 配置列表
-func GetWantedDeploys(app *paasv1alpha2.BkApp) []*appsv1.Deployment {
+// BuildProcDeployment build a deployment resource according to a bkapp's process declaration.
+func BuildProcDeployment(app *paasv1alpha2.BkApp, procName string) (*appsv1.Deployment, error) {
 	deployID := app.Status.DeployId
 	if deployID == "" {
 		deployID = DefaultDeployID
 	}
 
-	annotations := map[string]string{paasv1alpha2.DeployIDAnnoKey: deployID}
+	// Prepare data
 	envs := GetAppEnvs(app)
 	volMountMap := GetVolumeMountMap(app)
 	replicasGetter := NewReplicasGetter(app)
-	deployList := []*appsv1.Deployment{}
 	useCNB, _ := strconv.ParseBool(app.Annotations[paasv1alpha2.UseCNBAnnoKey])
-	for _, proc := range app.Spec.Processes {
-		selector := labels.PodSelector(app, proc.Name)
-		objLabels := labels.Deployment(app, proc.Name)
 
-		// TODO: Add error handling
-		image, pullPolicy, err := paasv1alpha2.NewProcImageGetter(app).Get(proc.Name)
-		if err != nil {
-			log.Info("Failed to get image for process %s: %v, use default values.", proc.Name, err)
-			image = DefaultImage
-			pullPolicy = corev1.PullIfNotPresent
-		}
-
-		resGetter := NewProcResourcesGetter(app)
-		resReq, err := resGetter.GetByProc(proc.Name)
-		if err != nil {
-			log.Info("Failed to get resources for process %s: %v, use default values.", proc.Name, err)
-			resReq = resGetter.Default()
-		}
-
-		deployment := &appsv1.Deployment{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "apps/v1",
-				Kind:       "Deployment",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        names.Deployment(app, proc.Name),
-				Namespace:   app.Namespace,
-				Labels:      objLabels,
-				Annotations: annotations,
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(app, schema.GroupVersionKind{
-						Group:   paasv1alpha2.GroupVersion.Group,
-						Version: paasv1alpha2.GroupVersion.Version,
-						Kind:    paasv1alpha2.KindBkApp,
-					}),
-				},
-			},
-			Spec: appsv1.DeploymentSpec{
-				Selector:             &metav1.LabelSelector{MatchLabels: selector},
-				RevisionHistoryLimit: lo.ToPtr(DeployRevisionHistoryLimit),
-				Replicas:             replicasGetter.GetByProc(proc.Name),
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels:      objLabels,
-						Annotations: map[string]string{paasv1alpha2.DeployIDAnnoKey: deployID},
-					},
-					Spec: corev1.PodSpec{
-						DNSConfig:        buildDNSConfig(app),
-						HostAliases:      buildHostAliases(app),
-						Containers:       buildContainers(proc, envs, image, pullPolicy, resReq, useCNB),
-						ImagePullSecrets: buildImagePullSecrets(app),
-						// 不默认向 Pod 中挂载 ServiceAccount Token
-						AutomountServiceAccountToken: lo.ToPtr(false),
-					},
-				},
-			},
-		}
-
-		for _, mount := range volMountMap {
-			err = mount.ApplyToDeployment(deployment, mount.Name, mount.MountPath)
-			if err != nil {
-				log.Error(err, "Failed to inject mounts info to process", proc.Name)
-			}
-		}
-
-		// Calculate a hash value for the deployment and set it as the annotation
-		deployment.Annotations[paasv1alpha2.DeployContentHashAnnoKey] = ComputeDeploymentHash(deployment)
-		deployList = append(deployList, deployment)
+	// Find the process spec object
+	proc, found := lo.Find(app.Spec.Processes, func(p paasv1alpha2.Process) bool { return p.Name == procName })
+	if !found {
+		return nil, fmt.Errorf("process %s not found", procName)
 	}
-	return deployList
+
+	// Start to build the deployment resource and return
+	selector := labels.PodSelector(app, proc.Name)
+	objLabels := labels.Deployment(app, proc.Name)
+
+	// TODO: Add error handling
+	image, pullPolicy, err := paasv1alpha2.NewProcImageGetter(app).Get(proc.Name)
+	if err != nil {
+		log.Info("Failed to get image for process %s: %v, use default values.", proc.Name, err)
+		image = DefaultImage
+		pullPolicy = corev1.PullIfNotPresent
+	}
+
+	// Get resource requirements
+	resGetter := NewProcResourcesGetter(app)
+	resReq, err := resGetter.GetByProc(proc.Name)
+	if err != nil {
+		log.Info("Failed to get resources for process %s: %v, use default values.", proc.Name, err)
+		resReq = resGetter.Default()
+	}
+
+	// Build annotations
+	bkAppJson, err := getSerializedBkApp(app)
+	if err != err {
+		return nil, errors.Wrapf(err, "serialize bkapp %s error", app.Name)
+	}
+	annotations := map[string]string{
+		paasv1alpha2.DeployIDAnnoKey:                  deployID,
+		paasv1alpha2.LastSyncedSerializedBkAppAnnoKey: string(bkAppJson),
+	}
+
+	deployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        names.Deployment(app, proc.Name),
+			Namespace:   app.Namespace,
+			Labels:      objLabels,
+			Annotations: annotations,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(app, schema.GroupVersionKind{
+					Group:   paasv1alpha2.GroupVersion.Group,
+					Version: paasv1alpha2.GroupVersion.Version,
+					Kind:    paasv1alpha2.KindBkApp,
+				}),
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector:             &metav1.LabelSelector{MatchLabels: selector},
+			RevisionHistoryLimit: lo.ToPtr(DeployRevisionHistoryLimit),
+			Replicas:             replicasGetter.GetByProc(proc.Name),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      objLabels,
+					Annotations: map[string]string{paasv1alpha2.DeployIDAnnoKey: deployID},
+				},
+				Spec: corev1.PodSpec{
+					DNSConfig:        buildDNSConfig(app),
+					HostAliases:      buildHostAliases(app),
+					Containers:       buildContainers(proc, envs, image, pullPolicy, resReq, useCNB),
+					ImagePullSecrets: buildImagePullSecrets(app),
+					// 不默认向 Pod 中挂载 ServiceAccount Token
+					AutomountServiceAccountToken: lo.ToPtr(false),
+				},
+			},
+		},
+	}
+
+	for _, mount := range volMountMap {
+		err = mount.ApplyToDeployment(deployment, mount.Name, mount.MountPath)
+		if err != nil {
+			log.Error(err, "Failed to inject mounts info to process", proc.Name)
+		}
+	}
+	return deployment, nil
 }
 
 // buildContainers 根据配置生产对应容器配置列表（目前设计单个 proc 只会有单个容器）
@@ -222,9 +234,15 @@ func buildHostAliases(app *paasv1alpha2.BkApp) (results []corev1.HostAlias) {
 	return nil
 }
 
-// ComputeDeploymentHash computes the hash value for the deployment object
-func ComputeDeploymentHash(obj *appsv1.Deployment) string {
-	deployHasher := fnv.New32a()
-	hash.DeepHashObject(deployHasher, obj)
-	return rand.SafeEncodeString(fmt.Sprint(deployHasher.Sum32()))
+// Get the serialized bkapp object, use JSON format, some fields such as status are removed.
+func getSerializedBkApp(bkapp *paasv1alpha2.BkApp) (string, error) {
+	bkAppJson, err := kuberuntime.Encode(unstructured.UnstructuredJSONScheme, bkapp)
+	if err != nil {
+		return "", err
+	}
+
+	// Remove status field because it's not part of the specification
+	data := string(bkAppJson)
+	data, _ = sjson.Delete(data, "status")
+	return data, nil
 }

--- a/operator/pkg/controllers/resources/deployment.go
+++ b/operator/pkg/controllers/resources/deployment.go
@@ -241,8 +241,9 @@ func getSerializedBkApp(bkapp *paasv1alpha2.BkApp) (string, error) {
 		return "", err
 	}
 
-	// Remove status field because it's not part of the specification
+	// Remove some field because it's not part of the specification
 	data := string(bkAppJson)
 	data, _ = sjson.Delete(data, "status")
+	data, _ = sjson.Delete(data, "metadata.managedFields")
 	return data, nil
 }

--- a/operator/pkg/controllers/svcdisc/configmap.go
+++ b/operator/pkg/controllers/svcdisc/configmap.go
@@ -50,10 +50,10 @@ type WorkloadsMutator struct {
 	bkapp  *paasv1alpha2.BkApp
 }
 
-// ApplyToDeployments mutates the given deployment, it try to inject service discovery information
+// ApplyToDeployment mutates the given deployment, it try to inject service discovery information
 // to the env variables and volumes of the deployment, it mutate the deployments in-place.
 // return whether the mutation is performed.
-func (w *WorkloadsMutator) ApplyToDeployments(ctx context.Context, deploys []*appsv1.Deployment) bool {
+func (w *WorkloadsMutator) ApplyToDeployment(ctx context.Context, d *appsv1.Deployment) bool {
 	log := logf.FromContext(ctx)
 
 	if w.bkapp.Spec.SvcDiscovery == nil {
@@ -70,19 +70,17 @@ func (w *WorkloadsMutator) ApplyToDeployments(ctx context.Context, deploys []*ap
 		return false
 	}
 
-	for _, d := range deploys {
-		for i, container := range d.Spec.Template.Spec.Containers {
-			// Use the index to modify the container structure in-place
-			d.Spec.Template.Spec.Containers[i].Env = append(container.Env, v1.EnvVar{
-				Name: EnvKeyBkSaaS,
-				ValueFrom: &v1.EnvVarSource{
-					ConfigMapKeyRef: &v1.ConfigMapKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{Name: w.configMapResourceName()},
-						Key:                  DataKeyBkSaaS,
-					},
+	for i, container := range d.Spec.Template.Spec.Containers {
+		// Use the index to modify the container structure in-place
+		d.Spec.Template.Spec.Containers[i].Env = append(container.Env, v1.EnvVar{
+			Name: EnvKeyBkSaaS,
+			ValueFrom: &v1.EnvVarSource{
+				ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: w.configMapResourceName()},
+					Key:                  DataKeyBkSaaS,
 				},
-			})
-		}
+			},
+		})
 	}
 	return true
 }

--- a/operator/pkg/controllers/svcdisc/configmap_test.go
+++ b/operator/pkg/controllers/svcdisc/configmap_test.go
@@ -67,13 +67,13 @@ var _ = Describe("Test configmap related functions", func() {
 			builder.WithScheme(scheme)
 		})
 
-		Context("test ApplyToDeployments", func() {
-			var deploys []*appsv1.Deployment
+		Context("test ApplyToDeployment", func() {
+			var deploy *appsv1.Deployment
 			var configmap *v1.ConfigMap
 
 			BeforeEach(func() {
 				// An empty deployment resource
-				deploy := appsv1.Deployment{
+				deploy = &appsv1.Deployment{
 					TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      names.Deployment(bkapp, "foo"),
@@ -88,7 +88,6 @@ var _ = Describe("Test configmap related functions", func() {
 						},
 					},
 				}
-				deploys = []*appsv1.Deployment{&deploy}
 
 				configmap = &v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: bkapp.Namespace, Name: "svc-disc-results-" + bkapp.Name},
@@ -99,7 +98,7 @@ var _ = Describe("Test configmap related functions", func() {
 			})
 
 			It("No configmap", func() {
-				ret := NewWorkloadsMutator(builder.Build(), bkapp).ApplyToDeployments(ctx, deploys)
+				ret := NewWorkloadsMutator(builder.Build(), bkapp).ApplyToDeployment(ctx, deploy)
 				Expect(ret).To(BeFalse())
 			})
 			It("Configmap has no valid key", func() {
@@ -108,7 +107,7 @@ var _ = Describe("Test configmap related functions", func() {
 				ret := NewWorkloadsMutator(
 					builder.WithObjects(configmap).Build(),
 					bkapp,
-				).ApplyToDeployments(ctx, deploys)
+				).ApplyToDeployment(ctx, deploy)
 				Expect(ret).To(BeFalse())
 			})
 			It("Configmap exists, but svc-discovery config is empty", func() {
@@ -116,18 +115,18 @@ var _ = Describe("Test configmap related functions", func() {
 				ret := NewWorkloadsMutator(
 					builder.WithObjects(configmap).Build(),
 					bkapp,
-				).ApplyToDeployments(ctx, deploys)
+				).ApplyToDeployment(ctx, deploy)
 				Expect(ret).To(BeFalse())
 			})
 			It("Applied successfully", func() {
-				Expect(len(deploys[0].Spec.Template.Spec.Containers[0].Env)).To(BeZero())
+				Expect(len(deploy.Spec.Template.Spec.Containers[0].Env)).To(BeZero())
 
 				ret := NewWorkloadsMutator(
 					builder.WithObjects(configmap).Build(),
 					bkapp,
-				).ApplyToDeployments(ctx, deploys)
+				).ApplyToDeployment(ctx, deploy)
 				Expect(ret).To(BeTrue())
-				Expect(len(deploys[0].Spec.Template.Spec.Containers[0].Env)).To(Equal(1))
+				Expect(len(deploy.Spec.Template.Spec.Containers[0].Env)).To(Equal(1))
 			})
 		})
 	})


### PR DESCRIPTION
In current implemetation, if the operator change the logic related with constructing the deployment body of bkapp, such as modify the default resource requirements, it will make all deployments to start a rolling update because the spec has change.

This PR fix this by doing a semantic compare between the syned and input bkapp spec when reconciling.