### PR TITLE
fix: 修复由于日志平台未开放 esquery_mapping 接口导致无法正常聚合字段的问题

### DIFF
--- a/apiserver/paasng/paasng/accessories/log/client.py
+++ b/apiserver/paasng/paasng/accessories/log/client.py
@@ -95,7 +95,7 @@ class BKLogClient:
         self, index: str, search: SmartSearch, timeout: int, scroll_id: Optional[str] = None, scroll="5m"
     ) -> Tuple[Response, int]:
         """search log(scrolling) from index with search"""
-        raise NotImplementedError("TODO: 确认日志平台接口 /esquery_scroll/ 是否可用")
+        raise NotImplementedError("日志平台接口 /esquery_scroll/ 暂不对外开放")
 
     def aggregate_date_histogram(self, index: str, search: SmartSearch, timeout: int) -> FieldBucketData:
         """Aggregate time-based histogram"""
@@ -119,22 +119,13 @@ class BKLogClient:
         self, index: str, search: SmartSearch, mappings: dict, timeout: int
     ) -> List[FieldFilter]:
         """aggregate fields filter"""
-        # 拉取最近 DEFAULT_LOG_BATCH_SIZE 条日志, 用于统计字段分布
-        search = search.limit_offset(limit=DEFAULT_LOG_BATCH_SIZE, offset=0)
-        data = {
-            "indices": index,
-            "scenario_id": self.config.scenarioID,
-            "body": search.to_dict(),
-        }
-        resp = self._call_api(data, timeout)
-        filters = {field: FieldFilter(name=field, key=field) for field in resp["data"]["select_fields_order"]}
-        # 根据 field 在所有日志记录中出现的次数进行降序排序, 再根据 key 的字母序排序(保证前缀接近的 key 靠近在一起, 例如 json.*)
-        filters = count_filters_options_from_logs(list(Response(search.search, resp["data"])), filters)
-        return sorted(filters.values(), key=attrgetter("total", "key"), reverse=True)
+        raise NotImplementedError(
+            "由于日志平台接口 /esquery_mapping/ 暂不对外开放, 暂时无法实现 aggregate_fields_filters"
+        )
 
     def get_mappings(self, index: str, time_range: SmartTimeRange, timeout: int) -> dict:
         """query the mappings in es"""
-        raise NotImplementedError("TODO: 确认日志平台接口 /esquery_mapping/ 是否可用")
+        raise NotImplementedError("日志平台接口 /esquery_mapping/ 暂不对外开放")
 
     def _get_indexes(self, index: str, time_range: SmartSearch) -> List[str]:
         """Get indexes within the time_range range from ES"""

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/definitions.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/definitions.py
@@ -282,6 +282,9 @@ class ElasticSearchParams(BaseModel):
     )
     builtinFilters: Dict[str, Union[str, List[str]]] = Field(default_factory=dict, description="内置的过滤条件")
     builtinExcludes: Dict[str, Union[str, List[str]]] = Field(default_factory=dict, description="内置的排除条件")
+
+    # example: ["json.message", "json.funcName", "json.levelname", "json.otelTraceID", "json.otelSpanID"]
+    filterFields: List[str] = Field(default_factory=list, description="前端可选的字段过滤选项集")
     # paas 的标准输出日志过滤条件
     # termTemplate = {"app_code": "{{ plugin_id }}"}
     # builtinFilters = {"environment": "prod", "stream": ["stderr", "stdout"]}

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/__init__.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/__init__.py
@@ -201,6 +201,7 @@ def aggregate_fields_filters(
         search_params = pd.log_config.ingress
     if not search_params:
         raise ValueError(f"this plugin does not support query {log_type} logs")
+
     search = make_base_search(plugin=instance, search_params=search_params, time_range=time_range, limit=200, offset=0)
     if query_string:
         search = search.filter("query_string", query=query_string, analyze_wildcard=True)
@@ -209,7 +210,10 @@ def aggregate_fields_filters(
     if exclude:
         search = search.exclude("terms", **exclude)
     return log_client.aggregate_fields_filters(
-        index=search_params.indexPattern, search=search, timeout=DEFAULT_ES_SEARCH_TIMEOUT
+        index=search_params.indexPattern,
+        search=search,
+        timeout=DEFAULT_ES_SEARCH_TIMEOUT,
+        fields=search_params.filterFields,
     )
 
 

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/client.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/client.py
@@ -50,7 +50,9 @@ class LogClientProtocol(Protocol):
     def aggregate_date_histogram(self, index: str, search: SmartSearch, timeout: int) -> FieldBucketData:
         """Aggregate time-based histogram"""
 
-    def aggregate_fields_filters(self, index: str, search: SmartSearch, timeout: int) -> List[FieldFilter]:
+    def aggregate_fields_filters(
+        self, index: str, search: SmartSearch, timeout: int, fields: List[str]
+    ) -> List[FieldFilter]:
         """Aggregate fields filters"""
 
 
@@ -93,7 +95,9 @@ class BKLogClient:
         resp = self._call_api(data, timeout)
         return AggResponse(search.search.aggs, search.search, resp["data"]["aggregations"]).histogram
 
-    def aggregate_fields_filters(self, index: str, search: SmartSearch, timeout: int) -> List[FieldFilter]:
+    def aggregate_fields_filters(
+        self, index: str, search: SmartSearch, timeout: int, fields: List[str]
+    ) -> List[FieldFilter]:
         """aggregate fields filter"""
         # 拉取最近 DEFAULT_LOG_BATCH_SIZE 条日志, 用于统计字段分布
         search = search.limit_offset(limit=DEFAULT_LOG_BATCH_SIZE, offset=0)
@@ -103,8 +107,9 @@ class BKLogClient:
             "body": search.to_dict(),
         }
         resp = self._call_api(data, timeout)
-        filters = {field: FieldFilter(name=field, key=field) for field in resp["data"]["select_fields_order"]}
-        return count_filters_options(list(Response(search.search, resp["data"])), filters)
+        response = Response(search.search, resp["data"])
+        filters = {field: FieldFilter(name=field, key=field) for field in fields}
+        return count_filters_options(list(response), filters)
 
     def _call_api(self, data, timeout: int):
         if self.config.bkdataAuthenticationMethod:
@@ -147,7 +152,9 @@ class ESLogClient:
             ],
         ).histogram
 
-    def aggregate_fields_filters(self, index: str, search: SmartSearch, timeout: int) -> List[FieldFilter]:
+    def aggregate_fields_filters(
+        self, index: str, search: SmartSearch, timeout: int, fields: List[str]
+    ) -> List[FieldFilter]:
         """aggregate fields filter"""
         # 拉取最近 DEFAULT_LOG_BATCH_SIZE 条日志, 用于统计字段分布
         search = search.limit_offset(limit=DEFAULT_LOG_BATCH_SIZE, offset=0)

--- a/apiserver/paasng/paasng/utils/es_log/misc.py
+++ b/apiserver/paasng/paasng/utils/es_log/misc.py
@@ -99,6 +99,9 @@ def count_filters_options(logs: List, properties: Dict[str, FieldFilter]) -> Lis
                 value = get_attribute(log, split_log_field)
             except (AttributeError, KeyError):
                 continue
+            # 过滤 None 值, 否则前端会出现异常
+            if value is None:
+                continue
             try:
                 field_counter[log_field][value] += 1
             except TypeError:


### PR DESCRIPTION
以前的写法是 bkbase 的接口返回格式。换对接的 API 时没改代码。

如何因为 bklog 未对外开放 esquery_mapping 接口，所以实现不了 ESClient 那种泛用性的实现，只能加个 `filterFields` 字段凑合用。