### PR TITLE
Enhance: display a different label which include error detail when the first deployment failed

### DIFF
--- a/webfe/package_vue/src/language/lang/en.js
+++ b/webfe/package_vue/src/language/lang/en.js
@@ -640,6 +640,7 @@ export default {
   独立访客数: 'Unique visitors',
   类别: 'Category',
   暂未部署: 'Not yet deployed',
+  暂未成功部署: 'Not yet successfully deployed',
   正在运行: 'Running',
   申请云API权限: 'Apply Cloud API',
   '应用未部署，不能访问': 'The APP is not deployed and cannot be accessed',

--- a/webfe/package_vue/src/views/dev-center/app/engine/cloud-deploy-manage/comps/deploy-module-list.vue
+++ b/webfe/package_vue/src/views/dev-center/app/engine/cloud-deploy-manage/comps/deploy-module-list.vue
@@ -80,6 +80,14 @@
                   </div>
                 </div>
               </template>
+              <template v-else-if="deploymentInfo.state.deployment.latest">
+                <div class="not-deployed">
+                  <span v-bk-tooltips="{content: 'Error: ' + deploymentInfo.state.deployment.latest.err_detail}">
+                    <i class="paasng-icon paasng-info-line info-icon mr5" />
+                    {{ $t('暂未成功部署') }}
+                  </span>
+                </div>
+              </template>
               <template v-else>
                 <div class="not-deployed">{{$t('暂未部署')}}</div>
               </template>


### PR DESCRIPTION
- Enhance: display a different label which include error detail when the first deployment failed

Screenshoot:

<img width="538" alt="image" src="https://github.com/TencentBlueKing/blueking-paas/assets/731266/43559ca4-9f6f-4bf7-83fe-5589d6ba11d0">
