### PR TITLE
WIP: 添加获取应用增强服务环境变量 KEY 的 API

### DIFF
--- a/apiserver/paasng/paasng/accessories/servicehub/serializers.py
+++ b/apiserver/paasng/paasng/accessories/servicehub/serializers.py
@@ -234,3 +234,8 @@ class SharedServiceInfoWithAllocationSLZ(SharedServiceInfoSLZ):
 
     provision_infos = ProvisionInfoSLZ(help_text="共享服务实例分配信息")
     specifications = serializers.ListField(help_text="配置信息", allow_null=True, child=ServicePlanSpecificationSLZ())
+
+
+class ServiceEnvKeys(serializers.Serializer):
+    active_env_keys = serializers.ListField(help_text="已生效的环境变量 KEY，即启用并分配了实例的增强服务的环境变量")
+    inactive_env_keys = serializers.ListField(help_text="已生效的环境变量 KEY，即未启用或者未分配实例的增强的环境变量")

--- a/apiserver/paasng/paasng/accessories/servicehub/urls.py
+++ b/apiserver/paasng/paasng/accessories/servicehub/urls.py
@@ -97,6 +97,11 @@ urlpatterns = [
         views.ModuleServicesViewSet.as_view({"get": "retrieve", "delete": "unbind"}),
         name="api.services.list_by_application",
     ),
+    re_path(
+        make_app_pattern("/services/env/", include_envs=False),
+        views.ModuleServiceAttachmentsViewSet.as_view({"get": "get_env_keys"}),
+        name="api.modules.services.env",
+    ),
     # Manager service attachments (from services side)
     url(
         r"^api/services/service-attachments/$",

--- a/apiserver/paasng/paasng/settings/__init__.py
+++ b/apiserver/paasng/paasng/settings/__init__.py
@@ -971,6 +971,11 @@ SERVICE_PROTECTED_SPEC_NAMES = ["app_zone"]
 # 比如 APP_ZONE_CLUSTER_MAPPINGS = {"main-cluster": "another-zone"}
 APP_ZONE_CLUSTER_MAPPINGS = settings.get("APP_ZONE_CLUSTER_MAPPINGS", {})
 
+# 本地增强服务内置环境变量 KEY
+LOCAL_SERVICE_BUILTIN_ENV_KEYS: Dict[str, List] = settings.get(
+    "LOCAL_SERVICE_BUILTIN_ENV_KEYS", {"redis": ["REDIS_HOST", "REDIS_PORT", "REDIS_PASSWORD"]}
+)
+
 # ---------------
 # 应用市场相关配置
 # ---------------

--- a/apiserver/paasng/paasng/settings/utils.py
+++ b/apiserver/paasng/paasng/settings/utils.py
@@ -117,6 +117,7 @@ def get_service_remote_endpoints(settings: LazySettings) -> List[Dict]:
             "key": jwt_key,
         },
         "prefer_async_delete": True,
+        "builtin_env_keys": [],
     }
 
     mysql_ep_url = settings.get("RSVC_BUNDLE_MYSQL_ENDPOINT_URL")
@@ -128,6 +129,7 @@ def get_service_remote_endpoints(settings: LazySettings) -> List[Dict]:
                     "name": "mysql_remote",
                     "endpoint_url": mysql_ep_url,
                     "provision_params_tmpl": {"egress_info": "{cluster_info.egress_info_json}"},
+                    "builtin_env_keys": ["MYSQL_HOST", "MYSQL_PORT", "MYSQL_USER", "MYSQL_NAME", "MYSQL_PASSWORD"],
                 },
             )
         )
@@ -143,6 +145,15 @@ def get_service_remote_endpoints(settings: LazySettings) -> List[Dict]:
                     "provision_params_tmpl": {
                         "app_developers": "{app_developers}",
                     },
+                    "builtin_env_keys": [
+                        "BKREPO_USERNAME",
+                        "BKREPO_BUCKET",
+                        "BKREPO_PRIVATE_BUCKET",
+                        "BKREPO_PUBLIC_BUCKET",
+                        "BKREPO_ENDPOINT_URL",
+                        "BKREPO_PROJECT",
+                        "BKREPO_PASSWORD",
+                    ],
                 },
             )
         )
@@ -155,6 +166,13 @@ def get_service_remote_endpoints(settings: LazySettings) -> List[Dict]:
                 {
                     "name": "svc_rabbitmq",
                     "endpoint_url": rabbitmq_ep_url,
+                    "builtin_env_keys": [
+                        "RABBITMQ_HOST",
+                        "RABBITMQ_PORT",
+                        "RABBITMQ_USER",
+                        "RABBITMQ_VHOST",
+                        "RABBITMQ_PASSWORD",
+                    ],
                 },
             )
         )
@@ -172,6 +190,7 @@ def get_service_remote_endpoints(settings: LazySettings) -> List[Dict]:
                         "env": "{env.environment}",
                     },
                     "is_ready": settings.get("RSVC_BUNDLE_OTEL_ENABLED", False),
+                    "builtin_env_keys": ["OTEL_TRACE", "OTEL_SAMPLER", "OTEL_BK_DATA_TOKEN", "OTEL_GRPC_URL"],
                 },
             )
         )


### PR DESCRIPTION
1. 已经下线的增强服务（如 ceph），未启用该增强服务的应用不会提示相关的变量
2. 在环境变量页面上按级别提升冲突的变量 KEY
- 已经生效的增强服务变量 KEY
- 未生效的增强服务变量 KEY