### PR TITLE
refactor: do not validate image credential when creating a cloud-native module

### DIFF
--- a/apiserver/paasng/paas_wl/workloads/images/serializers.py
+++ b/apiserver/paasng/paas_wl/workloads/images/serializers.py
@@ -33,11 +33,3 @@ class UsernamePasswordPairSLZ(serializers.ModelSerializer):
     class Meta:
         model = AppUserCredential
         fields = "__all__"
-
-
-class ImageCredentialSLZ(serializers.Serializer):
-    """镜像凭证相关参数"""
-
-    name = serializers.CharField(required=True)
-    username = serializers.CharField(required=True)
-    password = serializers.CharField(required=True)

--- a/apiserver/paasng/paasng/platform/applications/serializers/cnative.py
+++ b/apiserver/paasng/paasng/platform/applications/serializers/cnative.py
@@ -16,6 +16,8 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+from typing import Dict, Optional
+
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import ValidationError
 
@@ -46,4 +48,13 @@ class CreateCloudNativeAppSLZ(AppBasicInfoMixin):
         ):
             raise ValidationError("image_repository is not consistent with source_repo_url")
 
+        self._validate_image_credential(build_config.image_credential)
+
         return attrs
+
+    def _validate_image_credential(self, image_credential: Optional[Dict[str, str]]):
+        if not image_credential:
+            return
+
+        if not image_credential.get("password") or not image_credential.get("username"):
+            raise ValidationError("image credential missing valid username and password")

--- a/apiserver/paasng/paasng/platform/modules/serializers.py
+++ b/apiserver/paasng/paasng/platform/modules/serializers.py
@@ -27,7 +27,6 @@ from rest_framework.exceptions import ValidationError
 
 from paas_wl.infras.cluster.serializers import ClusterSLZ
 from paas_wl.infras.cluster.shim import EnvClusterService
-from paas_wl.workloads.images.serializers import ImageCredentialSLZ
 from paasng.platform.bkapp_model.serializers import ModuleDeployHookSLZ as CNativeModuleDeployHookSLZ
 from paasng.platform.bkapp_model.serializers import ModuleProcessSpecSLZ
 from paasng.platform.engine.constants import RuntimeType
@@ -308,6 +307,14 @@ class ModuleBuildConfigSLZ(serializers.Serializer):
                 detail={param: _("This field is required.") for param in missed_params}, code="required"
             )
         return attrs
+
+
+class ImageCredentialSLZ(serializers.Serializer):
+    """镜像凭证相关参数"""
+
+    name = serializers.CharField(required=True)
+    username = serializers.CharField(required=False)
+    password = serializers.CharField(required=False)
 
 
 class CreateModuleBuildConfigSLZ(serializers.Serializer):


### PR DESCRIPTION
根据产品设计，创建云原生模块时，不支持创建镜像凭证