### PR TITLE
minor: 进程名称显式限制不允许大写字母

### DIFF
--- a/apiserver/paasng/paasng/utils/validators.py
+++ b/apiserver/paasng/paasng/utils/validators.py
@@ -137,7 +137,9 @@ def str2bool(value):
         raise ValueError(f"Given value({value}) not valid!")
 
 
-PROC_TYPE_PATTERN = re.compile(r"^[a-zA-Z0-9]([-a-zA-Z0-9])*$")
+# 进程名称会用于 k8s 资源命名, k8s 资源命名要求 dns-safe, 因此目前限制进程名称只能有小写字母、数字和连字符
+# Note: 这个约束比 heroku 和 cnb 更严格, 未来如果有需求，可以再考虑调整这个限制, CNB/heroku 的限制是: ([a-zA-Z0-9_-]+
+PROC_TYPE_PATTERN = re.compile(r"^[a-z0-9]([-a-z0-9])*$")
 PROC_TYPE_MAX_LENGTH = 12
 
 

--- a/apiserver/paasng/tests/api/test_modules.py
+++ b/apiserver/paasng/tests/api/test_modules.py
@@ -284,7 +284,7 @@ class TestModuleDeployConfigViewSet:
         [
             ([], {}, True),
             ([{"name": "web", "command": "python -m http.server"}], {"web": "python -m http.server"}, True),
-            ([{"name": "WEB", "command": "python -m http.server"}], {"web": "python -m http.server"}, True),
+            ([{"name": "WEB", "command": "python -m http.server"}], {}, False),
             ([{"name": "w-e-b", "command": "python -m http.server"}], {"w-e-b": "python -m http.server"}, True),
             ([{"name": "-w-e-b", "command": "python -m http.server"}], {}, False),
             ([{"name": "w" * 13, "command": "python -m http.server"}], {}, False),

--- a/apiserver/paasng/tests/paasng/platform/engine/utils/test_source.py
+++ b/apiserver/paasng/tests/paasng/platform/engine/utils/test_source.py
@@ -63,6 +63,7 @@ class TestGetProcesses:
             (ValueError("trivial value error"), "Can not read Procfile file from repository"),
             ("invalid#$type: gunicorn\n", "pattern"),
             ("{}: gunicorn\n".format("p" * 13), "longer than"),
+            ("WEB: gunicorn wsgi -w 4\nworker: celery", "pattern"),
         ],
     )
     def test_invalid_procfile_cases(self, file_content, error_pattern, bk_module_full, bk_deployment_full):
@@ -83,7 +84,7 @@ class TestGetProcesses:
     def test_valid_procfile_cases(self, bk_module_full, bk_deployment_full):
         def fake_read_file(key, version):
             if "Procfile" in key:
-                return "WEB: gunicorn wsgi -w 4\nworker: celery"
+                return "web: gunicorn wsgi -w 4\nworker: celery"
             raise DoesNotExistsOnServer
 
         with mock.patch("paasng.platform.sourcectl.type_specs.SvnRepoController.read_file") as mocked_read_file:
@@ -257,7 +258,7 @@ class TestGetProcesses:
 
         def fake_read_file(key, version):
             if "Procfile" in key:
-                return "WEB: gunicorn wsgi -w 4\nworker: celery"
+                return "web: gunicorn wsgi -w 4\nworker: celery"
             raise DoesNotExistsOnServer
 
         with mock.patch("paasng.platform.sourcectl.type_specs.SvnRepoController.read_file") as mocked_read_file:


### PR DESCRIPTION
背景：目前如果进程名称有大写字母，构建后运行也会报错启动失败。
改动：将报错信息提早到准备阶段就触发。

![企业微信截图_16982153337655](https://github.com/TencentBlueKing/blueking-paas/assets/5237578/cc64d033-af29-416d-9591-14694d95e12b)
