### PR TITLE
feat: 添加 FeatureFlag 用于前端控制镜像应用是否能绑定源码信息

### DIFF
--- a/apiserver/paasng/paasng/misc/feature_flags/constants.py
+++ b/apiserver/paasng/paasng/misc/feature_flags/constants.py
@@ -37,3 +37,7 @@ class PlatformFeatureFlag(FeatureFlag):  # type: ignore
         label="创建与使用“蓝鲸插件”类型应用", default=settings.IS_ALLOW_CREATE_BK_PLUGIN_APP
     )
     BK_NOTICE = FeatureFlagField(label="蓝鲸通知公告服务", default=settings.ENABLE_BK_NOTICE)
+    # 是否允许镜像应用绑定源码仓库，目前绑定仅用于 Hompage
+    ENABLE_IMAGE_APP_BIND_REPO = FeatureFlagField(
+        label="镜像应用绑定源码仓库", default=settings.ENABLE_IMAGE_APP_BIND_REPO
+    )

--- a/apiserver/paasng/paasng/settings/__init__.py
+++ b/apiserver/paasng/paasng/settings/__init__.py
@@ -1189,6 +1189,8 @@ DOCKER_REGISTRY_CONFIG = settings.get(
     "DOCKER_REGISTRY_CONFIG", {"DEFAULT_REGISTRY": "https://hub.docker.com", "ALLOW_THIRD_PARTY_REGISTRY": False}
 )
 
+ENABLE_IMAGE_APP_BIND_REPO = settings.get("ENABLE_IMAGE_APP_BIND_REPO", False)
+
 # -----------------
 # 插件开发中心配置项
 # -----------------

--- a/webfe/package_vue/index.html
+++ b/webfe/package_vue/index.html
@@ -23,7 +23,7 @@
       var BK_APIGW_DOC_URL = '<%= process.env.BK_APIGW_DOC_URL %>' || ''
       var BK_COMPONENT_API_URL = '<%= process.env.BK_COMPONENT_API_URL %>' || ''
       var BK_ANALYSIS_JS = '<%= process.env.BK_ANALYSIS_JS %>' || ''
-      var DOCS_URL_PREFIX = `<%= process.env.BK_DOCS_URL_PREFIX %>/markdown/PaaS3.0`
+      var DOCS_URL_PREFIX = `<%= process.env.BK_DOCS_URL_PREFIX %>/markdown/PaaS/DevelopTools/BaseGuide`
       var BK_STATIC_URL = '<%= process.env.BK_STATIC_URL %>' || ''
       var BK_PAAS_VERSION = '<%= process.env.BK_PAAS_VERSION %>' || ''
       var GLOBAL_CONFIG = {


### PR DESCRIPTION
绑定功能可使用源码应用已有的 API，并测试了镜像应用绑定源码后各项功能均正常。但该功能仅在特定版本启用，所以需要提供 FeatureFlag 给前端。