### PR TITLE
enhance: 使用 merge-patch 更新 status, 避免日志频繁报冲突

### DIFF
--- a/operator/controllers/bkapp_controller.go
+++ b/operator/controllers/bkapp_controller.go
@@ -20,7 +20,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -182,7 +181,7 @@ func (r *BkAppReconciler) updateStatus(
 			return syncErr
 		} else {
 			// 与调和错误拼接
-			return fmt.Errorf("%s: %w", syncErr, reconcileErr)
+			return errors.Wrap(reconcileErr, syncErr.Error())
 		}
 	}
 

--- a/operator/controllers/bkapp_controller_test.go
+++ b/operator/controllers/bkapp_controller_test.go
@@ -37,13 +37,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	paasv1alpha2 "bk.tencent.com/paas-app-operator/api/v1alpha2"
 	"bk.tencent.com/paas-app-operator/pkg/controllers/resources/names"
 	"bk.tencent.com/paas-app-operator/pkg/platform/external"
 	"bk.tencent.com/paas-app-operator/pkg/testing"
 	"bk.tencent.com/paas-app-operator/pkg/utils/kubestatus"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("", func() {
@@ -327,6 +328,7 @@ var _ = Describe("", func() {
 
 var _ = Describe("Test Status", func() {
 	var bkapp *paasv1alpha2.BkApp
+	var originalBkapp *paasv1alpha2.BkApp
 	var builder *fake.ClientBuilder
 	var scheme *runtime.Scheme
 	var ctx context.Context
@@ -350,6 +352,7 @@ var _ = Describe("Test Status", func() {
 				ObservedGeneration: oldGeneration,
 			},
 		}
+		originalBkapp = bkapp.DeepCopy()
 
 		builder = fake.NewClientBuilder()
 		scheme = runtime.NewScheme()
@@ -362,7 +365,7 @@ var _ = Describe("Test Status", func() {
 		Expect(bkapp.Status.ObservedGeneration).To(Equal(oldGeneration))
 
 		reconciler := NewBkAppReconciler(builder.WithObjects(bkapp).Build(), scheme)
-		_ = reconciler.updateStatus(ctx, bkapp, nil)
+		_ = reconciler.updateStatus(ctx, bkapp, originalBkapp, nil)
 		Expect(bkapp.Status.ObservedGeneration).To(Equal(newGeneration))
 	})
 
@@ -370,7 +373,7 @@ var _ = Describe("Test Status", func() {
 		Expect(bkapp.Status.ObservedGeneration).To(Equal(oldGeneration))
 
 		reconciler := NewBkAppReconciler(builder.WithObjects(bkapp).Build(), scheme)
-		_ = reconciler.updateStatus(ctx, bkapp, errors.New("failed to reconcile hook"))
+		_ = reconciler.updateStatus(ctx, bkapp, originalBkapp, errors.New("failed to reconcile hook"))
 		Expect(bkapp.Status.ObservedGeneration).To(Equal(oldGeneration))
 	})
 })

--- a/operator/controllers/domaingroupmapping_controller.go
+++ b/operator/controllers/domaingroupmapping_controller.go
@@ -129,7 +129,7 @@ func (r *DomainGroupMappingReconciler) Sync(ctx context.Context, dgmapping *paas
 	// Update status first
 	if err := r.syncRefErrStatus(ctx, dgmapping, errRef); err != nil {
 		log.Error(err, "Error updating status", "DGroupMappingName", dgmapping.Name)
-		return err
+		return fmt.Errorf("%s: %w", err, errRef)
 	}
 	if errRef != nil {
 		if apierrors.IsNotFound(errRef) || errors.Is(errRef, ErrReferenceUndefined) {
@@ -137,7 +137,7 @@ func (r *DomainGroupMappingReconciler) Sync(ctx context.Context, dgmapping *paas
 			log.Info("Deleting related Ingresses")
 			if errDel := dgroupmapping.DeleteIngresses(ctx, r.client, dgmapping); errDel != nil {
 				log.Error(errDel, "Delete ingresses failed", "DGroupMappingName", dgmapping.Name)
-				return errDel
+				return fmt.Errorf("%s: %w", errDel, errRef)
 			}
 			return nil
 		}
@@ -177,13 +177,17 @@ func (r *DomainGroupMappingReconciler) SyncDeletion(
 		if apierrors.IsNotFound(err) || errors.Is(err, ErrReferenceUndefined) {
 			return nil
 		}
-		return err
+		return errors.WithStack(err)
 	}
 	// Update bkapp's "status.Addresses" field
 	// TODO: When multiple DomainGroupMapping objs reference to one same BkApp object,
 	// Only remove addresses which are bound with current mapping object.
+
+	// deep copy bkapp to generate merge-patch
+	originalBkApp := bkapp.DeepCopy()
+	// Update BkApp's status
 	bkapp.Status.Addresses = nil
-	return r.client.Status().Update(ctx, &bkapp)
+	return errors.WithStack(r.client.Status().Patch(ctx, &bkapp, client.MergeFrom(originalBkApp)))
 }
 
 // GetRef gets the BkApp object which is referenced by given mapping object
@@ -250,12 +254,14 @@ func (r *DomainGroupMappingReconciler) syncProcessedStatus(
 		Reason: "Processed",
 	})
 	if err := r.client.Status().Update(ctx, dgmapping); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
+	// deep copy bkapp to generate merge-patch
+	originalBkApp := bkapp.DeepCopy()
 	// Update BkApp's status
 	bkapp.Status.Addresses = ToAddressableStatus(domainGroups)
-	return r.client.Status().Update(ctx, bkapp)
+	return errors.WithStack(r.client.Status().Patch(ctx, bkapp, client.MergeFrom(originalBkApp)))
 }
 
 // BkAppIndexField is the name for indexing DomainGroupMapping

--- a/operator/controllers/domaingroupmapping_controller.go
+++ b/operator/controllers/domaingroupmapping_controller.go
@@ -129,7 +129,7 @@ func (r *DomainGroupMappingReconciler) Sync(ctx context.Context, dgmapping *paas
 	// Update status first
 	if err := r.syncRefErrStatus(ctx, dgmapping, errRef); err != nil {
 		log.Error(err, "Error updating status", "DGroupMappingName", dgmapping.Name)
-		return fmt.Errorf("%s: %w", err, errRef)
+		return errors.Wrap(errRef, err.Error())
 	}
 	if errRef != nil {
 		if apierrors.IsNotFound(errRef) || errors.Is(errRef, ErrReferenceUndefined) {
@@ -137,7 +137,7 @@ func (r *DomainGroupMappingReconciler) Sync(ctx context.Context, dgmapping *paas
 			log.Info("Deleting related Ingresses")
 			if errDel := dgroupmapping.DeleteIngresses(ctx, r.client, dgmapping); errDel != nil {
 				log.Error(errDel, "Delete ingresses failed", "DGroupMappingName", dgmapping.Name)
-				return fmt.Errorf("%s: %w", errDel, errRef)
+				return errors.Wrap(errRef, errDel.Error())
 			}
 			return nil
 		}

--- a/operator/pkg/controllers/resources/deployment.go
+++ b/operator/pkg/controllers/resources/deployment.go
@@ -19,7 +19,6 @@
 package resources
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -72,7 +71,7 @@ func BuildProcDeployment(app *paasv1alpha2.BkApp, procName string) (*appsv1.Depl
 	// Find the process spec object
 	proc, found := lo.Find(app.Spec.Processes, func(p paasv1alpha2.Process) bool { return p.Name == procName })
 	if !found {
-		return nil, fmt.Errorf("process %s not found", procName)
+		return nil, errors.Errorf("process %s not found", procName)
 	}
 
 	// Start to build the deployment resource and return

--- a/operator/pkg/controllers/resources/env_overlay.go
+++ b/operator/pkg/controllers/resources/env_overlay.go
@@ -19,8 +19,7 @@
 package resources
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 
 	paasv1alpha2 "bk.tencent.com/paas-app-operator/api/v1alpha2"
@@ -238,7 +237,7 @@ func (r *ProcResourcesGetter) GetByProc(name string) (result corev1.ResourceRequ
 	// Standard: read the "ResQuotaPlan" field from process
 	procObj := r.bkapp.Spec.FindProcess(name)
 	if procObj == nil {
-		return result, fmt.Errorf("process %s not found", name)
+		return result, errors.Errorf("process %s not found", name)
 	}
 	return r.fromQuotaPlan(procObj.ResQuotaPlan), nil
 }

--- a/operator/pkg/controllers/resources/ingress_plugins.go
+++ b/operator/pkg/controllers/resources/ingress_plugins.go
@@ -20,11 +20,11 @@ package resources
 
 import (
 	"bytes"
-	"fmt"
 	"strconv"
 	"text/template"
 
 	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
 
 	paasv1alpha1 "bk.tencent.com/paas-app-operator/api/v1alpha1"
 	paasv1alpha2 "bk.tencent.com/paas-app-operator/api/v1alpha2"
@@ -143,7 +143,7 @@ func init() {
         # content of access-control plugin ends`))
 
 	if err != nil {
-		panic(fmt.Errorf("failed to new access control template: %w", err))
+		panic(errors.Wrap(err, "failed to new access control template"))
 	}
 
 	paasAnalysisTempalte, err = template.New("pa").
@@ -156,7 +156,7 @@ func init() {
         # content of paas-analysis plugin ends`))
 
 	if err != nil {
-		panic(fmt.Errorf("failed to new paas-analysis template: %w", err))
+		panic(errors.Wrap(err, "failed to new paas-analysis template"))
 	}
 }
 


### PR DESCRIPTION
由于 DomainGroupMappingReconciler 和 BkAppReconciler 都需要更新 bkapp 的 status. 在一次部署过程会出现多次冲突。
这个 PR 将更新操作调整成 merge-patch+json. 尽可能减少冲突次数。

调整前会出现多次以下日志，调整后该日志消失:
```
Error updating status for processed item ...
Error updating status for processed item ...
Error updating status for processed item ...
```

这个改动可以导致报错次数变少