### PR TITLE
Fix: some admin pages use the wrong API path if the platform is deployed with a path prefix other than "/"

### DIFF
--- a/apiserver/paasng/paas_wl/apis/admin/urls.py
+++ b/apiserver/paasng/paas_wl/apis/admin/urls.py
@@ -29,81 +29,100 @@ urlpatterns = [
     path(
         "wl_api/platform/process_spec_plan/",
         processes.ProcessSpecPlanManageViewSet.as_view(dict(post="create", get="list")),
+        name="wl_api.process_spec_plan",
     ),
     path(
         "wl_api/platform/process_spec_plan/id/<int:id>/",
         processes.ProcessSpecPlanManageViewSet.as_view(dict(put="edit", get="list_binding_app")),
+        name="wl_api.process_spec_plan_by_id",
     ),
     path(
         "wl_api/regions/<str:region>/apps/<str:name>/processes/<str:process_type>/plan",
         processes.ProcessSpecManageViewSet.as_view({"put": "switch_process_plan"}),
+        name="wl_api.application.process_plan",
     ),
     path(
         "wl_api/regions/<str:region>/apps/<str:name>/processes/<str:process_type>/scale",
         processes.ProcessSpecManageViewSet.as_view({"put": "scale"}),
+        name="wl_api.application.process_scale",
     ),
     path(
         "wl_api/regions/<str:region>/apps/<str:name>/processes/<str:process_type>/instances/<str:instance_name>/",
         processes.ProcessInstanceViewSet.as_view({"get": "retrieve"}),
+        name="wl_api.application.process_instance",
     ),
     # 独立域名相关 API
     path(
         "wl_api/applications/<str:code>/domains/",
         domain.AppDomainsViewSet.as_view({"get": "list", "post": "create"}),
+        name="wl_api.application.domains",
     ),
     path(
         "wl_api/applications/<str:code>/domains/<int:id>/",
         domain.AppDomainsViewSet.as_view({"put": "update", "delete": "destroy"}),
+        name="wl_api.domain_by_id",
     ),
     # Shared certificates
     path(
         "wl_api/platform/app_certs/shared/",
         certs.AppDomainSharedCertsViewSet.as_view({"post": "create", "get": "list"}),
+        name="wl_api.shared_app_certs",
     ),
     path(
         "wl_api/platform/app_certs/shared/<str:name>",
         certs.AppDomainSharedCertsViewSet.as_view({"get": "retrieve", "put": "update", "delete": "destroy"}),
+        name="wl_api.shared_app_certs_by_name",
     ),
     # 日志采集管理
     path(
         "wl_api/applications/<str:code>/log_config/",
         logs.AppLogConfigViewSet.as_view({"get": "list", "post": "toggle"}),
+        name="wl_api.application.log_config",
     ),
     # 平台管理-集群管理API
     path(
         "wl_api/platform/clusters/",
         clusters.ClusterViewSet.as_view({"post": "update_or_create", "get": "list"}),
+        name="wl_api.clusters",
     ),
     path(
         "wl_api/platform/clusters/<str:cluster_name>/node_state/",
         clusters.ClusterViewSet.as_view({"post": "gen_node_state"}),
+        name="wl_api.cluster.node_state",
     ),
     path(
         "wl_api/platform/clusters/<str:cluster_name>/operator_info/",
         clusters.ClusterComponentViewSet.as_view({"get": "get_operator_info"}),
+        name="wl_api.cluster.operator_info",
     ),
     path(
         "wl_api/platform/clusters/<str:cluster_name>/components/",
         clusters.ClusterComponentViewSet.as_view({"get": "list_components"}),
+        name="wl_api.cluster.components",
     ),
     path(
         "wl_api/platform/clusters/<str:cluster_name>/components/<str:component_name>/",
         clusters.ClusterComponentViewSet.as_view({"get": "get_component_status"}),
+        name="wl_api.cluster.component_by_name",
     ),
     path(
         "wl_api/platform/clusters/<str:pk>/",
         clusters.ClusterViewSet.as_view({"get": "retrieve", "put": "update_or_create", "delete": "destroy"}),
+        name="wl_api.cluster_by_id",
     ),
     path(
         "wl_api/platform/clusters/<str:pk>/api_servers",
         clusters.ClusterViewSet.as_view({"post": "bind_api_server"}),
+        name="wl_api.cluster.api_servers",
     ),
     path(
         "wl_api/platform/clusters/<str:pk>/set_default/",
         clusters.ClusterViewSet.as_view({"post": "set_as_default"}),
+        name="wl_api.cluster.set_default",
     ),
     path(
         "wl_api/platform/clusters/<str:pk>/api_servers/<str:api_server_id>",
         clusters.ClusterViewSet.as_view({"delete": "unbind_api_server"}),
+        name="wl_api.cluster.api_server_by_id",
     ),
 ]

--- a/apiserver/paasng/paas_wl/apis/admin/urls.py
+++ b/apiserver/paasng/paas_wl/apis/admin/urls.py
@@ -60,7 +60,7 @@ urlpatterns = [
     path(
         "wl_api/applications/<str:code>/domains/<int:id>/",
         domain.AppDomainsViewSet.as_view({"put": "update", "delete": "destroy"}),
-        name="wl_api.domain_by_id",
+        name="wl_api.application.domain_by_id",
     ),
     # Shared certificates
     path(
@@ -71,7 +71,7 @@ urlpatterns = [
     path(
         "wl_api/platform/app_certs/shared/<str:name>",
         certs.AppDomainSharedCertsViewSet.as_view({"get": "retrieve", "put": "update", "delete": "destroy"}),
-        name="wl_api.shared_app_certs_by_name",
+        name="wl_api.shared_app_cert_by_name",
     ),
     # 日志采集管理
     path(

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/applications/detail/engine/custom_domain.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/applications/detail/engine/custom_domain.html
@@ -76,7 +76,7 @@
         list: decodeURI("{% url 'wl_api.application.domains' application.code %}"),
         create: decodeURI("{% url 'wl_api.application.domains' application.code %}"),
         {# Use an integer "65535" as the ID placeholder in order to call url #}
-        detail: decodeURI("{% url 'wl_api.domain_by_id' application.code 65535 %}"),
+        detail: decodeURI("{% url 'wl_api.application.domain_by_id' application.code 65535 %}"),
     }
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/applications/detail/engine/custom_domain.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/applications/detail/engine/custom_domain.html
@@ -73,9 +73,10 @@
     const envChoices = {{ env_choices | to_json }}
 
     const URLRouter = {
-        list: decodeURI("{{ '/admin42/wl_api/applications/${code}/domains/' }}"),
-        create: decodeURI("{{ '/admin42/wl_api/applications/${code}/domains/' }}"),
-        detail: decodeURI("{{ '/admin42/wl_api/applications/${code}/domains/${id}/' }}"),
+        list: decodeURI("{% url 'wl_api.application.domains' application.code %}"),
+        create: decodeURI("{% url 'wl_api.application.domains' application.code %}"),
+        {# Use an integer "65535" as the ID placeholder in order to call url #}
+        detail: decodeURI("{% url 'wl_api.domain_by_id' application.code 65535 %}"),
     }
 
     document.addEventListener('DOMContentLoaded', () => {
@@ -110,7 +111,7 @@
                 fetchDomainList: async function () {
                     const el = this.$bkLoading({title: '加载中'})
                     try {
-                        await this.$http.get(URLRouter.list.replace("${code}", this.application.code)).then(res => {
+                        await this.$http.get(URLRouter.list).then(res => {
                             this.domainList = res
                         })
                     } finally {
@@ -145,7 +146,8 @@
                     this.dialog.form.https_enabled = row.https_enabled
                 },
                 fillUrlTemplate: function (url_template, {form}) {
-                  return url_template.replace("${code}", this.application.code).replace("${module}", form.module_name).replace("${id}", form.id)
+                  // Replace the placeholder in the tail of the URL
+                  return url_template.replace(/\/65535\/$/, `/${form.id}/`)
                 },
                 submitCallback: function () {
                      this.fetchDomainList()

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/applications/detail/engine/log_config.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/applications/detail/engine/log_config.html
@@ -29,8 +29,8 @@
     const envChoices = {{ env_choices | to_json }}
 
     const URLRouter = {
-        list: decodeURI("{{ '/admin42/wl_api/applications/${code}/log_config/' }}"),
-        detail: decodeURI("{{ '/admin42/wl_api/applications/${code}/log_config/' }}"),
+        list: decodeURI("{% url 'wl_api.application.log_config' application.code %}"),
+        detail: decodeURI("{% url 'wl_api.application.log_config' application.code %}"),
     }
 
     document.addEventListener('DOMContentLoaded', () => {
@@ -57,7 +57,7 @@
                         el = this.$bkLoading({title: '加载中'})
                     }
                     try {
-                        await this.$http.get(URLRouter.list.replace("${code}", this.application.code)).then(res => {
+                        await this.$http.get(URLRouter.list).then(res => {
                             this.data = res
                         })
                     } finally {
@@ -66,7 +66,7 @@
                 },
                 handleChange: async function(row) {
                     const el = this.$bkLoading({title: '加载中'})
-                    this.$http.post(URLRouter.detail.replace("${code}", this.application.code),
+                    this.$http.post(URLRouter.detail,
                         {
                             module_name: row.module_name,
                             environment: row.environment,

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/applications/detail/engine/processes.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/applications/detail/engine/processes.html
@@ -30,7 +30,7 @@
                     </bk-table-column>
                     <bk-table-column prop="start_time" label="创建时间">
                         <template slot-scope="props">
-                            创建于 <span v-bk-tooltips="{content: props.row.start_time }">$[ props.row.start_time_humanized ]</span>
+                            创建于 <span>$[ props.row.start_time ]</span>
                         </template>
                     </bk-table-column>
 
@@ -108,10 +108,10 @@
     const processes = {{ processes | to_json }}
 
     const URLRouter = {
-        list: decodeURI("{{ '/admin42/wl_api/platform/process_spec_plan/' }}"),
-        switch_process_plan: decodeURI("{{ '/admin42/wl_api/regions/${region}/apps/${engine_app_name}/processes/${process_type}/plan' }}"),
-        scale: decodeURI("{{ '/admin42/wl_api/regions/${region}/apps/${engine_app_name}/processes/${process_type}/scale' }}"),
-        retrieve: decodeURI("{{ '/admin42/wl_api/regions/${region}/apps/${engine_app_name}/processes/${process_type}/instances/${process_instance_name}/' }}"),
+        list: decodeURI("{% url 'wl_api.process_spec_plan' %}"),
+        switch_process_plan: decodeURI("{% url 'wl_api.application.process_plan' application.region '${engine_app_name}' '${process_type}' %}"),
+        scale: decodeURI("{% url 'wl_api.application.process_scale' application.region '${engine_app_name}' '${process_type}' %}"),
+        retrieve: decodeURI("{% url 'wl_api.application.process_instance' application.region '${engine_app_name}' '${process_type}' '${process_instance_name}' %}"),
     }
 
 
@@ -175,8 +175,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 } else if (form.type === '资源方案') {
                     url_template = URLRouter['switch_process_plan']
                 }
-              return url_template.replace("${region}", this.application.region)
-                        .replace("${engine_app_name}", row.engine_app)
+              return url_template.replace("${engine_app_name}", row.engine_app)
                         .replace("${process_type}", row.type)
             },
             submitCallback: function () {
@@ -245,9 +244,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (row.envs !== undefined) {
                         return true;
                     }
-                    let url = URLRouter.retrieve.replace("${region}", region)
-                            .replace("${engine_app_name}", engine_app)
-                            .replace("${process_type}", row.process_type).replace("${process_instance_name}", row.name)
+                    let url = URLRouter.retrieve.replace("${engine_app_name}", engine_app)
+                            .replace("${process_type}", row.process_type)
+                            .replace("${process_instance_name}", row.name)
                     let data = await this.$http.get(url)
                     row.envs = data.envs
                     return true

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/certs.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/certs.html
@@ -80,7 +80,7 @@ const regionList = {{ region_list | to_json }}
 const URLRouter = {
     create: decodeURI("{% url 'wl_api.shared_app_certs' %}"),
     list: decodeURI("{% url 'wl_api.shared_app_certs' %}"),
-    detail: decodeURI("{% url 'wl_api.shared_app_certs_by_name' '${cert_name}' %}"),
+    detail: decodeURI("{% url 'wl_api.shared_app_cert_by_name' '${cert_name}' %}"),
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/certs.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/certs.html
@@ -78,9 +78,9 @@
 const regionList = {{ region_list | to_json }}
 
 const URLRouter = {
-    create: decodeURI("{{ '/admin42/wl_api/platform/app_certs/shared/' }}"),
-    list: decodeURI("{{ '/admin42/wl_api/platform/app_certs/shared/' }}"),
-    detail: decodeURI("{{ '/admin42/wl_api/platform/app_certs/shared/${cert_name}' }}"),
+    create: decodeURI("{% url 'wl_api.shared_app_certs' %}"),
+    list: decodeURI("{% url 'wl_api.shared_app_certs' %}"),
+    detail: decodeURI("{% url 'wl_api.shared_app_certs_by_name' '${cert_name}' %}"),
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/cluster_components.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/cluster_components.html
@@ -135,9 +135,9 @@
     const clusterComponents = {{ cluster_components | to_json }}
 
     const URLRouter = {
-        listClusters: decodeURI("{{ '/admin42/wl_api/platform/clusters/' }}"),
-        list: decodeURI("{{ '/admin42/wl_api/platform/clusters/${cluster_name}/components/' }}"),
-        retrieve: decodeURI("{{ '/admin42/wl_api/platform/clusters/${cluster_name}/components/${comp_name}/' }}"),
+        listClusters: decodeURI("{% url 'wl_api.clusters' %}"),
+        list: decodeURI("{% url 'wl_api.cluster.components' '${cluster_name}' %}"),
+        retrieve: decodeURI("{% url 'wl_api.cluster.component_by_name' '${cluster_name}' '${comp_name}' %}"),
     }
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/clusters.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/clusters.html
@@ -432,14 +432,14 @@
     }
 
     const URLRouter = {
-        create: decodeURI("{{ '/admin42/wl_api/platform/clusters/' }}"),
-        list: decodeURI("{{ '/admin42/wl_api/platform/clusters/' }}"),
-        detail: decodeURI("{{ '/admin42/wl_api/platform/clusters/${cluster_id}/' }}"),
-        setAsDefault: decodeURI("{{ '/admin42/wl_api/platform/clusters/${cluster_id}/set_default/' }}"),
-        genNodeState: decodeURI("{{ '/admin42/wl_api/platform/clusters/${cluster_name}/node_state/' }}"),
+        create: decodeURI("{% url 'wl_api.clusters' %}"),
+        list: decodeURI("{% url 'wl_api.clusters' %}"),
+        detail: decodeURI("{% url 'wl_api.cluster_by_id' '${cluster_id}' %}"),
+        setAsDefault: decodeURI("{% url 'wl_api.cluster.set_default' '${cluster_id}' %}"),
+        genNodeState: decodeURI("{% url 'wl_api.cluster.node_state' '${cluster_name}' %}"),
         apiServer: {
-            upsert: decodeURI("{{ '/admin42/wl_api/platform/clusters/${cluster_id}/api_servers' }}"),
-            delete: decodeURI("{{ '/admin42/wl_api/platform/clusters/${cluster_id}/api_servers/${api_server_id}' }}"),
+            upsert: decodeURI("{% url 'wl_api.cluster.api_servers' '${cluster_id}' %}"),
+            delete: decodeURI("{% url 'wl_api.cluster.api_server_by_id' '${cluster_id}' '${api_server_id}' %}"),
         }
     }
 

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/operator.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/operator.html
@@ -75,8 +75,8 @@
     const cnativeDefaultCluster = {{ cnative_default_cluster | to_json }}
 
     const URLRouter = {
-        listClusters: decodeURI("{{ '/admin42/wl_api/platform/clusters/' }}"),
-        getOperatorInfo: decodeURI("{{ '/admin42/wl_api/platform/clusters/${cluster_name}/operator_info/' }}"),
+        listClusters: decodeURI("{% url 'wl_api.clusters' %}"),
+        getOperatorInfo: decodeURI("{% url 'wl_api.cluster.operator_info' '${cluster_name}' %}"),
     }
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/process_spec_plans.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/platformmgr/process_spec_plans.html
@@ -126,8 +126,9 @@ const pagination = {{ pagination | to_json }}
 const data = {{ process_spec_plan_list | to_json }}
 
 const URLRouter = {
-    create: decodeURI("{{ '/admin42/wl_api/platform/process_spec_plan/' }}"),
-    detail: decodeURI("{{ '/admin42/wl_api/platform/process_spec_plan/id/${id}/' }}"),
+    create: decodeURI("{% url 'wl_api.process_spec_plan' %}"),
+    {# Use an integer "65535" as the ID placeholder in order to call url #}
+    detail: decodeURI("{% url 'wl_api.process_spec_plan_by_id' 65535 %}"),
 }
 
 const ResourceSchema = {
@@ -299,7 +300,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     return 'json-view'
             },
             fillUrlTemplate: function (url_template, {form}) {
-              return url_template.replace("${id}", form.id)
+              // Replace the placeholder in the tail of the URL
+              return url_template.replace(/\/65535\/$/, `/${form.id}/`)
             },
             submitCallback: function () {
                 this.dialog.row.name = this.dialog.form.name


### PR DESCRIPTION
Some admin pages use fixed API paths instead of calling the `url` function. If the platform was deployed with a path prefix, these paths could be incorrect and cause the webpage to fail to load resources. This PR fixes this by using `{% url ... %}`.