### PR TITLE
Fix: adm_stats/res_mapper_v1 unable to display envs that has an empty mapper version

### DIFF
--- a/apiserver/paasng/paasng/plat_admin/admin_cli/mapper_version.py
+++ b/apiserver/paasng/paasng/plat_admin/admin_cli/mapper_version.py
@@ -2,6 +2,7 @@ import datetime
 import uuid
 from typing import Dict, Iterable
 
+from django.conf import settings
 from typing_extensions import TypeAlias
 
 from paas_wl.bk_app.applications.models.config import Config
@@ -24,8 +25,7 @@ def get_mapper_v1_envs() -> Iterable[ModuleEnvironment]:
         processed[config.app_id] = config.created
 
         m = config.metadata or {}
-        if ver := m.get("mapper_version"):
-            version_map[config.app_id] = ver
+        version_map[config.app_id] = m.get("mapper_version", settings.GLOBAL_DEFAULT_MAPPER_VERSION)
 
     # Filter and print all envs that use v1
     for app_id, ver in version_map.items():


### PR DESCRIPTION
- Fix: adm_stats/res_mapper_v1 unable to display envs that has an empty mapper version