### PR TITLE
Update APIs which starts with "/svc_workloads/" to remove the prefix

### DIFF
--- a/apiserver/paasng/paas_wl/bk_app/processes/urls.py
+++ b/apiserver/paasng/paas_wl/bk_app/processes/urls.py
@@ -37,7 +37,8 @@ urlpatterns = [
         views.ProcessesViewSet.as_view({"post": "update"}),
         name="api.processes.update",
     ),
-    # Cloud-native type application
+    # Cloud-native type application, list and watch processes of an environment, the result
+    # include multiple modules.
     re_path(
         r"api/bkapps/applications/(?P<code>[^/]+)/envs/(?P<environment>stag|prod)/processes/list/$",
         views.CNativeListAndWatchProcsViewSet.as_view({"get": "list"}),
@@ -50,21 +51,24 @@ urlpatterns = [
     ),
     # Below paths using legacy prefix.
     #
-    # TODO: This path a duplication with "api.processes.update", should be removed in the future.
+    # Default type application, list and watch processes of an environment, the result
+    # only include one module.
     re_path(
-        make_app_pattern_legacy_wl(r"/processes/$"),
-        views.ProcessesViewSet.as_view({"post": "update"}),
-        name="api.processes",
-    ),
-    # Default type application
-    re_path(
-        make_app_pattern_legacy_wl(r"/processes/list/$"),
+        make_app_pattern(r"/processes/list/$"),
         views.ListAndWatchProcsViewSet.as_view({"get": "list"}),
         name="api.list_processes",
     ),
     re_path(
-        make_app_pattern_legacy_wl(r"/processes/watch/$"),
+        make_app_pattern(r"/processes/watch/$"),
         views.ListAndWatchProcsViewSet.as_view({"get": "watch"}),
         name="api.watch_processes",
+    ),
+    # The list API with "/svc_workloads/" prefix has been registered in the API Gateway,
+    # So we will leave it as is until we modify the API Gateway config in the future.
+    # TODO: Remove this API.
+    re_path(
+        make_app_pattern_legacy_wl(r"/processes/list/$"),
+        views.ListAndWatchProcsViewSet.as_view({"get": "list"}),
+        name="api.list_processes",
     ),
 ]

--- a/apiserver/paasng/paas_wl/workloads/images/urls.py
+++ b/apiserver/paasng/paas_wl/workloads/images/urls.py
@@ -20,26 +20,14 @@ from django.urls import path
 
 from . import views
 
-
-# In legacy architecture, all workloads's APIs starts with a fixed prefix "/svc_workloads" and use
-# a slightly different format. While the prefix is not required in the new architecture, we have
-# to keep it to maintain backward-compatibility.
-#
-# This function helps up to build paths with the legacy prefix.
-#
-# TODO: Remove the 'svc_workloads' prefix and clean up the URL paths.
-def make_app_pattern_legacy_wl(suffix: str) -> str:
-    return r"svc_workloads/api/credentials/" + suffix
-
-
 urlpatterns = [
     path(
-        make_app_pattern_legacy_wl("applications/<str:code>/image_credentials/"),
+        "api/bkapps/applications/<str:code>/image_credentials/",
         views.AppUserCredentialViewSet.as_view({"get": "list", "post": "create"}),
         name="api.applications.image_credentials",
     ),
     path(
-        make_app_pattern_legacy_wl("applications/<str:code>/image_credentials/<str:name>"),
+        "api/bkapps/applications/<str:code>/image_credentials/<str:name>",
         views.AppUserCredentialViewSet.as_view({"put": "update", "delete": "destroy"}),
         name="api.applications.image_credentials.detail",
     ),

--- a/apiserver/paasng/paas_wl/workloads/networking/egress/urls.py
+++ b/apiserver/paasng/paas_wl/workloads/networking/egress/urls.py
@@ -16,30 +16,18 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-from functools import partial
-
 from paasng.utils.basic import make_app_pattern, re_path
 
 from . import views
 
-# In legacy architecture, all workloads's APIs starts with a fixed prefix "/svc_workloads" and use
-# a slightly different format. While the prefix is not required in the new architecture, we have
-# to keep it to maintain backward-compatibility.
-#
-# This function helps up to build paths with the legacy prefix.
-#
-# TODO: Remove the 'svc_workloads' prefix and clean up the URL paths.
-make_app_pattern_legacy_wl = partial(make_app_pattern, prefix="svc_workloads/api/scheduling/applications/")
-
-
 urlpatterns = [
     re_path(
-        make_app_pattern_legacy_wl(r"/egress_gateway_infos/$"),
+        make_app_pattern(r"/egress_gateway_infos/$"),
         views.EgressGatewayInfosViewSet.as_view({"post": "create"}),
         name="api.egress_gateway_infos",
     ),
     re_path(
-        make_app_pattern_legacy_wl(r"/egress_gateway_infos/default/$"),
+        make_app_pattern(r"/egress_gateway_infos/default/$"),
         views.EgressGatewayInfosViewSet.as_view({"get": "retrieve", "delete": "destroy"}),
         name="api.egress_gateway_infos.default",
     ),

--- a/apiserver/paasng/paas_wl/workloads/networking/entrance/urls.py
+++ b/apiserver/paasng/paas_wl/workloads/networking/entrance/urls.py
@@ -20,18 +20,6 @@ from paasng.utils.basic import re_path
 
 from . import views
 
-
-# In legacy architecture, all workloads's APIs starts with a fixed prefix "/svc_workloads" and use
-# a slightly different format. While the prefix is not required in the new architecture, we have
-# to keep it to maintain backward-compatibility.
-#
-# This function helps up to build paths with the legacy prefix.
-#
-# TODO: Remove the 'svc_workloads' prefix and clean up the URL paths.
-def make_app_pattern_legacy_wl(suffix: str) -> str:
-    return r"^svc_workloads/api/services/" + suffix
-
-
 urlpatterns = [
     re_path(
         r"api/bkapps/applications/(?P<code>[^/]+)/domains/$",
@@ -58,29 +46,5 @@ urlpatterns = [
         r"api/bkapps/applications/(?P<code>[^/]+)/modules/(?P<module_name>[^/]+)/entrances/$",
         views.AppEntranceViewSet.as_view({"get": "list_module_available_entrances"}),
         name="api.applications.entrances.all_module_entrances",
-    ),
-    # TODO: These paths are duplicated an exists only because backward-compatibility, remove
-    # them in the future.
-    re_path(
-        make_app_pattern_legacy_wl(r"applications/(?P<code>[^/]+)/domains/$"),
-        views.AppDomainsViewSet.as_view({"get": "list", "post": "create"}),
-        name="api.app_domains",
-    ),
-    re_path(
-        make_app_pattern_legacy_wl(r"applications/(?P<code>[^/]+)/domains/(?P<id>\d+)/$"),
-        views.AppDomainsViewSet.as_view({"put": "update", "delete": "destroy"}),
-        name="api.app_domains.singular",
-    ),
-    re_path(
-        make_app_pattern_legacy_wl(r"applications/(?P<code>[^/]+)/domains/configs/$"),
-        views.AppDomainsViewSet.as_view({"get": "list_configs"}),
-        name="api.app_domains.configs",
-    ),
-    # Deprecated: use `api.app_domains.configs` instead
-    # TODO: Remove this path.
-    re_path(
-        "^api/bkapps/applications/(?P<code>[^/]+)/custom_domains/config/$",
-        views.AppDomainsViewSet.as_view({"get": "list_configs"}),
-        name="api.custom_domains_config",
     ),
 ]

--- a/apiserver/paasng/paas_wl/workloads/networking/ingress/urls.py
+++ b/apiserver/paasng/paas_wl/workloads/networking/ingress/urls.py
@@ -16,35 +16,24 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
-from functools import partial
-
 from paasng.utils.basic import make_app_pattern, re_path
 
 from . import views
 
-# In legacy architecture, all workloads's APIs starts with a fixed prefix "/svc_workloads" and use
-# a slightly different format. While the prefix is not required in the new architecture, we have
-# to keep it to maintain backward-compatibility.
-#
-# This function helps up to build paths with the legacy prefix.
-#
-# TODO: Remove the 'svc_workloads' prefix and clean up the URL paths.
-make_app_pattern_legacy_wl = partial(make_app_pattern, prefix="svc_workloads/api/services/applications/")
-
 urlpatterns = [
     re_path(
-        make_app_pattern_legacy_wl(r"/process_services/$"),
+        make_app_pattern(r"/process_services/$"),
         views.ProcessServicesViewSet.as_view({"get": "list"}),
         name="api.process_services",
     ),
     re_path(
-        make_app_pattern_legacy_wl(r"/process_services/(?P<service_name>[a-z0-9-]+)$"),
+        make_app_pattern(r"/process_services/(?P<service_name>[a-z0-9-]+)$"),
         views.ProcessServicesViewSet.as_view({"post": "update"}),
         name="api.process_services.single",
     ),
     # Manage the default ingress rule
     re_path(
-        make_app_pattern_legacy_wl(r"/process_ingresses/default$"),
+        make_app_pattern(r"/process_ingresses/default$"),
         views.ProcessIngressesViewSet.as_view({"post": "update"}),
         name="api.process_ingresses.default",
     ),

--- a/apiserver/paasng/support-files/apigw/resources.yaml
+++ b/apiserver/paasng/support-files/apigw/resources.yaml
@@ -550,7 +550,7 @@ paths:
         backend:
           type: HTTP
           method: get
-          path: /backend/svc_workloads/api/processes/applications/{app_code}/modules/{module}/envs/{env}/processes/list/
+          path: /backend/api/bkapps/applications/{app_code}/modules/{module}/envs/{env}/processes/list/
           matchSubpath: false
           timeout: 30
           upstreams: {}

--- a/apiserver/paasng/tests/paas_wl/api/test_image_credential.py
+++ b/apiserver/paasng/tests/paas_wl/api/test_image_credential.py
@@ -42,12 +42,12 @@ def build_config(bk_app, bk_module, image_credential):
 
 class TestAppUserCredentialViewSet:
     def test_destroy(self, api_client, bk_app, image_credential):
-        url = f"/svc_workloads/api/credentials/applications/{bk_app.code}/image_credentials/{image_credential.name}"
+        url = f"/api/bkapps/applications/{bk_app.code}/image_credentials/{image_credential.name}"
         response = api_client.delete(url)
         assert response.status_code == 204
 
     def test_destroy_when_used(self, api_client, bk_app, bk_module, image_credential, build_config):
         """测试镜像凭证已被绑定的情况下，删除镜像凭证"""
-        url = f"/svc_workloads/api/credentials/applications/{bk_app.code}/image_credentials/{image_credential.name}"
+        url = f"/api/bkapps/applications/{bk_app.code}/image_credentials/{image_credential.name}"
         response = api_client.delete(url)
         assert response.status_code == 400


### PR DESCRIPTION
- Update APIs which starts with "/svc_workloads/" to remove the prefix
- The API "process.list" was excluded from this CL because it's still being used in the API Gateway. It will be removed after we modify the API Gateway resource.