### PR TITLE
fix: incorrectly set image_credential_name in ModuleProcessSpec 

### DIFF
--- a/apiserver/paasng/paasng/platform/modules/manager.py
+++ b/apiserver/paasng/paasng/platform/modules/manager.py
@@ -302,12 +302,10 @@ class ModuleInitializer:
             )
             for proc in bkapp_spec["processes"]
         ]
-        image_credential_names = (
-            {proc["name"]: image_credential["name"] for proc in bkapp_spec["processes"]} if image_credential else {}
-        )
 
         mgr = ModuleProcessSpecManager(self.module)
-        mgr.sync_from_bkapp(processes, image_credential_names)
+        # image_credential_names 设置为空字典, 用于非 v1alph1 版本
+        mgr.sync_from_bkapp(processes, image_credential_names={})
         for proc in bkapp_spec["processes"]:
             if env_overlay := proc.get("env_overlay"):
                 mgr.sync_env_overlay(proc_name=proc["name"], env_overlay=env_overlay)

--- a/apiserver/paasng/paasng/platform/modules/manager.py
+++ b/apiserver/paasng/paasng/platform/modules/manager.py
@@ -304,7 +304,7 @@ class ModuleInitializer:
         ]
 
         mgr = ModuleProcessSpecManager(self.module)
-        # image_credential_names 设置为空字典, 用于非 v1alph1 版本
+        # image_credential_names 设置为空字典, 目的是不保存到 ModuleProcessSpec 的 image_credential_name 字段, 该字段仅为 v1alpha1 设计
         mgr.sync_from_bkapp(processes, image_credential_names={})
         for proc in bkapp_spec["processes"]:
             if env_overlay := proc.get("env_overlay"):

--- a/apiserver/paasng/tests/api/test_applications.py
+++ b/apiserver/paasng/tests/api/test_applications.py
@@ -524,10 +524,11 @@ class TestCreateCloudNativeApp:
         module = Module.objects.get(id=app_data["modules"][0]["id"])
         cfg = BuildConfig.objects.get_or_create_by_module(module)
         assert cfg.image_repository == image_repository
+        assert cfg.image_credential_name == image_credential_name
+
         process_spec = ModuleProcessSpec.objects.get(module=module, name="web")
         assert process_spec.image is None
         assert process_spec.command == ["bash", "/app/start_web.sh"]
-        assert process_spec.image_credential_name == image_credential_name
         assert process_spec.get_target_replicas("stag") == 1
         assert process_spec.get_target_replicas("prod") == 2
 


### PR DESCRIPTION
修复：初始化模块时，不应该设置 ModuleProcessSpec 的 image_credential_name