### PR TITLE
minor: 统一 buildpack 名称; 增加初始化云原生 buildpack 的脚本

### DIFF
--- a/apiserver/init.sh
+++ b/apiserver/init.sh
@@ -106,6 +106,20 @@ ensure-apt-buildpack() {
     --type tar \
     --address "${buildpack_url}/${buildpack_name}-${apt_buildpack_version}.tar" \
     --hidden
+
+    # 云原生应用直接使用社区的 apt buildapck
+    python manage.py manage_buildpack \
+    --region "${region}" \
+    --name "fagiani/apt" \
+    --display_name_zh_cn "安装系统包" \
+    --display_name_en "Install Apt package" \
+    --description_zh_cn "安装 Aptfile 文件描述的系统依赖包" \
+    --description_en "Install the system dependency packages described in the Aptfile file" \
+    --tag "0.2.5" \
+    --language Apt \
+    --type tar \
+    --address "urn:cnb:registry:fagiani/apt" \
+    --hidden
 }
 
 ensure-python-buildpack() {
@@ -211,11 +225,27 @@ ensure-buleking-image() {
     --display_name_en "Blueking Basic Image" \
     --description_zh_cn "基于 Ubuntu，支持多构建工具组合构建" \
     --description_en "Ubuntu-based, multi-buildpack combination build support" \
-    --label secureEncrypted=1 normal_app=1 smart_app=1
+    --label secureEncrypted=1 supportHttp=1 normal_app=1 smart_app=1
     python manage.py bind_buildpacks --image "${image_name}" --buildpack-name "${apt_buildpack_name}"
     python manage.py bind_buildpacks --image "${image_name}" --buildpack-name "${python_buildpack_name}"
     python manage.py bind_buildpacks --image "${image_name}" --buildpack-name "${nodejs_buildpack_name}"
     python manage.py bind_buildpacks --image "${image_name}" --buildpack-name "${golang_buildpack_name}"
+
+    cnb_image_name="blueking-cloudnative"
+    python manage.py manage_image \
+    --region "${region}" \
+    --image "${PAAS_HEROKU_BUILDER_IMAGE}" \
+    --name "${cnb_image_name}" \
+    --display_name_zh_cn "蓝鲸基础镜像" \
+    --display_name_en "Blueking Basic Image" \
+    --description_zh_cn "基于 Ubuntu，支持多构建工具组合构建" \
+    --description_en "Ubuntu-based, multi-buildpack combination build support" \
+    --environment "CNB_PLATFORM_API=0.11" "RUN_IMAGE=${PAAS_HEROKU_RUNNER_IMAGE}" \
+    --label secureEncrypted=1 supportHttp=1 isCloudNativeBuilder=1 cnative_app=1
+    python manage.py bind_buildpacks --image "${cnb_image_name}" --buildpack-name "fagiani/apt"
+    python manage.py bind_buildpacks --image "${cnb_image_name}" --buildpack-name "${python_buildpack_name}"
+    python manage.py bind_buildpacks --image "${cnb_image_name}" --buildpack-name "${nodejs_buildpack_name}"
+    python manage.py bind_buildpacks --image "${cnb_image_name}" --buildpack-name "${golang_buildpack_name}"
 }
 
 ensure-legacy-image() {

--- a/builder-stack/README.md
+++ b/builder-stack/README.md
@@ -73,7 +73,7 @@
     -e OUTPUT_IMAGE="mirrors.tencent.com/foo:latest" \
     -e RUN_IMAGE="mirrors.tencent.com/bkpaas/heroku-stack-bionic:run" \
     -e SOURCE_GET_URL="file:///tmp/source.tgz" \
-    -e REQUIRED_BUILDPACKS="tgz fagiani/apt ... 0.2.5;tgz blueking/python ... v213" \
+    -e REQUIRED_BUILDPACKS="tgz fagiani/apt ... 0.2.5;tgz bk-buildpack-python ... v213" \
     # 非必要不要改这个值
     -e CNB_PLATFORM_API="0.11" \
     # TODO: 修改成你的镜像源访问凭证, 结构为 Dict[str, str], key 是镜像仓库名称, value 是 Basic Auth 格式的用户凭证

--- a/builder-stack/cloudnative-buildpacks/builders/heroku-builder/builder.toml
+++ b/builder-stack/cloudnative-buildpacks/builders/heroku-builder/builder.toml
@@ -23,17 +23,17 @@ description = "Ubuntu bionic base image with buildpacks for Java, .NET Core, Nod
 
 [[buildpacks]]
   uri = "../../buildpacks/bk-buildpack-python/shim"
-  id = "blueking/python"
+  id = "bk-buildpack-python"
   version = "v213"
 
 [[buildpacks]]
   uri = "../../buildpacks/bk-buildpack-nodejs/shim"
-  id = "blueking/nodejs"
+  id = "bk-buildpack-nodejs"
   version = "v163"
 
 [[buildpacks]]
   uri = "../../buildpacks/bk-buildpack-go/shim"
-  id = "blueking/go"
+  id = "bk-buildpack-go"
   version = "v168"
 
 [[buildpacks]]
@@ -57,19 +57,19 @@ description = "Ubuntu bionic base image with buildpacks for Java, .NET Core, Nod
 
 [[order]]
   [[order.group]]
-    id = "blueking/python"
+    id = "bk-buildpack-python"
     version = "v213"
 
 
 [[order]]
   [[order.group]]
-    id = "blueking/nodejs"
+    id = "bk-buildpack-nodejs"
     version = "v163"
 
 
 [[order]]
   [[order.group]]
-    id = "blueking/go"
+    id = "bk-buildpack-go"
     version = "v168"
 
 

--- a/builder-stack/cloudnative-buildpacks/buildpacks/bk-buildpack-go/shim/buildpack.toml
+++ b/builder-stack/cloudnative-buildpacks/buildpacks/bk-buildpack-go/shim/buildpack.toml
@@ -1,7 +1,7 @@
 api = "0.4"
 
 [buildpack]
-  id = "blueking/go"
+  id = "bk-buildpack-go"
   version = "v168"
   name = "bk-buildpack-go"
 

--- a/builder-stack/cloudnative-buildpacks/buildpacks/bk-buildpack-nodejs/shim/buildpack.toml
+++ b/builder-stack/cloudnative-buildpacks/buildpacks/bk-buildpack-nodejs/shim/buildpack.toml
@@ -1,7 +1,7 @@
 api = "0.4"
 
 [buildpack]
-  id = "blueking/nodejs"
+  id = "bk-buildpack-nodejs"
   version = "v163"
   name = "bk-buildpack-nodejs"
 

--- a/builder-stack/cloudnative-buildpacks/buildpacks/bk-buildpack-python/shim/buildpack.toml
+++ b/builder-stack/cloudnative-buildpacks/buildpacks/bk-buildpack-python/shim/buildpack.toml
@@ -1,7 +1,7 @@
 api = "0.4"
 
 [buildpack]
-  id = "blueking/python"
+  id = "bk-buildpack-python"
   version = "v213"
   name = "bk-buildpack-python"
 

--- a/builder-stack/cnb-builder-shim/cmd/build-init/main_test.go
+++ b/builder-stack/cnb-builder-shim/cmd/build-init/main_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Test setupBuildpacksOrder", func() {
 	})
 
 	It("test write order.toml successfully", func() {
-		err := setupBuildpacksOrder(logging.Default(), "tgz apt https://example.com v;tgz blueking/python https://example.com v213", cnbDir)
+		err := setupBuildpacksOrder(logging.Default(), "tgz apt https://example.com v;tgz bk-buildpack-python https://example.com v213", cnbDir)
 		Expect(err).To(BeNil())
 
 		content, _ := ioutil.ReadFile(filepath.Join(cnbDir, "order.toml"))
@@ -90,19 +90,19 @@ id = 'apt'
 version = 'v'
 
 [[order.group]]
-id = 'blueking/python'
+id = 'bk-buildpack-python'
 version = 'v213'
 `))
 	})
 
 	It("test skip wrong value", func() {
-		err := setupBuildpacksOrder(logging.Default(), "tgz apt;tgz blueking/python https://example.com v213", cnbDir)
+		err := setupBuildpacksOrder(logging.Default(), "tgz apt;tgz bk-buildpack-python https://example.com v213", cnbDir)
 		Expect(err).To(BeNil())
 
 		content, _ := ioutil.ReadFile(filepath.Join(cnbDir, "order.toml"))
 		Expect(string(content)).To(Equal(`[[order]]
 [[order.group]]
-id = 'blueking/python'
+id = 'bk-buildpack-python'
 version = 'v213'
 `))
 	})


### PR DESCRIPTION
外发的 init.sh 里已经写死过名称，云原生应用就往这名称靠吧。