### PR TITLE
enhance: add "type" field in latest operated applications API

### DIFF
--- a/apiserver/paasng/paasng/platform/applications/serializers/app.py
+++ b/apiserver/paasng/paasng/platform/applications/serializers/app.py
@@ -279,7 +279,7 @@ class ApplicationSLZ4Record(serializers.ModelSerializer):
 
     class Meta:
         model = Application
-        fields = ["id", "code", "name", "logo_url", "config_info"]
+        fields = ["id", "type", "code", "name", "logo_url", "config_info"]
 
 
 class MarketAppMinimalSLZ(serializers.Serializer):


### PR DESCRIPTION
- Add "type" field to the "/applications/lists/latest/" API so that the web frontend can know what type of navigation to use, this fixes a bug where hitting the "back" button on the cloud-native application page doesn't work as intended. @leafage-collb 