### PR TITLE
Fix: error tagging requirements when the file is using wrong encoding

### DIFF
--- a/apiserver/paasng/paasng/accessories/smart_advisor/tagging.py
+++ b/apiserver/paasng/paasng/accessories/smart_advisor/tagging.py
@@ -45,7 +45,9 @@ def dig_tags_local_repo(local_path: str):
     # Python detection
     if p.child("requirements.txt").exists():
         tags.append(force_tag("app-pl:python"))
-        with open(p.child("requirements.txt")) as fp:
+        # Set `errors="ignore"` to ignore non-ascii characters when the file is using a
+        # different encoding other than utf-8.
+        with open(p.child("requirements.txt"), encoding="utf-8", errors="ignore") as fp:
             requirements_txt = fp.read()
             for pkg_name in ("celery", "django", "gunicorn", "blueapps"):
                 if py_module_in_requirements(pkg_name, requirements_txt):

--- a/apiserver/paasng/tests/paasng/accessories/smart_advisor/test_tagging.py
+++ b/apiserver/paasng/tests/paasng/accessories/smart_advisor/test_tagging.py
@@ -22,7 +22,6 @@ from textwrap import dedent
 from unittest import mock
 
 import pytest
-from django.test import TestCase
 from django_dynamic_fixture import G
 from unipath import Path
 
@@ -37,16 +36,15 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.django_db
 
 
-class TestTaggingLocalPath(TestCase):
-    def setUp(self):
-        pass
-
-    def test_tagging_python(self):
+class TestTaggingLocalPath:
+    @pytest.mark.parametrize("encoding", ["utf-8", "gbk"])
+    def test_tagging_python_using_different_encodings(self, encoding):
         repo_path = Path(tempfile.mkdtemp())
-        with open(repo_path.child("requirements.txt"), "w") as fp:
+        with open(repo_path.child("requirements.txt"), "w", encoding=encoding) as fp:
             fp.write(
                 dedent(
                     """\
+            # 中文非 ascii 字符
             Django==1.11.2
             blueapps==1.0.15
             gunicorn==19.6.0


### PR DESCRIPTION
- Fix: error tagging requirements when the file is using wrong encoding

This is a frequently captured error in sentry.