### PR TITLE
feature: 实现 HookFinishedPredicate 控制仅当 Hook 执行成功时触发调和循环

### DIFF
--- a/operator/controllers/bkapp_controller.go
+++ b/operator/controllers/bkapp_controller.go
@@ -32,18 +32,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	autoscaling "github.com/Tencent/bk-bcs/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/pkg/apis/autoscaling/v1alpha1"
+
 	paasv1alpha1 "bk.tencent.com/paas-app-operator/api/v1alpha1"
 	paasv1alpha2 "bk.tencent.com/paas-app-operator/api/v1alpha2"
 	"bk.tencent.com/paas-app-operator/pkg/config"
+	"bk.tencent.com/paas-app-operator/pkg/controllers/predicates"
 	"bk.tencent.com/paas-app-operator/pkg/controllers/reconcilers"
 	"bk.tencent.com/paas-app-operator/pkg/metrics"
-	autoscaling "github.com/Tencent/bk-bcs/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/pkg/apis/autoscaling/v1alpha1"
 )
 
 // NewBkAppReconciler will return a BkAppReconciler with given k8s client and scheme
@@ -195,7 +198,7 @@ func (r *BkAppReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager
 		For(&paasv1alpha2.BkApp{}).
 		WithOptions(opts).
 		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Pod{})
+		Owns(&corev1.Pod{}, builder.WithPredicates(predicates.NewHookFinishedPredicate()))
 
 	if config.Global.IsAutoscalingEnabled() {
 		if err = mgr.GetFieldIndexer().IndexField(

--- a/operator/pkg/controllers/predicates/hooks.go
+++ b/operator/pkg/controllers/predicates/hooks.go
@@ -1,0 +1,52 @@
+package predicates
+
+import (
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	paasv1alpha2 "bk.tencent.com/paas-app-operator/api/v1alpha2"
+	"bk.tencent.com/paas-app-operator/pkg/utils/kubestatus"
+)
+
+// NewHookFinishedPredicate create an HookFinishedPredicate instance
+func NewHookFinishedPredicate() predicate.Predicate {
+	return &HookFinishedPredicate{
+		Logger: logf.Log,
+	}
+}
+
+// HookFinishedPredicate implements an update predicate function on the Hook Pod being ready.
+//
+// This predicate will skip all other events unless the pod state is change from not-ready to ready.
+// * With this predicate, any successful hook will wake up the bkapp reconciler.
+type HookFinishedPredicate struct {
+	Logger logr.Logger
+	predicate.Funcs
+}
+
+// Update implements UpdateEvent filter for validating whether the pod state is change from not-ready to ready.
+func (p HookFinishedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil {
+		p.Logger.Error(nil, "Update event has no old object to update", "event", e)
+		return false
+	}
+	if e.ObjectNew == nil {
+		p.Logger.Error(nil, "Update event has no new object for update", "event", e)
+		return false
+	}
+	if e.ObjectNew.GetLabels()[paasv1alpha2.ResourceTypeKey] != "hook" {
+		p.Logger.V(1).Info("Update event received from a pod that is not a hook, skip it", "event", e)
+		return false
+	}
+	oldPod := e.ObjectOld.(*corev1.Pod)
+	newPod := e.ObjectNew.(*corev1.Pod)
+	oldHealthStatus := kubestatus.CheckPodHealthStatus(oldPod)
+	newHealthStatus := kubestatus.CheckPodHealthStatus(newPod)
+
+	// the pod state is change from not-ready to ready
+	return (oldHealthStatus.Phase != paasv1alpha2.HealthHealthy) &&
+		(newHealthStatus.Phase == paasv1alpha2.HealthHealthy)
+}


### PR DESCRIPTION
解决由于 Pod 被 kubelet 更新 status 时也会触发调和循环的问题。

目前已知会错误触发调和循环的场景:
- pod 无法拉取镜像, kubelet 会不停更新 status (imagePullBackOff <-> ErrImagePull 来回切换)
- pod 重启, 不管什么原因，重启就会更新 status 的 restartCount (进程的 Pod 重启也会触发调和）
