### PR TITLE
Fix: pre/post-compile hooks using dash naming style fail to execute(python-buildpack)

### DIFF
--- a/builder-stack/heroku-buildpacks/bk-buildpack-python/hooks/setup-user-compile-hook
+++ b/builder-stack/heroku-buildpacks/bk-buildpack-python/hooks/setup-user-compile-hook
@@ -12,6 +12,13 @@ make_hook() {
     cat > "${hook}" << EOF
 #!/bin/bash
 status=0
+
+# Define a simple wrapper function for executing commands, it can be overriden with
+# the "alias" command for testing purposes.
+function trace_call() {
+    exec "\$@" 
+}
+
 if [ -f "${BUILD_DIR}/bin/${target}" ]; then
     chmod +x "${BUILD_DIR}/bin/${target}"
     trace_call "${BUILD_DIR}/bin/${target}"


### PR DESCRIPTION
- Fix: pre/post-compile hooks using dash naming style fail to execute(python-buildpack)