### PR TITLE
Fix buildpack go

### DIFF
--- a/builder-stack/heroku-buildpacks/bk-buildpack-go/hooks/post-compile
+++ b/builder-stack/heroku-buildpacks/bk-buildpack-go/hooks/post-compile
@@ -2,26 +2,9 @@
 # 在 bin/compile 命令最后注入
 
 declare build
-export GOPATH="${GOPATH:-${HOME}/go}"
 
 # post-compile 钩子调用保证能够找到编译后文件
-env PATH="${GOPATH}/bin:${PATH}:${build}/bin" ${buildpack}/hooks/run_hook "post-compile" "${build}" "bin/post-compile"
-
-# 将 GOPATH 的二进制复制到构建目录 go/bin 中
-mkdir -p "${GOPATH}/bin"
-gopath_bin=$(realpath "${GOPATH}/bin")
-mkdir -p "go/bin"
-go_bin=$(realpath "go/bin")
-if [ "${gopath_bin}" != "${go_bin}" ]; then
-    cp -u "${gopath_bin}"/* "${go_bin}" || true
-fi
-
-# 设置 ~/go 为运行时 GOPATH
-mkdir -p "${build}/.profile.d"
-cat > "${build}/.profile.d/gopath.sh" << EOF
-GOPATH=\$HOME/go
-PATH=\$PATH:\$GOPATH/bin:\$HOME/bin
-EOF
+env PATH="${build}/bin:${PATH}" ${buildpack}/hooks/run_hook "post-compile" "${build}" "bin/post-compile"
 
 # 清理代码文件以减少 slug 包体积
 if [ "${WITH_CODE_FILES}" != "1" ]; then

--- a/builder-stack/heroku-buildpacks/bk-buildpack-go/hooks/pre-compile
+++ b/builder-stack/heroku-buildpacks/bk-buildpack-go/hooks/pre-compile
@@ -4,23 +4,6 @@
 
 declare build
 
-# beego migration 目录需要使用 bee 命令编译
-# 使用 go mod 不指定入口会错误对 beego migration 进行编译导致失败
-# 框架提供的入口都是应用名，如果有特殊的，指定 GO_INSTALL_PACKAGE_SPEC 即可
-if [ "${GO_BKAPP_FRAMEWORK}" == "1" ] && [ -z "${GO_INSTALL_PACKAGE_SPEC}" ]; then
-    GO_INSTALL_PACKAGE_SPEC=${BKPAAS_APP_ID}
-    export GO_INSTALL_PACKAGE_SPEC
-fi
-
-# heroku buildpack 通过识别 go.mod 文件中类似：// +heroku goVersion go1.11
-# 这样的格式的注释来识别具体指定的 go 版本，但是事实上，go.mod 已经有类似：go 1.14
-# 这样的格式来描述版本信息，因此需要修改对应的规则：
-# 1. 如果指定了 GOVERSION 环境变量，使用该版本
-# 2. 如果 go.mod 有版本信息，使用该版本
-# 3. 如果 go.mod 有 +heroku goVersion 注释，使用该版本
-# 4. 使用默认版本
-sed -i "/info \"Detected go modules via go.mod\"/a GOVERSION=\${GOVERSION:-\$(awk '{ if (\$1 == \"go\" ) { print \$2; exit } }' \${goMOD})}" "${buildpack}/lib/common.sh"
-
 # 修复不正确的缩进
 sed -i 's/echo -e "\${GREEN}       \$@\${NC}"/echo -e "\${GREEN}\$@\${NC}"/' "${buildpack}/lib/common.sh"
 sed -i 's/echo -e "\${YELLOW} !!    \$@\${NC}"/echo -e "\${YELLOW}!! \$@\${NC}"/' "${buildpack}/lib/common.sh"
@@ -30,7 +13,7 @@ sed -i 's/echo -e >\&2 "\${RED} !!    \$@\${NC}"/echo -e >\&2 "\${RED}!! \$@\${N
 sed -i '/setGitCredHelper() {/a \    return' "${buildpack}/lib/common.sh"
 sed -i '/clearGitCredHelper() {/a \    return' "${buildpack}/lib/common.sh"
 
-# 创建到 /tmp/build 的软链接，兼容旧版应用
+# 创建到 /tmp/build 的软链接，兼容 legacy-builder(PaaS V2)
 if [ ! -e /tmp/build ]; then
     ln -sf "${build}" /tmp/build
 fi

--- a/builder-stack/heroku-buildpacks/bk-buildpack-go/patchs/buildpack/bin/compile.patch
+++ b/builder-stack/heroku-buildpacks/bk-buildpack-go/patchs/buildpack/bin/compile.patch
@@ -1,6 +1,7 @@
-13a14
+13a14,15
 > source "${buildpack}/hooks/pre-compile"
-428,429c429,437
+> 
+428,429c430,438
 <   # For an explanation of what this is doing, see https://dave.cheney.net/2014/09/14/go-list-your-swiss-army-knife
 <   go list -find "${FLAGS[@]}" -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./...
 ---
@@ -13,7 +14,6 @@
 >     # For an explanation of what this is doing, see https://dave.cheney.net/2014/09/14/go-list-your-swiss-army-knife
 >     go list -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./...
 >   fi
-718a727,728
+718a728,729
 > 
 > source "${buildpack}/hooks/post-compile"
-\ No newline at end of file

--- a/builder-stack/heroku-buildpacks/bk-buildpack-go/patchs/buildpack/bin/compile.patch
+++ b/builder-stack/heroku-buildpacks/bk-buildpack-go/patchs/buildpack/bin/compile.patch
@@ -1,18 +1,19 @@
 13a14
 > source "${buildpack}/hooks/pre-compile"
-422a424,425
-> 
-> source "${buildpack}/hooks/pre-gobuild"
-470,477d472
-<         export GOBIN="${build}/bin"
-<         if [ "${GO_SETUP_GOPATH_FOR_MODULE_CACHE}" = "true" ]; then
-<             export GOPATH="${build}/.heroku/go-path"
-<             mkdir -p $GOPATH # ensure that it's created
-<         else
-<             export GOPATH="${cache}/go-path"
-<         fi
-< 
-718a714,715
+428,429c429,437
+<   # For an explanation of what this is doing, see https://dave.cheney.net/2014/09/14/go-list-your-swiss-army-knife
+<   go list -find "${FLAGS[@]}" -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./...
+---
+>   # beego migration 目录需要使用 bee 命令编译(否则必然构建失败)
+>   # 使用 go mod 不指定入口会遍历所有 package main, 导致错误对 beego migration 进行编译
+>   # 因此对于 beego 框架, 如未指定 GO_INSTALL_PACKAGE_SPEC, 默认使用应用名作为构建入口
+>   if [ "${GO_BKAPP_FRAMEWORK}" == "1" ] && [ -z "${GO_INSTALL_PACKAGE_SPEC}" ]; then
+>     echo ${BKPAAS_APP_ID}
+>   elif
+>     # For an explanation of what this is doing, see https://dave.cheney.net/2014/09/14/go-list-your-swiss-army-knife
+>     go list -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./...
+>   fi
+718a727,728
 > 
 > source "${buildpack}/hooks/post-compile"
 \ No newline at end of file

--- a/builder-stack/heroku-buildpacks/bk-buildpack-go/patchs/buildpack/bin/compile.patch
+++ b/builder-stack/heroku-buildpacks/bk-buildpack-go/patchs/buildpack/bin/compile.patch
@@ -9,7 +9,7 @@
 >   # 因此对于 beego 框架, 如未指定 GO_INSTALL_PACKAGE_SPEC, 默认使用应用名作为构建入口
 >   if [ "${GO_BKAPP_FRAMEWORK}" == "1" ] && [ -z "${GO_INSTALL_PACKAGE_SPEC}" ]; then
 >     echo ${BKPAAS_APP_ID}
->   elif
+>   else
 >     # For an explanation of what this is doing, see https://dave.cheney.net/2014/09/14/go-list-your-swiss-army-knife
 >     go list -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./...
 >   fi


### PR DESCRIPTION
- refactor: 移除对 GOVERSION 探测的 patch(buildpack 本身已有相关逻辑)
- refactor: 移除意义不明的 patch 代码
- fix: go 语言的 buildpack 在构建后期会输出大量无法删除的权限错误