### PR TITLE
Fix: unable to delete process & Refactor ObsoleteProcessesCleaner & Generation module and etc

### DIFF
--- a/apiserver/paasng/paas_wl/bk_app/deploy/actions/__init__.py
+++ b/apiserver/paasng/paas_wl/bk_app/deploy/actions/__init__.py
@@ -16,6 +16,6 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-from .deploy import DeployAction, ZombieProcessesKiller
+from .deploy import DeployAction
 
-__all__ = ["DeployAction", "ZombieProcessesKiller"]
+__all__ = ["DeployAction"]

--- a/apiserver/paasng/paas_wl/bk_app/deploy/app_res/client.py
+++ b/apiserver/paasng/paas_wl/bk_app/deploy/app_res/client.py
@@ -115,7 +115,7 @@ class K8sScheduler:
         """Delete process will delete the Deployment and the Service(if with_access=True)"""
         for process in processes:
             if with_access:
-                self.get_default_services(process.app, process.type).create_or_patch()
+                self.get_default_services(process.app, process.type).remove()
             self.processes_handler.delete(process=process)
 
     @staticmethod

--- a/apiserver/paasng/paas_wl/bk_app/deploy/app_res/controllers.py
+++ b/apiserver/paasng/paas_wl/bk_app/deploy/app_res/controllers.py
@@ -20,7 +20,7 @@ import datetime
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import arrow
 from django.conf import settings
@@ -39,8 +39,8 @@ from paas_wl.infras.resources.base.exceptions import (
     ResourceMissing,
 )
 from paas_wl.infras.resources.base.kres import KDeployment, KNamespace, KPod, KReplicaSet, set_default_options
-from paas_wl.infras.resources.generation.mapper import MapperProcConfig
-from paas_wl.infras.resources.generation.version import AppResVerManager, get_proc_deployment_name
+from paas_wl.infras.resources.generation.mapper import MapperProcConfig, ResourceIdentifiers
+from paas_wl.infras.resources.generation.version import AppResVerManager
 from paas_wl.infras.resources.kube_res.base import AppEntityManager
 from paas_wl.infras.resources.kube_res.exceptions import AppEntityNotFound
 from paas_wl.infras.resources.utils.basic import get_client_by_app
@@ -89,13 +89,39 @@ class ProcessesHandler(ResourceHandlerBase):
         super().__init__(*args, **kwargs)
         self.process_manager = AppEntityManager(Process)
 
-    def deploy(self, process: Process):
-        """Deploy a process to the cluster."""
-        mapper_ver = AppResVerManager(process.app).curr_version
-        try:
-            self.process_manager.update(process, "replace", mapper_version=mapper_ver, allow_not_concrete=True)
-        except AppEntityNotFound:
-            self.process_manager.create(process, mapper_version=mapper_ver)
+    def deploy(self, processes: List[Process]):
+        """Deploy a list process objects.
+
+        :param processes: The process list.
+        """
+        for process in processes:
+            mapper_ver = AppResVerManager(process.app).curr_version
+            try:
+                self.process_manager.update(process, "replace", mapper_version=mapper_ver, allow_not_concrete=True)
+            except AppEntityNotFound:
+                self.process_manager.create(process, mapper_version=mapper_ver)
+            self.get_default_services(process.app, process.type).create_or_patch()
+
+    def shutdown(self, config: MapperProcConfig):
+        """Shutdown a process.
+
+        :param config: The mapper proc config object.
+        """
+        self.scale(config, 0)
+
+    def scale(self, config: MapperProcConfig, replicas: int):
+        """Scale a process's replicas to given value.
+
+        :param config: The mapper proc config object.
+        :param replicas: The replicas value, such as 2.
+        """
+        self.get_default_services(config.app, config.type).create_or_patch()
+
+        # Send patch request
+        patch_body = {"spec": {"replicas": replicas}}
+        KDeployment(self.client).patch(
+            self.res_identifiers(config).deployment_name, namespace=config.app.namespace, body=patch_body
+        )
 
     def delete(self, config: MapperProcConfig, remove_svc: bool):
         """Delete a process by the config object.
@@ -107,30 +133,26 @@ class ProcessesHandler(ResourceHandlerBase):
         if remove_svc:
             self.get_default_services(app, config.type).remove()
 
-        mapper_version = AppResVerManager(config.app).curr_version
-        deploy_info = mapper_version.deployment(config)
-
         # Delete the resources
-        KDeployment(self.client).delete(deploy_info.name, namespace=app.namespace, non_grace_period=True)
+        res = self.res_identifiers(config)
+        KDeployment(self.client).delete(res.deployment_name, namespace=app.namespace, non_grace_period=True)
         # Delete ReplicaSet and Pods manually
-        KReplicaSet(self.client).ops_label.delete_collection(labels=deploy_info.match_labels, namespace=app.namespace)
-        KPod(self.client).ops_label.delete_individual(labels=deploy_info.match_labels, namespace=app.namespace)
+        KReplicaSet(self.client).ops_label.delete_collection(labels=res.match_labels, namespace=app.namespace)
+        KPod(self.client).ops_label.delete_individual(labels=res.match_labels, namespace=app.namespace)
 
-    def delete_gracefully(self, app: "WlApp", process_type: str):
-        """Delete a process gracefully."""
-        res_name = get_proc_deployment_name(app, process_type)
-        KDeployment(self.client).delete(res_name, namespace=app.namespace)
+    def delete_gracefully(self, config: MapperProcConfig):
+        """Delete a process gracefully by the config object.
 
-    def scale(self, app: "WlApp", process_type: str, replicas: int):
-        """Scale a process's replicas to given value.
-
-        :param app: The application object.
-        :param process_type: The type of process, such as "web".
-        :param replicas: The replicas value, such as 2.
+        :param config: The mapper proc config object.
         """
-        patch_body = {"spec": {"replicas": replicas}}
-        res_name = get_proc_deployment_name(app, process_type)
-        KDeployment(self.client).patch(res_name, namespace=app.namespace, body=patch_body)
+        res = self.res_identifiers(config)
+        KDeployment(self.client).delete(res.deployment_name, namespace=config.app.namespace)
+
+    @staticmethod
+    def res_identifiers(config: MapperProcConfig) -> ResourceIdentifiers:
+        """Get the resource identifiers of a process."""
+        mapper_version = AppResVerManager(config.app).curr_version
+        return mapper_version.proc_resources(config)
 
     @staticmethod
     def get_default_services(app: "WlApp", process_type: str) -> ProcDefaultServices:

--- a/apiserver/paasng/paas_wl/bk_app/deploy/app_res/controllers.py
+++ b/apiserver/paasng/paas_wl/bk_app/deploy/app_res/controllers.py
@@ -20,7 +20,6 @@ import datetime
 import logging
 import os
 import time
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
 import arrow
@@ -28,6 +27,7 @@ from django.conf import settings
 from django.utils.timezone import localtime
 from kubernetes.client.rest import ApiException
 
+from paas_wl.bk_app.monitoring.app_monitor.utils import build_monitor_port
 from paas_wl.bk_app.processes.kres_entities import Process
 from paas_wl.infras.resources.base.exceptions import (
     CreateServiceAccountTimeout,
@@ -38,8 +38,9 @@ from paas_wl.infras.resources.base.exceptions import (
     ResourceDuplicate,
     ResourceMissing,
 )
-from paas_wl.infras.resources.base.kres import KDeployment, KNamespace, KPod
-from paas_wl.infras.resources.generation.version import get_proc_deployment_name
+from paas_wl.infras.resources.base.kres import KDeployment, KNamespace, KPod, KReplicaSet, set_default_options
+from paas_wl.infras.resources.generation.mapper import MapperProcConfig
+from paas_wl.infras.resources.generation.version import AppResVerManager, get_proc_deployment_name
 from paas_wl.infras.resources.kube_res.base import AppEntityManager
 from paas_wl.infras.resources.kube_res.exceptions import AppEntityNotFound
 from paas_wl.infras.resources.utils.basic import get_client_by_app
@@ -52,44 +53,68 @@ from paas_wl.utils.kubestatus import (
     parse_pod,
 )
 from paas_wl.workloads.autoscaling.kres_entities import ProcAutoscaling
+from paas_wl.workloads.networking.ingress.managers.service import ProcDefaultServices
 from paas_wl.workloads.release_controller.hooks.kres_entities import Command, command_kmodel
 
 if TYPE_CHECKING:
     from paas_wl.bk_app.applications.models import WlApp
     from paas_wl.infras.resources.base.base import EnhancedApiClient
-    from paas_wl.infras.resources.generation.mapper import MapperPack
     from paasng.platform.engine.configurations.building import SlugBuilderTemplate
 
 logger = logging.getLogger(__name__)
 
+# NOTE: dynamic client only support a single timeout parameter, use summed value as
+# the total timeout seconds.
+_default_request_timeout: float = settings.K8S_DEFAULT_CONNECT_TIMEOUT + settings.K8S_DEFAULT_READ_TIMEOUT
+set_default_options({"request_timeout": _default_request_timeout})
 
-@dataclass
+
 class ResourceHandlerBase:
-    client: "EnhancedApiClient"
-    default_connect_timeout: int
-    default_request_timeout: tuple
-    mapper_version: "MapperPack"
+    """The base class for handling resources."""
+
+    def __init__(self, client: "EnhancedApiClient"):
+        self.client = client
+
+    @classmethod
+    def new_by_app(cls, app: "WlApp"):
+        """Create a handler object by app object."""
+        client = get_client_by_app(app)
+        return cls(client)
 
 
 class ProcessesHandler(ResourceHandlerBase):
+    """Process handler."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.process_manager = AppEntityManager(Process)
 
     def deploy(self, process: Process):
+        """Deploy a process to the cluster."""
+        mapper_ver = AppResVerManager(process.app).curr_version
         try:
-            self.process_manager.update(
-                process, "replace", mapper_version=self.mapper_version, allow_not_concrete=True
-            )
+            self.process_manager.update(process, "replace", mapper_version=mapper_ver, allow_not_concrete=True)
         except AppEntityNotFound:
-            self.process_manager.create(process, mapper_version=self.mapper_version)
+            self.process_manager.create(process, mapper_version=mapper_ver)
 
-    def delete(self, process: Process):
-        self.mapper_version.deployment(process=process).delete(non_grace_period=True)
+    def delete(self, config: MapperProcConfig, remove_svc: bool):
+        """Delete a process by the config object.
 
-        # we have to delete rs & pod manually
-        self.mapper_version.replica_set(process=process).delete_collection()
-        self.mapper_version.pod(process=process).delete_individual()
+        :param config: The mapper proc config object.
+        :param remove_svc: Whether to remove the related default service.
+        """
+        app = config.app
+        if remove_svc:
+            self.get_default_services(app, config.type).remove()
+
+        mapper_version = AppResVerManager(config.app).curr_version
+        deploy_info = mapper_version.deployment(config)
+
+        # Delete the resources
+        KDeployment(self.client).delete(deploy_info.name, namespace=app.namespace, non_grace_period=True)
+        # Delete ReplicaSet and Pods manually
+        KReplicaSet(self.client).ops_label.delete_collection(labels=deploy_info.match_labels, namespace=app.namespace)
+        KPod(self.client).ops_label.delete_individual(labels=deploy_info.match_labels, namespace=app.namespace)
 
     def delete_gracefully(self, app: "WlApp", process_type: str):
         """Delete a process gracefully."""
@@ -106,6 +131,11 @@ class ProcessesHandler(ResourceHandlerBase):
         patch_body = {"spec": {"replicas": replicas}}
         res_name = get_proc_deployment_name(app, process_type)
         KDeployment(self.client).patch(res_name, namespace=app.namespace, body=patch_body)
+
+    @staticmethod
+    def get_default_services(app: "WlApp", process_type: str) -> ProcDefaultServices:
+        monitor_port = build_monitor_port(app)
+        return ProcDefaultServices(app, process_type, monitor_port=monitor_port)
 
 
 class NamespacesHandler(ResourceHandlerBase):

--- a/apiserver/paasng/paas_wl/bk_app/deploy/app_res/controllers.py
+++ b/apiserver/paasng/paas_wl/bk_app/deploy/app_res/controllers.py
@@ -63,10 +63,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# NOTE: dynamic client only support a single timeout parameter, use summed value as
-# the total timeout seconds.
-_default_request_timeout: float = settings.K8S_DEFAULT_CONNECT_TIMEOUT + settings.K8S_DEFAULT_READ_TIMEOUT
-set_default_options({"request_timeout": _default_request_timeout})
+# Set the default timeout
+set_default_options({"request_timeout": (settings.K8S_DEFAULT_CONNECT_TIMEOUT, settings.K8S_DEFAULT_READ_TIMEOUT)})
 
 
 class ResourceHandlerBase:

--- a/apiserver/paasng/paas_wl/bk_app/deploy/app_res/utils.py
+++ b/apiserver/paasng/paas_wl/bk_app/deploy/app_res/utils.py
@@ -21,10 +21,7 @@ to the current version of the project delivered to anyone in the future.
 import logging
 from typing import TYPE_CHECKING
 
-from django.conf import settings
-
 from paas_wl.bk_app.deploy.app_res.client import K8sScheduler
-from paas_wl.infras.resources.generation.version import AppResVerManager
 from paas_wl.infras.resources.kube_res.base import Schedule
 from paas_wl.infras.resources.utils.basic import (
     get_client_by_app,
@@ -46,12 +43,7 @@ def get_scheduler_client(cluster_name: str):
 
 def get_scheduler_client_by_app(app: "WlApp") -> "K8sScheduler":
     """A wrapper function to make K8sSchedulerClient from a raw client object"""
-    return K8sScheduler(
-        get_client_by_app(app),
-        settings.K8S_DEFAULT_CONNECT_TIMEOUT,
-        settings.K8S_DEFAULT_READ_TIMEOUT,
-        AppResVerManager(app).curr_version,
-    )
+    return K8sScheduler(get_client_by_app(app))
 
 
 def get_schedule_config(app: "WlApp") -> "Schedule":

--- a/apiserver/paasng/paas_wl/bk_app/processes/kres_entities.py
+++ b/apiserver/paasng/paas_wl/bk_app/processes/kres_entities.py
@@ -143,7 +143,7 @@ class Process(AppEntity):
             ),
             resources=Resources(**config.resource_requirements.get(type_, {})),
         )
-        process.name = mapper_version.deployment(process=process).name
+        process.name = mapper_version.proc_resources(process=process).deployment_name
         return process
 
     @property

--- a/apiserver/paasng/paas_wl/bk_app/processes/kres_slzs.py
+++ b/apiserver/paasng/paas_wl/bk_app/processes/kres_slzs.py
@@ -310,7 +310,7 @@ class ProcessSerializer(AppEntitySerializer["Process"]):
 
         deployment_body: Dict[str, Any] = {
             "metadata": {
-                "labels": mapper_version.deployment(process=obj).labels,
+                "labels": mapper_version.proc_resources(process=obj).labels,
                 "name": obj.name,
                 "annotations": {PROCESS_MAPPER_VERSION_KEY: mapper_version.version},
             },
@@ -325,13 +325,13 @@ class ProcessSerializer(AppEntitySerializer["Process"]):
                         "maxSurge": "75%",
                     },
                 },
-                "selector": {"matchLabels": mapper_version.deployment(process=obj).match_labels},
+                "selector": {"matchLabels": mapper_version.proc_resources(process=obj).match_labels},
                 "minReadySeconds": 1,
                 "template": {
                     "spec": self._construct_pod_body_specs(obj),
                     "metadata": {
-                        "labels": mapper_version.pod(process=obj).labels,
-                        "name": mapper_version.pod(process=obj).name,
+                        "labels": mapper_version.proc_resources(process=obj).labels,
+                        "name": mapper_version.proc_resources(process=obj).pod_name,
                     },
                 },
                 "replicas": obj.replicas,

--- a/apiserver/paasng/paas_wl/core/resource.py
+++ b/apiserver/paasng/paas_wl/core/resource.py
@@ -86,4 +86,4 @@ def get_process_selector(app: "WlApp", process_type: str) -> Dict[str, str]:
         version=release.version,
         command_name=command_name,
     )
-    return {"pod_selector": AppResVerManager(app).curr_version.deployment(proc_config).pod_selector}
+    return {"pod_selector": AppResVerManager(app).curr_version.proc_resources(proc_config).pod_selector}

--- a/apiserver/paasng/paas_wl/infras/resources/generation/mapper.py
+++ b/apiserver/paasng/paas_wl/infras/resources/generation/mapper.py
@@ -17,19 +17,14 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 import logging
-from contextlib import contextmanager
 from dataclasses import dataclass
-from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Protocol, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional, Protocol, Type, Union
 
 from paas_wl.bk_app.applications.models import WlApp
-from paas_wl.infras.resources.base.kres import BaseKresource, KDeployment, KPod, KReplicaSet
 from paas_wl.utils.command import get_command_name
 
 if TYPE_CHECKING:
-    from paas_wl.infras.resources.base.base import EnhancedApiClient
-
-MapperResource = TypeVar("MapperResource", bound=BaseKresource)
+    from paas_wl.bk_app.applications.models import Release
 
 logger = logging.getLogger(__name__)
 
@@ -43,21 +38,10 @@ class Process(Protocol):
     runtime: Any
 
 
-class Mapper(Generic[MapperResource]):
-    """映射器，用于将 WlApp 映射到 k8s 资源"""
+class ResourceIdentifiers:
+    """A class that stores the identifiers for kubernetes resources, such as name, labels."""
 
-    # 主要映射两种东西：
-    # - 属性值
-    # - 具体到 k8s 的行为
-
-    # 前者是简单的名字转换，类似 v1 pod 名称是 xxx, v2 pod 名称是 yyy
-    # 后者是行为的不同: v1 pod 通过 get() 方法获取(from NameBasedOperations),
-    #                v2 pod 则是通过 list() 获取(from LabelBasedOperations)
-    # 这里的行为映射，并不只是 kres 的等量替换，而是在 kres 上的一层封装
-
-    kres_class: Type[MapperResource]
-
-    def __init__(self, process: "Union[Process, MapperProcConfig]", client: Optional["EnhancedApiClient"] = None):
+    def __init__(self, process: "Union[Process, MapperProcConfig]"):
         if not isinstance(process, MapperProcConfig):
             _proc_config = get_mapper_proc_config(process)
             if not _proc_config:
@@ -66,11 +50,7 @@ class Mapper(Generic[MapperResource]):
             _proc_config = process
 
         self.proc_config: "MapperProcConfig" = _proc_config
-        self.client = client
 
-    ##############
-    # attributes #
-    ##############
     @property
     def name(self) -> str:
         """获取资源名"""
@@ -97,98 +77,13 @@ class Mapper(Generic[MapperResource]):
         return self.proc_config.app.namespace
 
 
-class CallThroughKresMapper(Mapper, Generic[MapperResource]):
-    """针对特定版本，只需要代理指向 kres 请求"""
-
-    @contextmanager
-    def kres(self):
-        """Return kres object as a context manager which was initialized with kubernetes client, will close all
-        connection automatically when exit to avoid connections leaking.
-        """
-        if self.client is None:
-            raise ValueError("client is required when calling kres")
-
-        with self.client:
-            yield self.kres_class(self.client)
-
-    def _kres_call_through(self, method: str, use_label_based: bool = False) -> Callable:
-        with self.kres() as target_obj:
-            if use_label_based:
-                return getattr(target_obj.ops_label, method)
-            else:
-                return getattr(target_obj, method)
-
-    def get(self) -> MapperResource:
-        """get 方法快捷注入"""
-        return self._kres_call_through("get")(name=self.name, namespace=self.namespace)
-
-    def create(self, body) -> MapperResource:
-        """get 方法快捷注入"""
-        return self._kres_call_through("create")(name=self.name, namespace=self.namespace, body=body)
-
-    def replace_or_patch(self, body) -> MapperResource:
-        """replace_or_patch 方法快捷注入"""
-        return self._kres_call_through("replace_or_patch")(body=body, name=self.name, namespace=self.namespace)
-
-    def create_or_update(self, body, update_method: str = "replace") -> Tuple[MapperResource, bool]:
-        """create_or_update 方法快捷注入"""
-        return self._kres_call_through("create_or_update")(
-            body=body, update_method=update_method, name=self.name, namespace=self.namespace
-        )
-
-    def delete(self, non_grace_period: bool = True):
-        """delete 方法快捷注入"""
-        return self._kres_call_through("delete")(
-            non_grace_period=non_grace_period, name=self.name, namespace=self.namespace
-        )
-
-    def delete_individual(self):
-        """delete_individual 方法快捷注入"""
-        return self._kres_call_through("delete_individual", use_label_based=True)(
-            labels=self.match_labels, namespace=self.namespace
-        )
-
-    def delete_collection(self, non_grace_period: bool = True):
-        """delete_collection 方法快捷注入"""
-        return self._kres_call_through("delete_collection", use_label_based=True)(
-            labels=self.match_labels, namespace=self.namespace
-        )
-
-
-class MapperField(Generic[MapperResource]):
-    """MapperField 使用描述符协议为 CallThroughKresMapper 提供默认的 client 属性"""
-
-    def __init__(self, mapper_class: Type[CallThroughKresMapper[MapperResource]]):
-        self.mapper_class = mapper_class
-
-    def __call__(
-        self, instance: "MapperPack", process: Process, client: Optional["EnhancedApiClient"] = None
-    ) -> CallThroughKresMapper[MapperResource]:
-        return self.mapper_class(process=process, client=client or instance.client)
-
-    def __get__(
-        self, instance: Optional["MapperPack"], owner: Type["MapperPack"]
-    ) -> Callable[..., CallThroughKresMapper[MapperResource]]:
-        if instance is None:
-            return self
-        return partial(self.__call__, instance)
-
-
 class MapperPack:
-    _ignore_command_name = False
     version: str
-    pod: MapperField[KPod]
-    deployment: MapperField[KDeployment]
-    replica_set: MapperField[KReplicaSet]
 
-    def __init__(self, client: Optional["EnhancedApiClient"] = None):
-        # client can only be used at CallThroughKresMapper
-        # never be used at Mapper
-        self.client = client
-
-    @property
-    def ignore_command_name(self) -> bool:
-        return self._ignore_command_name
+    # Set these identifier types in child classes
+    pod: Type[ResourceIdentifiers] = ResourceIdentifiers
+    deployment: Type[ResourceIdentifiers] = ResourceIdentifiers
+    replica_set: Type[ResourceIdentifiers] = ResourceIdentifiers
 
 
 @dataclass
@@ -220,3 +115,14 @@ def get_mapper_proc_config(proc: Process) -> Optional[MapperProcConfig]:
     except Exception:
         logger.warning("Error getting mapper_proc_config object, process: %s", proc)
         return None
+
+
+def get_mapper_proc_config_from_release(release: "Release", process_type: str) -> MapperProcConfig:
+    """Get the proc config object by release.
+
+    :param release: The release object.
+    :param process_type: The type of process.
+    """
+    version = release.version
+    command_name = get_command_name(release.get_procfile()[process_type])
+    return MapperProcConfig(app=release.app, type=process_type, version=version, command_name=command_name)

--- a/apiserver/paasng/paas_wl/infras/resources/generation/v1.py
+++ b/apiserver/paasng/paas_wl/infras/resources/generation/v1.py
@@ -16,6 +16,8 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+from paas_wl.bk_app.applications.models import WlApp
+from paas_wl.bk_app.applications.models.managers.app_metadata import get_metadata
 from paas_wl.bk_app.cnative.specs.constants import (
     BKAPP_CODE_ANNO_KEY,
     ENVIRONMENT_ANNO_KEY,
@@ -23,11 +25,8 @@ from paas_wl.bk_app.cnative.specs.constants import (
     RESOURCE_TYPE_KEY,
     WLAPP_NAME_ANNO_KEY,
 )
-from paas_wl.bk_app.applications.models import WlApp
-from paas_wl.bk_app.applications.models.managers.app_metadata import get_metadata
-from paas_wl.infras.resources.base.kres import KDeployment, KPod, KReplicaSet
 
-from .mapper import CallThroughKresMapper, MapperField, MapperPack
+from .mapper import MapperPack, ResourceIdentifiers
 
 
 def v1_scheduler_safe_name(app: WlApp):
@@ -36,9 +35,7 @@ def v1_scheduler_safe_name(app: WlApp):
     return f"{app.region}-{app.scheduler_safe_name}"
 
 
-class PodMapper(CallThroughKresMapper[KPod]):
-    kres_class = KPod
-
+class PodResIdentifiers(ResourceIdentifiers):
     @property
     def pod_selector(self) -> str:
         return f"{v1_scheduler_safe_name(self.proc_config.app)}-{self.proc_config.type}-deployment"
@@ -82,9 +79,7 @@ class PodMapper(CallThroughKresMapper[KPod]):
         )
 
 
-class DeploymentMapper(CallThroughKresMapper[KDeployment]):
-    kres_class = KDeployment
-
+class DeploymentResIdentifiers(ResourceIdentifiers):
     @property
     def pod_selector(self) -> str:
         return f"{v1_scheduler_safe_name(self.proc_config.app)}-{self.proc_config.type}-deployment"
@@ -128,9 +123,7 @@ class DeploymentMapper(CallThroughKresMapper[KDeployment]):
         )
 
 
-class ReplicaSetMapper(CallThroughKresMapper[KReplicaSet]):
-    kres_class = KReplicaSet
-
+class ReplicaSetResIdentifiers(ResourceIdentifiers):
     @property
     def pod_selector(self) -> str:
         return f"{v1_scheduler_safe_name(self.proc_config.app)}-{self.proc_config.type}-deployment"
@@ -149,6 +142,7 @@ class ReplicaSetMapper(CallThroughKresMapper[KReplicaSet]):
 
 class V1Mapper(MapperPack):
     version = "v1"
-    pod: MapperField[KPod] = MapperField(PodMapper)
-    deployment: MapperField[KDeployment] = MapperField(DeploymentMapper)
-    replica_set: MapperField[KReplicaSet] = MapperField(ReplicaSetMapper)
+
+    pod = PodResIdentifiers
+    deployment = DeploymentResIdentifiers
+    replica_set = ReplicaSetResIdentifiers

--- a/apiserver/paasng/paas_wl/infras/resources/generation/v2.py
+++ b/apiserver/paasng/paas_wl/infras/resources/generation/v2.py
@@ -29,44 +29,23 @@ from paas_wl.utils.basic import digest_if_length_exceeded
 from .mapper import MapperPack, ResourceIdentifiers
 
 
-class PodResIdentifiers(ResourceIdentifiers):
+class V2ProcResIdentifiers(ResourceIdentifiers):
+    """Resource identifiers for process, v2"""
+
     @property
-    def name(self) -> str:
+    def deployment_name(self) -> str:
+        """The name of deployment."""
         return f"{self.proc_config.app.scheduler_safe_name}--{self.proc_config.type}"
 
     @property
-    def pod_selector(self) -> str:
-        return digest_if_length_exceeded(f"{self.proc_config.app.name}-{self.proc_config.type}", 63)
-
-    @property
-    def labels(self) -> dict:
-        mdata = get_metadata(self.proc_config.app)
-        return {
-            "pod_selector": self.pod_selector,
-            "release_version": str(self.proc_config.version),
-            "region": self.proc_config.app.region,
-            "app_code": mdata.get_paas_app_code(),
-            "module_name": mdata.module_name,
-            "env": mdata.environment,
-            "process_id": self.proc_config.type,
-            "category": "bkapp",
-            "mapper_version": "v2",
-            # 新 labels
-            BKAPP_CODE_ANNO_KEY: mdata.get_paas_app_code(),
-            MODULE_NAME_ANNO_KEY: mdata.module_name,
-            ENVIRONMENT_ANNO_KEY: mdata.environment,
-            WLAPP_NAME_ANNO_KEY: self.proc_config.app.name,
-            RESOURCE_TYPE_KEY: "process",
-        }
+    def pod_name(self) -> str:
+        """The name of pod."""
+        return f"{self.proc_config.app.scheduler_safe_name}--{self.proc_config.type}"
 
     @property
     def match_labels(self) -> dict:
-        return dict(
-            pod_selector=self.pod_selector,
-        )
+        return {"pod_selector": self.pod_selector}
 
-
-class DeploymentResIdentifiers(ResourceIdentifiers):
     @property
     def pod_selector(self) -> str:
         return digest_if_length_exceeded(f"{self.proc_config.app.name}-{self.proc_config.type}", 63)
@@ -92,35 +71,7 @@ class DeploymentResIdentifiers(ResourceIdentifiers):
             RESOURCE_TYPE_KEY: "process",
         }
 
-    @property
-    def match_labels(self) -> dict:
-        return dict(
-            pod_selector=self.pod_selector,
-        )
-
-    @property
-    def name(self) -> str:
-        return f"{self.proc_config.app.scheduler_safe_name}--{self.proc_config.type}"
-
-
-class ReplicaSetResIdentifiers(ResourceIdentifiers):
-    @property
-    def pod_selector(self) -> str:
-        return digest_if_length_exceeded(f"{self.proc_config.app.name}-{self.proc_config.type}", 63)
-
-    @property
-    def name(self) -> str:
-        return f"{self.proc_config.app.scheduler_safe_name}--{self.proc_config.type}"
-
-    @property
-    def match_labels(self) -> dict:
-        return dict(
-            pod_selector=self.pod_selector,
-        )
-
 
 class V2Mapper(MapperPack):
     version = "v2"
-    pod = PodResIdentifiers
-    deployment = DeploymentResIdentifiers
-    replica_set = ReplicaSetResIdentifiers
+    proc_resources = V2ProcResIdentifiers

--- a/apiserver/paasng/paas_wl/infras/resources/generation/v2.py
+++ b/apiserver/paasng/paas_wl/infras/resources/generation/v2.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+from paas_wl.bk_app.applications.models.managers.app_metadata import get_metadata
 from paas_wl.bk_app.cnative.specs.constants import (
     BKAPP_CODE_ANNO_KEY,
     ENVIRONMENT_ANNO_KEY,
@@ -23,16 +24,12 @@ from paas_wl.bk_app.cnative.specs.constants import (
     RESOURCE_TYPE_KEY,
     WLAPP_NAME_ANNO_KEY,
 )
-from paas_wl.bk_app.applications.models.managers.app_metadata import get_metadata
-from paas_wl.infras.resources.base.kres import KDeployment, KPod, KReplicaSet
 from paas_wl.utils.basic import digest_if_length_exceeded
 
-from .mapper import CallThroughKresMapper, MapperField, MapperPack
+from .mapper import MapperPack, ResourceIdentifiers
 
 
-class PodMapper(CallThroughKresMapper[KPod]):
-    kres_class = KPod
-
+class PodResIdentifiers(ResourceIdentifiers):
     @property
     def name(self) -> str:
         return f"{self.proc_config.app.scheduler_safe_name}--{self.proc_config.type}"
@@ -69,9 +66,7 @@ class PodMapper(CallThroughKresMapper[KPod]):
         )
 
 
-class DeploymentMapper(CallThroughKresMapper[KDeployment]):
-    kres_class = KDeployment
-
+class DeploymentResIdentifiers(ResourceIdentifiers):
     @property
     def pod_selector(self) -> str:
         return digest_if_length_exceeded(f"{self.proc_config.app.name}-{self.proc_config.type}", 63)
@@ -108,9 +103,7 @@ class DeploymentMapper(CallThroughKresMapper[KDeployment]):
         return f"{self.proc_config.app.scheduler_safe_name}--{self.proc_config.type}"
 
 
-class ReplicaSetMapper(CallThroughKresMapper[KReplicaSet]):
-    kres_class = KReplicaSet
-
+class ReplicaSetResIdentifiers(ResourceIdentifiers):
     @property
     def pod_selector(self) -> str:
         return digest_if_length_exceeded(f"{self.proc_config.app.name}-{self.proc_config.type}", 63)
@@ -128,7 +121,6 @@ class ReplicaSetMapper(CallThroughKresMapper[KReplicaSet]):
 
 class V2Mapper(MapperPack):
     version = "v2"
-    _ignore_command_name = True
-    pod: MapperField[KPod] = MapperField(PodMapper)
-    deployment: MapperField[KDeployment] = MapperField(DeploymentMapper)
-    replica_set: MapperField[KReplicaSet] = MapperField(ReplicaSetMapper)
+    pod = PodResIdentifiers
+    deployment = DeploymentResIdentifiers
+    replica_set = ReplicaSetResIdentifiers

--- a/apiserver/paasng/paas_wl/infras/resources/generation/version.py
+++ b/apiserver/paasng/paas_wl/infras/resources/generation/version.py
@@ -25,7 +25,6 @@ from paas_wl.bk_app.applications.models.release import Release
 from paas_wl.infras.resources.generation.mapper import MapperProcConfig
 from paas_wl.infras.resources.generation.v1 import V1Mapper
 from paas_wl.infras.resources.generation.v2 import V2Mapper
-from paas_wl.infras.resources.utils.basic import get_client_by_app
 from paas_wl.utils.command import get_command_name
 
 if TYPE_CHECKING:
@@ -51,10 +50,8 @@ class AppResVerManager:
         latest_config = self.app.latest_config
 
         # 一般对于只读的操作，都只需要直接读取当前版本
-        client = get_client_by_app(self.app)
         return get_mapper_version(
             target=latest_config.metadata.get(self._mapper_version_term) or settings.LEGACY_MAPPER_VERSION,
-            init_kwargs=dict(client=client),
         )
 
     def update(self, version: str):
@@ -74,10 +71,10 @@ class AppResVerManager:
         latest_config.save(update_fields=["metadata", "updated"])
 
 
-def get_mapper_version(target: str, init_kwargs: Optional[dict] = None):
+def get_mapper_version(target: str):
     available_packs = dict()
     for generation, mapper_class in AVAILABLE_GENERATIONS.items():
-        available_packs[generation] = mapper_class(**init_kwargs or {})
+        available_packs[generation] = mapper_class()
     return available_packs[target]
 
 

--- a/apiserver/paasng/paasng/plat_admin/admin_cli/deploy.py
+++ b/apiserver/paasng/paasng/plat_admin/admin_cli/deploy.py
@@ -2,7 +2,7 @@ import time
 from typing import Callable, List, Optional
 
 from paas_wl.bk_app.applications.models.release import Release
-from paas_wl.bk_app.deploy.app_res.utils import get_scheduler_client_by_app
+from paas_wl.bk_app.deploy.app_res.controllers import ProcessesHandler
 from paas_wl.bk_app.processes.shim import ProcessManager
 from paasng.platform.applications.models import ModuleEnvironment
 
@@ -14,10 +14,10 @@ def list_proc_types(env: ModuleEnvironment) -> List[str]:
 
 def refresh_services(env: ModuleEnvironment):
     """Refresh the service resource for the given environment."""
-    s_client = get_scheduler_client_by_app(env.wl_app)
+    handler = ProcessesHandler.new_by_app(env.wl_app)
     for proc_type in list_proc_types(env):
         # Recreate the service resource to select the new pods
-        svc = s_client.get_default_services(env.wl_app, proc_type)
+        svc = handler.get_default_services(env.wl_app, proc_type)
         svc.remove()
         svc.create_or_patch()
 

--- a/apiserver/paasng/paasng/plat_admin/admin_cli/deploy.py
+++ b/apiserver/paasng/paasng/plat_admin/admin_cli/deploy.py
@@ -14,10 +14,9 @@ def list_proc_types(env: ModuleEnvironment) -> List[str]:
 
 def refresh_services(env: ModuleEnvironment):
     """Refresh the service resource for the given environment."""
-    handler = ProcessesHandler.new_by_app(env.wl_app)
     for proc_type in list_proc_types(env):
         # Recreate the service resource to select the new pods
-        svc = handler.get_default_services(env.wl_app, proc_type)
+        svc = ProcessesHandler.get_default_services(env.wl_app, proc_type)
         svc.remove()
         svc.create_or_patch()
 

--- a/apiserver/paasng/paasng/plat_admin/admin_cli/management/commands/adm_mapper_v1.py
+++ b/apiserver/paasng/paasng/plat_admin/admin_cli/management/commands/adm_mapper_v1.py
@@ -30,6 +30,7 @@ from paas_wl.bk_app.applications.api import get_latest_build_id
 from paas_wl.bk_app.applications.models.managers.app_metadata import get_metadata, update_metadata
 from paas_wl.bk_app.applications.models.release import Release
 from paas_wl.bk_app.deploy.app_res.utils import get_scheduler_client_by_app
+from paas_wl.infras.resources.generation.mapper import get_mapper_proc_config_latest
 from paasng.plat_admin.admin_cli.cmd_utils import CommandBasicMixin
 from paasng.plat_admin.admin_cli.deploy import list_proc_types, refresh_services, wait_for_release
 from paasng.platform.applications.models import ModuleEnvironment
@@ -127,7 +128,8 @@ class Command(BaseCommand, CommandBasicMixin):
         s_client = get_scheduler_client_by_app(env.wl_app)
         for proc_type in list_proc_types(env):
             self.print(f"Deleting process: {proc_type}...")
-            s_client.processes_handler.delete_gracefully(wl_app, proc_type)
+            proc_config = get_mapper_proc_config_latest(wl_app, proc_type)
+            s_client.processes_handler.delete_gracefully(proc_config)
 
         # TODO: Check if v1 workload resources are still there, if not, report error and quit.
         self.print("Refreshing service resources, requests will be forwarded to older workloads...")
@@ -147,6 +149,7 @@ class Command(BaseCommand, CommandBasicMixin):
             s_client = get_scheduler_client_by_app(env.wl_app)
             for proc_type in list_proc_types(env):
                 self.print(f"Deleting process: {proc_type}...")
-                s_client.processes_handler.delete_gracefully(wl_app, proc_type)
+                proc_config = get_mapper_proc_config_latest(wl_app, proc_type)
+                s_client.processes_handler.delete_gracefully(proc_config)
         finally:
             update_metadata(wl_app, mapper_version=old_version)

--- a/apiserver/paasng/tests/paas_wl/bk_app/deploy/actions/test_deploy.py
+++ b/apiserver/paasng/tests/paas_wl/bk_app/deploy/actions/test_deploy.py
@@ -18,65 +18,81 @@ to the current version of the project delivered to anyone in the future.
 """
 import pytest
 
-from paas_wl.bk_app.deploy.actions.deploy import ZombieProcessesKiller
+from paas_wl.bk_app.applications.models.managers.app_metadata import update_metadata
+from paas_wl.bk_app.deploy.actions.deploy import ObsoleteProcessesCleaner
 from tests.paas_wl.utils.wl_app import create_wl_release
 
 pytestmark = pytest.mark.django_db(databases=["default", "workloads"])
 
 
-class TestZombieProcessesKiller:
+class TestObsoleteProcessesCleaner:
     @pytest.mark.parametrize(
-        ("last_procfile", "latest_procfile", "diff"),
+        ("prev_procfile", "curr_procfile", "expected_diff"),
         [
-            ({"web": "command -x -z -y"}, {"web1": "command -x -z -y"}, {"types": ["web"], "names": []}),
+            # Unchanged proc lists
+            ({"web": "command -x", "worker": "command -x"}, {"web": "command -x", "worker": "command -x"}, []),
+            # Single proc that changes proc type
+            ({"web": "command -x"}, {"worker": "command -x"}, [("web", True)]),
+            # multiple procs that been replaced all
             (
-                {"web": "command -x -z -y", "web1": "command -x -z -y"},
-                {"web": "command2 -x -z -y"},
-                {"types": ["web1"], "names": ["web"]},
+                {"web": "command -x", "worker": "command -x"},
+                {"new-web": "command -x", "new-worker": "command -x"},
+                [("web", True), ("worker", True)],
             ),
-            (
-                {"web": "command -x -z -y", "web1": "command -x -z -y"},
-                {"web": "command2 -x -z -y", "web1": "command3 -x -z -y"},
-                {"types": [], "names": ["web", "web1"]},
-            ),
-            (
-                {
-                    "web": "gunicorn1 wsgi -w 4 -b :$PORT --access-logfile - "
-                    "--error-logfile - --access-logformat '[%(h)s] "
-                    '%({request_id}i)s %(u)s %(t)s "%(r)s" %(s)s %(D)s %(b)s "%(f)s" "%(a)s"\''
-                },
-                {
-                    "web": "gunicorn wsgi -w 4 -b :$PORT --access-logfile - "
-                    "--error-logfile - --access-logformat '[%(h)s] "
-                    '%({request_id}i)s %(u)s %(t)s "%(r)s" %(s)s %(D)s %(b)s "%(f)s" "%(a)s"\''
-                },
-                {"types": [], "names": ["web"]},
-            ),
-            (
-                {"web": "command -x -z -y", "web1": "command -x -z -y"},
-                {"web": "command -x -z -y", "web1": "command -x -z -y"},
-                {"types": [], "names": []},
-            ),
-            (
-                {"web": "command -x -z -y", "web1": "command -x -z -y"},
-                {"web2": "command -x -z -y", "web3": "command -x -z -y"},
-                {"types": ["web", "web1"], "names": []},
-            ),
+            # Multiple procs that change command
+            ({"web": "command -x", "worker": "command -x"}, {"web": "new-command -x", "worker": "new-command -x"}, []),
+            # A mixed that has changed command, the proc that has different command should
+            # has been ignored because mapper v2 does not depends on it when constructing
+            # resource names.
+            ({"web": "command -x", "worker": "command -x"}, {"web": "new_command -x"}, [("worker", True)]),
         ],
     )
-    def test_search(self, wl_app, latest_procfile, last_procfile, diff):
-        last_release = create_wl_release(wl_app, build_params={"procfile": last_procfile})
-        latest_release = create_wl_release(
+    def test_find_all_latest_mapper_v2(self, wl_app, curr_procfile, prev_procfile, expected_diff):
+        update_metadata(wl_app, mapper_version="v2")
+        prev_release = create_wl_release(wl_app, build_params={"procfile": prev_procfile})
+        curr_release = create_wl_release(
             wl_app,
-            build_params={"procfile": latest_procfile},
-            release_params={"version": last_release.version + 1},
+            build_params={"procfile": curr_procfile},
+            release_params={"version": prev_release.version + 1},
         )
+        proc_cleaner = ObsoleteProcessesCleaner(curr_release, prev_release)
+        self._assert_equal_find_all_results(proc_cleaner.find_all(), expected_diff)
 
-        killer = ZombieProcessesKiller(release=latest_release, last_release=last_release)
-        types, names = killer.search()
+    @pytest.mark.parametrize(
+        ("prev_procfile", "curr_procfile", "expected_diff"),
+        [
+            # Single proc that changes proc type
+            ({"web": "command -x"}, {"worker": "command -x"}, [("web", True)]),
+            # A mixed that has changed command
+            (
+                {"web": "command -x", "worker": "command -x"},
+                {"web": "new_command -x"},
+                [("web", False), ("worker", True)],
+            ),
+            # Multiple procs that change command
+            (
+                {"web": "command -x", "worker": "command -x"},
+                {"web": "new-command -x", "worker": "new-command -x"},
+                [("web", False), ("worker", False)],
+            ),
+            # Multiple procs that change arguments only
+            ({"web": "command -x", "worker": "command -x"}, {"web": "command -y", "worker": "command -y"}, []),
+        ],
+    )
+    def test_find_all_latest_mapper_v1(self, wl_app, curr_procfile, prev_procfile, expected_diff):
+        update_metadata(wl_app, mapper_version="v1")
+        prev_release = create_wl_release(wl_app, build_params={"procfile": prev_procfile})
+        curr_release = create_wl_release(
+            wl_app,
+            build_params={"procfile": curr_procfile},
+            release_params={"version": prev_release.version + 1},
+        )
+        proc_cleaner = ObsoleteProcessesCleaner(curr_release, prev_release)
+        self._assert_equal_find_all_results(proc_cleaner.find_all(), expected_diff)
 
-        assert len(types) == len(diff["types"])
-        assert len(names) == len(diff["names"])
-
-        assert {x.type for x in types} == set(diff["types"])
-        assert {x.type for x in names} == set(diff["names"])
+    @staticmethod
+    def _assert_equal_find_all_results(results, simplified_diff):
+        """A helper function to compare find_all results."""
+        sim_results = [(cfg.type, should_remove_svc) for cfg, should_remove_svc in results]
+        sim_results.sort()
+        assert sim_results == simplified_diff

--- a/apiserver/paasng/tests/paas_wl/bk_app/deploy/app_res/test_controllers.py
+++ b/apiserver/paasng/tests/paas_wl/bk_app/deploy/app_res/test_controllers.py
@@ -16,21 +16,29 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+from dataclasses import make_dataclass
 from textwrap import dedent
+from unittest.mock import Mock, patch
 
 import pytest
+from django.conf import settings
 from django_dynamic_fixture import G
 
-from paas_wl.bk_app.deploy.app_res.controllers import CommandHandler
+from paas_wl.bk_app.deploy.app_res.controllers import CommandHandler, ProcessesHandler
+from paas_wl.bk_app.processes.managers import AppProcessManager
 from paas_wl.infras.resource_templates.constants import AppAddOnType
 from paas_wl.infras.resource_templates.models import AppAddOnTemplate
 from paas_wl.infras.resources.base.exceptions import PodTimeoutError
+from paas_wl.infras.resources.generation.mapper import get_mapper_proc_config_latest
+from paas_wl.infras.resources.generation.version import AppResVerManager
 from paas_wl.infras.resources.kube_res.exceptions import AppEntityNotFound
 from paas_wl.workloads.release_controller.constants import ImagePullPolicy
 from paas_wl.workloads.release_controller.hooks.kres_entities import Command, command_kmodel
 from paas_wl.workloads.release_controller.hooks.models import Command as CommandModel
 
 pytestmark = pytest.mark.django_db(databases=["default", "workloads"])
+
+region = settings.DEFAULT_REGION_NAME
 
 
 @pytest.mark.auto_create_ns()
@@ -117,3 +125,119 @@ class TestCommand:
         waitable.wait(60)
         with pytest.raises(AppEntityNotFound):
             command_kmodel.get(command.app, command.name)
+
+
+class TestProcessHandler:
+    @pytest.fixture(autouse=True)
+    def _set_res_version(self, wl_app, wl_release):
+        AppResVerManager(wl_app).update("v1")
+
+    @pytest.fixture()
+    def web_process(self, wl_app, wl_release):
+        return AppProcessManager(app=wl_app).assemble_process("web", release=wl_release)
+
+    @pytest.fixture()
+    def worker_process(self, wl_app, wl_release):
+        return AppProcessManager(app=wl_app).assemble_process("worker", release=wl_release)
+
+    @pytest.mark.mock_get_structured_app()
+    def test_deploy_processes(self, wl_app, web_process):
+        handler = ProcessesHandler.new_by_app(wl_app)
+        with patch("paas_wl.infras.resources.base.kres.NameBasedOperations.replace_or_patch") as kd, patch(
+            "paas_wl.workloads.networking.ingress.managers.service.service_kmodel"
+        ) as ks, patch("paas_wl.workloads.networking.ingress.managers.base.ingress_kmodel") as ki:
+            ks.get.side_effect = AppEntityNotFound()
+            ki.get.side_effect = AppEntityNotFound()
+
+            handler.deploy([web_process])
+
+            # Check deployment resource
+            assert kd.called
+            deployment_args, deployment_kwargs = kd.call_args_list[0]
+            assert deployment_kwargs.get("name") == f"{region}-{wl_app.name}-web-python-deployment"
+            assert deployment_kwargs.get("body")
+            assert deployment_kwargs.get("namespace") == wl_app.namespace
+
+            # Check service resource
+            assert ks.get.called
+            assert ks.create.called
+            proc_service = ks.create.call_args_list[0][0][0]
+            assert proc_service.name == f"{region}-{wl_app.name}-web"
+
+            # Check ingress resource
+            assert ks.get.called
+            assert ki.save.called
+            proc_ingress = ki.save.call_args_list[0][0][0]
+            assert proc_ingress.name == f"{region}-{wl_app.name}"
+
+    def test_scale_process(self, wl_app):
+        handler = ProcessesHandler.new_by_app(wl_app)
+        with patch("paas_wl.infras.resources.base.kres.NameBasedOperations.patch") as kp, patch(
+            "paas_wl.workloads.networking.ingress.managers.service.service_kmodel"
+        ) as ks:
+            proc_config = get_mapper_proc_config_latest(wl_app, "worker")
+            handler.scale(proc_config, 3)
+
+            # Test service patch was performed
+            assert ks.get.called
+            assert not ks.create.called
+
+            # Test deployment patch was performed
+            assert kp.called
+            args, kwargs = kp.call_args_list[0]
+            assert kwargs.get("body")["spec"]["replicas"] == 3
+
+    def test_shutdown_process(self, wl_app):
+        handler = ProcessesHandler.new_by_app(wl_app)
+        d_spec = make_dataclass("Dspec", [("replicas", int)])
+        d_body = make_dataclass("DBody", [("spec", d_spec)])
+        kg = Mock(return_value=d_body(spec=d_spec(replicas=1)))
+
+        with patch("paas_wl.infras.resources.base.kres.NameBasedOperations.patch") as kp, patch(
+            "paas_wl.workloads.networking.ingress.managers.service.service_kmodel"
+        ) as ks, patch("paas_wl.workloads.networking.ingress.managers.base.ingress_kmodel") as ki, patch(
+            "paas_wl.infras.resources.base.kres.NameBasedOperations.get", kg
+        ):
+            proc_config = get_mapper_proc_config_latest(wl_app, "worker")
+            handler.shutdown(proc_config)
+
+            # 测试: 不删除 Service
+            assert not ks.delete_by_name.called
+
+            # 测试: 不删除 Ingress
+            assert not ki.delete_by_name.called
+
+            # Check deployment resource
+            assert kp.called
+            args, kwargs = kp.call_args_list[0]
+            assert kwargs["body"]["spec"]["replicas"] == 0
+
+    def test_shutdown_web_processes(self, wl_app, web_process):
+        handler = ProcessesHandler.new_by_app(wl_app)
+        d_spec = make_dataclass("Dspec", [("replicas", int)])
+        d_body = make_dataclass("DBody", [("spec", d_spec)])
+        kg = Mock(return_value=d_body(spec=d_spec(replicas=1)))
+
+        with patch("paas_wl.infras.resources.base.kres.NameBasedOperations.patch") as kp, patch(
+            "paas_wl.workloads.networking.ingress.managers.service.service_kmodel"
+        ) as ks, patch("paas_wl.workloads.networking.ingress.managers.base.ingress_kmodel") as ki, patch(
+            "paas_wl.infras.resources.base.kres.NameBasedOperations.get", kg
+        ):
+            # Make ingress point to web service
+            faked_ingress = Mock()
+            faked_ingress.configure_mock(service_name=f"{region}-{wl_app.name}-web")
+            ki.get.return_value = faked_ingress
+
+            proc_config = get_mapper_proc_config_latest(wl_app, "worker")
+            handler.shutdown(proc_config)
+
+            # 测试: 不删除 Service
+            assert not ks.delete_by_name.called
+
+            # 测试: 不删除 Ingress
+            assert not ki.delete_by_name.called
+
+            # Check deployment resource
+            assert kp.called
+            args, kwargs = kp.call_args_list[0]
+            assert kwargs["body"]["spec"]["replicas"] == 0

--- a/apiserver/paasng/tests/paas_wl/bk_app/deploy/app_res/test_controllers.py
+++ b/apiserver/paasng/tests/paas_wl/bk_app/deploy/app_res/test_controllers.py
@@ -25,7 +25,6 @@ from paas_wl.bk_app.deploy.app_res.controllers import CommandHandler
 from paas_wl.infras.resource_templates.constants import AppAddOnType
 from paas_wl.infras.resource_templates.models import AppAddOnTemplate
 from paas_wl.infras.resources.base.exceptions import PodTimeoutError
-from paas_wl.infras.resources.generation.version import get_mapper_version
 from paas_wl.infras.resources.kube_res.exceptions import AppEntityNotFound
 from paas_wl.workloads.release_controller.constants import ImagePullPolicy
 from paas_wl.workloads.release_controller.hooks.kres_entities import Command, command_kmodel
@@ -64,14 +63,7 @@ class TestCommand:
 
     @pytest.fixture()
     def handler(self, k8s_client, settings):
-        return CommandHandler(
-            client=k8s_client,
-            default_connect_timeout=settings.K8S_DEFAULT_CONNECT_TIMEOUT,
-            default_request_timeout=settings.K8S_DEFAULT_CONNECT_TIMEOUT + settings.K8S_DEFAULT_READ_TIMEOUT,
-            mapper_version=get_mapper_version(
-                target=settings.GLOBAL_DEFAULT_MAPPER_VERSION, init_kwargs={"client": k8s_client}
-            ),
-        )
+        return CommandHandler(client=k8s_client)
 
     def test_run(self, handler, command):
         with pytest.raises(AppEntityNotFound):

--- a/apiserver/paasng/tests/paas_wl/bk_app/processes/test_controllers.py
+++ b/apiserver/paasng/tests/paas_wl/bk_app/processes/test_controllers.py
@@ -45,7 +45,7 @@ def make_process(wl_app: WlApp, process_type: str) -> Process:
             args=[],
         ),
     )
-    process.name = AppResVerManager(wl_app).curr_version.deployment(process).name
+    process.name = AppResVerManager(wl_app).curr_version.proc_resources(process).deployment_name
     return process
 
 

--- a/apiserver/paasng/tests/paas_wl/bk_app/processes/test_managers.py
+++ b/apiserver/paasng/tests/paas_wl/bk_app/processes/test_managers.py
@@ -69,12 +69,12 @@ class TestProcInstManager:
 
     @pytest.fixture()
     def pod(self, wl_app, release, client, process_manager, process, v2_mapper):
-        pod_name = v2_mapper.pod(process=process).name
+        pod_name = v2_mapper.proc_resources(process=process).pod_name
         serializer = process_manager._make_serializer(wl_app)
         pod_body = {
             "apiVersion": "v1",
             "kind": "Pod",
-            "metadata": {"labels": v2_mapper.pod(process=process).labels, "name": pod_name},
+            "metadata": {"labels": v2_mapper.proc_resources(process=process).labels, "name": pod_name},
             "spec": serializer._construct_pod_body_specs(process),  # type: ignore
         }
         pod, _ = KPod(client).create_or_update(name=pod_name, namespace=process.app.namespace, body=pod_body)
@@ -141,7 +141,7 @@ class TestProcInstManager:
         assert len(events) > 0
 
     def test_watch_unknown_res(self, wl_app, client, process_manager, process, v2_mapper):
-        pod_name = v2_mapper.pod(process=process).name
+        pod_name = v2_mapper.proc_resources(process=process).pod_name
         serializer = process_manager._make_serializer(wl_app)
         pod_body = {
             "apiVersion": "v1",

--- a/apiserver/paasng/tests/paas_wl/infras/cluster/test_utils.py
+++ b/apiserver/paasng/tests/paas_wl/infras/cluster/test_utils.py
@@ -16,8 +16,6 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-from unittest import mock
-
 import pytest
 
 from paas_wl.infras.cluster.models import Cluster
@@ -52,15 +50,6 @@ class TestGetClusterByApp:
         ]
         for cluster in clusters:
             Cluster.objects.register_cluster(**cluster)
-
-        # 由于注册集群到 DB 后，未能刷新 _k8s_global_configuration_pool_map，
-        # 导致创建 WlApp 后触发的信号处理逻辑中，无法获取到集群的 context，因此抛出 ValueError
-        # 考虑到本处不获取集群 client，并不影响当前测试，因此通过 mock 处理
-        with mock.patch(
-            "paas_wl.infras.resources.generation.version.get_client_by_app",
-            return_value=None,
-        ):
-            yield
 
     def test_get_cluster_by_app_normal(self):
         app = create_wl_app(force_app_info={"region": "region-2"})

--- a/apiserver/paasng/tests/paas_wl/infras/resources/generation/test_generation.py
+++ b/apiserver/paasng/tests/paas_wl/infras/resources/generation/test_generation.py
@@ -49,24 +49,33 @@ class TestGeneration:
 
     def test_v1_pod_name(self, v1_mapper, process):
         assert (
-            v1_mapper.pod(process=process).name == f"{process.app.region}-{process.app.scheduler_safe_name}-"
+            v1_mapper.proc_resources(process=process).pod_name
+            == f"{process.app.region}-{process.app.scheduler_safe_name}-"
             f"{process.type}-{get_command_name(process.runtime.proc_command)}-deployment"
         )
 
         assert (
-            v1_mapper.deployment(process=process).name == f"{process.app.region}-{process.app.scheduler_safe_name}-"
+            v1_mapper.proc_resources(process=process).deployment_name
+            == f"{process.app.region}-{process.app.scheduler_safe_name}-"
             f"{process.type}-{get_command_name(process.runtime.proc_command)}-deployment"
         )
 
     def test_preset_process_client(self, wl_app, process, v1_mapper):
         assert (
-            v1_mapper.pod(process=process).name == f"{process.app.region}-{process.app.scheduler_safe_name}-"
+            v1_mapper.proc_resources(process=process).pod_name
+            == f"{process.app.region}-{process.app.scheduler_safe_name}-"
             f"{process.type}-{get_command_name(process.runtime.proc_command)}-deployment"
         )
 
     def test_v2_name(self, process, v2_mapper):
-        assert v2_mapper.pod(process=process).name == f"{process.app.name.replace('_', '0us0')}--{process.type}"
-        assert v2_mapper.deployment(process=process).name == f"{process.app.name.replace('_', '0us0')}--{process.type}"
+        assert (
+            v2_mapper.proc_resources(process=process).pod_name
+            == f"{process.app.name.replace('_', '0us0')}--{process.type}"
+        )
+        assert (
+            v2_mapper.proc_resources(process=process).deployment_name
+            == f"{process.app.name.replace('_', '0us0')}--{process.type}"
+        )
 
 
 def test_get_proc_deployment_name(wl_app):


### PR DESCRIPTION
- Fix: Unable to delete obsolete process when deploying an archived application
- Refactor: Refactor the obsolete processes cleaner for better clarity
- Refactor: Simplify the generation module by deleting some unnecessary abstractions
- Refactor: Remove process-related operation from SchedulerClient