### PR TITLE
Enhance: disallow duplicate entries when upsert svc-disc config & other fixes

### DIFF
--- a/apiserver/paasng/locale/en/LC_MESSAGES/django.po
+++ b/apiserver/paasng/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-31 15:47+0800\n"
+"POT-Creation-Date: 2024-03-27 14:39+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,28 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-#: paas_wl/bk_app/applications/models/build.py:64
-#: paas_wl/bk_app/applications/models/build.py:261
-#: paas_wl/bk_app/cnative/specs/models/app_resource.py:79
-#: paas_wl/bk_app/cnative/specs/models/app_resource.py:109
-#: paas_wl/bk_app/cnative/specs/models/app_resource.py:160
-#: paas_wl/bk_app/cnative/specs/models/mount.py:48
-#: paas_wl/bk_app/cnative/specs/serializers.py:36
-#: paas_wl/workloads/images/models.py:70
-msgid "所属应用"
-msgstr "APP"
-
-#: paas_wl/bk_app/applications/models/build.py:65
-#: paas_wl/bk_app/applications/models/build.py:262
-#: paas_wl/bk_app/cnative/specs/models/app_resource.py:80
-#: paas_wl/bk_app/cnative/specs/models/app_resource.py:110
-#: paas_wl/bk_app/cnative/specs/models/app_resource.py:161
-#: paas_wl/bk_app/cnative/specs/models/mount.py:49
-#: paas_wl/bk_app/cnative/specs/models/mount.py:118
-#: paas_wl/bk_app/cnative/specs/serializers.py:37
-msgid "所属模块"
-msgstr "Module"
 
 #: paas_wl/bk_app/cnative/specs/constants.py:82
 msgid "待实施"
@@ -70,6 +48,24 @@ msgstr "spec.build.image is missing"
 msgid "image is missing"
 msgstr "image is missing"
 
+#: paas_wl/bk_app/cnative/specs/models/app_resource.py:79
+#: paas_wl/bk_app/cnative/specs/models/app_resource.py:109
+#: paas_wl/bk_app/cnative/specs/models/app_resource.py:160
+#: paas_wl/bk_app/cnative/specs/models/mount.py:37
+#: paas_wl/bk_app/cnative/specs/models/mount.py:56
+#: paas_wl/workloads/images/models.py:70
+msgid "所属应用"
+msgstr "APP"
+
+#: paas_wl/bk_app/cnative/specs/models/app_resource.py:80
+#: paas_wl/bk_app/cnative/specs/models/app_resource.py:110
+#: paas_wl/bk_app/cnative/specs/models/app_resource.py:161
+#: paas_wl/bk_app/cnative/specs/models/mount.py:38
+#: paas_wl/bk_app/cnative/specs/models/mount.py:57
+#: paas_wl/bk_app/cnative/specs/models/mount.py:76
+msgid "所属模块"
+msgstr "Module"
+
 #: paas_wl/bk_app/cnative/specs/models/app_resource.py:114
 msgid "模型版本"
 msgstr "Model version"
@@ -99,9 +95,10 @@ msgid "是否已删除"
 msgstr ""
 
 #: paas_wl/bk_app/cnative/specs/models/app_resource.py:164
-#: paas_wl/bk_app/cnative/specs/models/mount.py:53
-#: paas_wl/bk_app/cnative/specs/models/mount.py:122
-#: paasng/platform/bkapp_model/models.py:111
+#: paas_wl/bk_app/cnative/specs/models/mount.py:40
+#: paas_wl/bk_app/cnative/specs/models/mount.py:59
+#: paas_wl/bk_app/cnative/specs/models/mount.py:80
+#: paasng/platform/bkapp_model/models.py:137
 msgid "环境名称"
 msgstr "Env Name"
 
@@ -128,45 +125,23 @@ msgid "状态最近变更时间"
 msgstr ""
 
 #: paas_wl/bk_app/cnative/specs/models/app_resource.py:179
-#: paas_wl/bk_app/cnative/specs/serializers.py:66
 msgid "操作者"
 msgstr ""
 
-#: paas_wl/bk_app/cnative/specs/models/mount.py:56
-msgid "ConfigMap 名"
+#: paas_wl/bk_app/cnative/specs/models/mount.py:42
+#: paas_wl/bk_app/cnative/specs/models/mount.py:61
+msgid "挂载资源名"
 msgstr ""
 
-#: paas_wl/bk_app/cnative/specs/models/mount.py:124
+#: paas_wl/bk_app/cnative/specs/models/mount.py:82
 msgid "挂载点的名称"
 msgstr ""
 
-#: paas_wl/bk_app/cnative/specs/serializers.py:38
-#: paas_wl/bk_app/cnative/specs/serializers.py:46
-#: paas_wl/bk_app/cnative/specs/serializers.py:72
-msgid "BkApp 配置信息"
-msgstr "config info"
+#: paas_wl/bk_app/cnative/specs/mounts.py:198
+msgid "删除持久存储资源失败,请先删除相应挂载卷资源"
+msgstr ""
 
-#: paas_wl/bk_app/cnative/specs/serializers.py:52
-msgid "进程类型"
-msgstr "Process Type"
-
-#: paas_wl/bk_app/cnative/specs/serializers.py:53
-msgid "旧副本数"
-msgstr "Old replicas"
-
-#: paas_wl/bk_app/cnative/specs/serializers.py:54
-msgid "新副本数"
-msgstr "New replicas"
-
-#: paas_wl/bk_app/cnative/specs/serializers.py:60
-msgid "进程副本数变化"
-msgstr "Replica Change"
-
-#: paas_wl/bk_app/cnative/specs/serializers.py:165
-msgid "挂载卷名称"
-msgstr "Volume Name"
-
-#: paas_wl/bk_app/cnative/specs/serializers.py:174
+#: paas_wl/bk_app/cnative/specs/serializers.py:58
 msgid ""
 "挂载卷内容为一个字典，其中键表示文件名称，值表示文件内容。例如：{'file1."
 "yaml': 'file1 content', 'file2.yaml': 'file2 content'}"
@@ -175,48 +150,77 @@ msgstr ""
 "file contents. For example:{'file1.yaml': 'file1 content', 'file2.yaml': "
 "'file2 content'}"
 
-#: paas_wl/bk_app/cnative/specs/serializers.py:197
+#: paas_wl/bk_app/cnative/specs/serializers.py:81
+msgid "挂载卷名称"
+msgstr "Volume Name"
+
+#: paas_wl/bk_app/cnative/specs/serializers.py:108
 msgid "该环境(包括 global )中已存在同名挂载卷"
 msgstr ""
 "Existing mount volume with the same name in the environment (including "
 "global)"
 
-#: paas_wl/bk_app/cnative/specs/serializers.py:203
+#: paas_wl/bk_app/cnative/specs/serializers.py:114
 msgid "挂载卷内容不可为空"
 msgstr "Mount volume content cannot be empty"
 
-#: paas_wl/bk_app/cnative/specs/serializers.py:214
-msgid "挂载卷内容"
-msgstr "Mount volume content"
+#: paas_wl/bk_app/cnative/specs/serializers.py:119
+msgid "configmap 挂载"
+msgstr ""
 
-#: paas_wl/bk_app/cnative/specs/serializers.py:236
+#: paas_wl/bk_app/cnative/specs/serializers.py:120
+msgid "持久存储资源"
+msgstr ""
+
+#: paas_wl/bk_app/cnative/specs/serializers.py:150
+#: paas_wl/bk_app/cnative/specs/serializers.py:164
 #, fuzzy
 #| msgid "获取进程信息失败"
 msgid "获取挂载卷内容信息失败"
 msgstr "Failed to get process information"
 
-#: paas_wl/bk_app/cnative/specs/views_enduser.py:331
+#: paas_wl/bk_app/cnative/specs/serializers.py:204
+msgid "挂载资源的名称"
+msgstr ""
+
+#: paas_wl/bk_app/cnative/specs/serializers.py:212
+msgid "挂载卷资源类型"
+msgstr ""
+
+#: paas_wl/bk_app/cnative/specs/serializers.py:213
+msgid "已绑定模块信息"
+msgstr ""
+
+#: paas_wl/bk_app/cnative/specs/serializers.py:217
+msgid "显示名称"
+msgstr ""
+
+#: paas_wl/bk_app/cnative/specs/views.py:120
 msgid "权限不足或仓库不可达"
 msgstr "Insufficient permissions or repository unreachable"
 
-#: paas_wl/bk_app/cnative/specs/views_enduser.py:366
+#: paas_wl/bk_app/cnative/specs/views.py:155
 msgid "镜像凭证不存在"
 msgstr "Image credentials not found"
 
-#: paas_wl/bk_app/cnative/specs/views_enduser.py:383
+#: paas_wl/bk_app/cnative/specs/views.py:172
 msgid "查看镜像 Tag"
 msgstr "View image Tag"
 
-#: paas_wl/bk_app/cnative/specs/views_enduser.py:391
+#: paas_wl/bk_app/cnative/specs/views.py:180
 #: paasng/platform/sourcectl/views.py:413
 #, python-format
 msgid "%s的仓库信息查询异常"
 msgstr "The warehouse information query of %s is abnormal"
 
-#: paas_wl/bk_app/cnative/specs/views_enduser.py:447
-#: paas_wl/bk_app/cnative/specs/views_enduser.py:475
+#: paas_wl/bk_app/cnative/specs/views.py:237
+#: paas_wl/bk_app/cnative/specs/views.py:276
 msgid "同环境和路径挂载卷已存在"
 msgstr "Mount volume already exists in the same environment and path."
+
+#: paas_wl/bk_app/cnative/specs/views.py:339
+msgid "当前应用暂不支持持久存储功能，请联系管理员"
+msgstr ""
 
 #: paas_wl/bk_app/processes/controllers.py:51
 msgid "进程操作过于频繁，请间隔 {operation_interval.total_seconds()} 秒再试。"
@@ -269,7 +273,7 @@ msgstr ""
 msgid "scaling_config 配置格式有误：{}"
 msgstr "Incorrect format for scaling_config: {}"
 
-#: paas_wl/bk_app/processes/views_enduser.py:79
+#: paas_wl/bk_app/processes/views.py:95
 msgid "环境未就绪或已下架, 请尝试重新部署"
 msgstr ""
 
@@ -364,36 +368,40 @@ msgid "未设置部署信息"
 msgstr "Deployment information not set"
 
 #: paas_wl/utils/error_codes.py:49
-msgid "Failed to deploy bkapp"
-msgstr "Failed to deploy bkapp"
-
-#: paas_wl/utils/error_codes.py:50
-msgid "Failed to find bkapp in Kubernetes"
-msgstr "Failed to find bkapp in Kubernetes"
-
-#: paas_wl/utils/error_codes.py:51
 msgid "The bkapp is invalid"
 msgstr "The bkapp is invalid"
 
-#: paas_wl/utils/error_codes.py:52
+#: paas_wl/utils/error_codes.py:50
 msgid "Failed to find deployed version"
 msgstr "Failed to find deployed version"
 
-#: paas_wl/utils/error_codes.py:53
+#: paas_wl/utils/error_codes.py:51
 msgid "Failed to list tag from image repository"
 msgstr "Failed to list tag from image repository"
 
-#: paas_wl/utils/error_codes.py:54
+#: paas_wl/utils/error_codes.py:52
 msgid "Failed to create volume mount"
 msgstr "Failed to create volume mount"
 
-#: paas_wl/utils/error_codes.py:55
+#: paas_wl/utils/error_codes.py:53
 msgid "Failed to list volume mount"
 msgstr "Failed to list volume mount"
 
-#: paas_wl/utils/error_codes.py:56
+#: paas_wl/utils/error_codes.py:54
 msgid "Failed to update volume mount"
 msgstr "Failed to update volume mount"
+
+#: paas_wl/utils/error_codes.py:55
+#, fuzzy
+#| msgid "Failed to list volume mount"
+msgid "Failed to list volume mount sources"
+msgstr "Failed to list volume mount"
+
+#: paas_wl/utils/error_codes.py:56
+#, fuzzy
+#| msgid "Failed to create volume mount"
+msgid "Failed to create volume mount source"
+msgstr "Failed to create volume mount"
 
 #: paas_wl/utils/error_codes.py:59
 msgid "Failed to create credentials"
@@ -410,6 +418,12 @@ msgid "Failed to delete credentials"
 msgstr "Failed to create credentials"
 
 #: paas_wl/utils/error_codes.py:64
+#, fuzzy
+#| msgid "Failed to create credentials"
+msgid "Failed to switch default cluster"
+msgstr "Failed to create credentials"
+
+#: paas_wl/utils/error_codes.py:65
 msgid "Cluster component not exist"
 msgstr "Cluster component not exist"
 
@@ -429,17 +443,17 @@ msgstr "CPU usage amount"
 msgid "内存使用量"
 msgstr "Memory usage amount"
 
-#: paas_wl/workloads/images/views_enduser.py:58
-#: paasng/platform/applications/views.py:714
+#: paas_wl/workloads/images/views.py:58
+#: paasng/platform/applications/views.py:718
 #: paasng/platform/modules/views.py:324
 msgid "同名凭证已存在"
 msgstr "Credential with the same name already exists"
 
-#: paas_wl/workloads/images/views_enduser.py:76
+#: paas_wl/workloads/images/views.py:76
 msgid "该凭证已被应用使用"
 msgstr ""
 
-#: paas_wl/workloads/networking/egress/views_enduser.py:65
+#: paas_wl/workloads/networking/egress/views.py:65
 msgid "新建出口 IP 绑定功能已禁用，如有需要请联系管理员"
 msgstr ""
 "Creation of egress IP binding is disabled; please contact the administrator "
@@ -451,13 +465,14 @@ msgstr "Parameter format error"
 
 #: paas_wl/workloads/networking/entrance/serializers.py:65
 msgid "该域名与路径组合已被其他应用或模块使用"
-msgstr "This domain and path combination is already in use by another APP or module."
+msgstr ""
+"This domain and path combination is already in use by another APP or module."
 
-#: paas_wl/workloads/networking/ingress/serializers.py:51
+#: paas_wl/workloads/networking/ingress/serializers.py:52
 msgid "内部服务端口列表 ports 不能为空"
 msgstr "Internal service ports list ports cannot be empty"
 
-#: paas_wl/workloads/networking/ingress/serializers.py:60
+#: paas_wl/workloads/networking/ingress/serializers.py:61
 #, python-brace-format
 msgid "端口列表中发现重复值 {value}"
 msgstr "Duplicate value {value} found in the ports list"
@@ -493,7 +508,7 @@ msgid "当前密钥为内置密钥，不允许删除"
 msgstr "The current secret is built-in and cannot be deleted"
 
 #: paasng/accessories/app_secret/views.py:144
-#: paasng/platform/applications/views.py:960
+#: paasng/platform/applications/views.py:964
 #: paasng/platform/sourcectl/views.py:178
 msgid "验证码错误"
 msgstr "Verification code error"
@@ -502,7 +517,7 @@ msgstr "Verification code error"
 msgid "密钥已被禁用，不能设置为内置密钥"
 msgstr "A disabled secret cannot be set as a built-in secret"
 
-#: paasng/accessories/log/client.py:233
+#: paasng/accessories/log/client.py:169 paasng/accessories/log/client.py:273
 #: paasng/bk_plugins/pluginscenter/log/client.py:182
 msgid "No mappings available, maybe index does not exist or no logs at all"
 msgstr "No mappings available, maybe index does not exist or no logs at all"
@@ -548,11 +563,11 @@ msgstr ""
 msgid "日志采集路径必须是绝对路径"
 msgstr "Log collection path must be an absolute path"
 
-#: paasng/accessories/log/views/config.py:160
+#: paasng/accessories/log/views/config.py:162
 msgid "内置采集规则只能停用, 不能删除"
 msgstr ""
 
-#: paasng/accessories/log/views/config.py:174
+#: paasng/accessories/log/views/config.py:176
 msgid "平台内置日志采集规则"
 msgstr ""
 
@@ -749,73 +764,93 @@ msgid "存在正在进行的下架任务，请勿重复操作"
 msgstr ""
 "There are ongoing downgrading tasks, please do not repeat the operation"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:133
+#: paasng/bk_plugins/pluginscenter/constants.py:135
 msgid "创建"
 msgstr "Create "
 
-#: paasng/bk_plugins/pluginscenter/constants.py:134
+#: paasng/bk_plugins/pluginscenter/constants.py:136
 msgid "新建"
 msgstr "Create"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:135
+#: paasng/bk_plugins/pluginscenter/constants.py:137
 msgid "重新发布"
 msgstr "Republish"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:136
+#: paasng/bk_plugins/pluginscenter/constants.py:138
 msgid "终止发布"
 msgstr "Unpublish"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:137
+#: paasng/bk_plugins/pluginscenter/constants.py:139
 msgid "修改"
 msgstr "Modify"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:138
+#: paasng/bk_plugins/pluginscenter/constants.py:140
 #, fuzzy
 #| msgid "删除应用"
 msgid "删除"
 msgstr "Delete APP"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:139
+#: paasng/bk_plugins/pluginscenter/constants.py:141
 #, fuzzy
 #| msgid "已下架"
 msgid "下架"
 msgstr "Archived"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:140
+#: paasng/bk_plugins/pluginscenter/constants.py:142
 msgid "重新上架"
 msgstr ""
 
-#: paasng/bk_plugins/pluginscenter/constants.py:146
+#: paasng/bk_plugins/pluginscenter/constants.py:148
 msgid "插件"
 msgstr "Plugin"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:147
+#: paasng/bk_plugins/pluginscenter/constants.py:149
+msgid "测试版本"
+msgstr ""
+
+#: paasng/bk_plugins/pluginscenter/constants.py:150
 msgid "版本"
 msgstr "Version"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:148
+#: paasng/bk_plugins/pluginscenter/constants.py:151
 #, fuzzy
 #| msgid "同步应用基本信息"
 msgid "基本信息"
 msgstr "Basic information about the Sync APP"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:149
+#: paasng/bk_plugins/pluginscenter/constants.py:152
 msgid "logo"
 msgstr "logo"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:150
+#: paasng/bk_plugins/pluginscenter/constants.py:153
 #, fuzzy
 #| msgid "同步应用市场信息"
 msgid "市场信息"
 msgstr "Synchronise Market information"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:151
+#: paasng/bk_plugins/pluginscenter/constants.py:154
 msgid "配置信息"
 msgstr "config info"
 
-#: paasng/bk_plugins/pluginscenter/constants.py:152
+#: paasng/bk_plugins/pluginscenter/constants.py:155
 msgid "可见范围"
 msgstr "visible range"
+
+#: paasng/bk_plugins/pluginscenter/constants.py:161
+msgid "正式发布"
+msgstr ""
+
+#: paasng/bk_plugins/pluginscenter/constants.py:162
+msgid "测试发布"
+msgstr ""
+
+#: paasng/bk_plugins/pluginscenter/constants.py:168
+msgid "灰度发布"
+msgstr ""
+
+#: paasng/bk_plugins/pluginscenter/constants.py:169
+msgid "全量发布"
+msgstr ""
 
 #: paasng/bk_plugins/pluginscenter/exceptions.py:24
 msgid "创建插件项目(源码)失败, 请联系管理员"
@@ -840,102 +875,106 @@ msgid "该代码分支/Tag 已经发布过，不能重复发布"
 msgstr ""
 
 #: paasng/bk_plugins/pluginscenter/exceptions.py:30
+msgid "该代码分支/Tag 正在发布，不能重复发布"
+msgstr ""
+
+#: paasng/bk_plugins/pluginscenter/exceptions.py:31
 #, fuzzy
 #| msgid "部署失败，已有部署任务进行中，请刷新查看"
 msgid "已有发布任务进行中，请刷新查看"
 msgstr ""
 "Deployment failed, existing deployment in progress, please refresh to see"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:31
+#: paasng/bk_plugins/pluginscenter/exceptions.py:32
 msgid "重试步骤失败, 当前步骤不支持重试。"
 msgstr "The retry step failed, the current step does not support retrying."
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:32
+#: paasng/bk_plugins/pluginscenter/exceptions.py:33
 msgid "无法退回至上一步"
 msgstr "Can't go back to previous step"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:33
+#: paasng/bk_plugins/pluginscenter/exceptions.py:34
 msgid "无法停止发布"
 msgstr "Can't stop publish"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:34
-#: paasng/bk_plugins/pluginscenter/views.py:625
+#: paasng/bk_plugins/pluginscenter/exceptions.py:35
+#: paasng/bk_plugins/pluginscenter/views.py:629
 msgid "插件不支持终止发布操作"
 msgstr "Plugin does not support abort publish operation"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:35
+#: paasng/bk_plugins/pluginscenter/exceptions.py:36
 msgid "无法重新发布该版本"
 msgstr "Unable to republish this version"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:36
+#: paasng/bk_plugins/pluginscenter/exceptions.py:37
 msgid "发布步骤执行失败"
 msgstr "Publish step execution failed"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:37
+#: paasng/bk_plugins/pluginscenter/exceptions.py:38
 msgid "当前步骤在新的发布流程中被移除, 请重新发起部署流程或联系插件管理员"
 msgstr ""
 "The current step is removed in the new release process, please re-initiate "
 "the deployment process or contact the plugin administrator"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:38
+#: paasng/bk_plugins/pluginscenter/exceptions.py:39
 #, python-brace-format
 msgid "该插件 {conflict_fields} 的配置项已存在, 不能重复添加"
 msgstr ""
 "The configuration item of the plugin {conflict_fields} already exists and "
 "cannot be added repeatedly"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:39
+#: paasng/bk_plugins/pluginscenter/exceptions.py:40
 msgid "查询步骤详情失败"
 msgstr "Failed to query step details"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:40
+#: paasng/bk_plugins/pluginscenter/exceptions.py:41
 msgid "插件不支持重新上架"
 msgstr "Plugin does not support abort publish operation"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:41
+#: paasng/bk_plugins/pluginscenter/exceptions.py:42
 msgid "下架失败"
 msgstr "Archive Failed"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:42
+#: paasng/bk_plugins/pluginscenter/exceptions.py:43
 msgid "重新上架失败"
 msgstr "Republish failed"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:45
+#: paasng/bk_plugins/pluginscenter/exceptions.py:46
 msgid "插件应该至少拥有一个管理员"
 msgstr "The plugin should have at least one administrator"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:46
+#: paasng/bk_plugins/pluginscenter/exceptions.py:47
 msgid "添加插件成员失败"
 msgstr "Failed to add plugin member"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:47
+#: paasng/bk_plugins/pluginscenter/exceptions.py:48
 msgid "修改插件成员角色失败"
 msgstr "Failed to modify plugin member role"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:49
+#: paasng/bk_plugins/pluginscenter/exceptions.py:50
 msgid "不允许删除"
 msgstr "Not allowed to delete"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:50
+#: paasng/bk_plugins/pluginscenter/exceptions.py:51
 msgid "插件已下架, 无法进行该操作"
 msgstr "The plug-in has been removed, and this operation cannot be performed"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:52
+#: paasng/bk_plugins/pluginscenter/exceptions.py:53
 msgid "添加/删除仓库成员异常, 请稍后重试"
 msgstr "Add/delete repository member exception, please try again later"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:54
+#: paasng/bk_plugins/pluginscenter/exceptions.py:55
 msgid "查询代码仓库概览数据异常"
 msgstr "Query code warehouse overview data exception"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:56
+#: paasng/bk_plugins/pluginscenter/exceptions.py:57
 #, fuzzy
 #| msgid "日志查询失败，请稍后重试"
 msgid "日志系统异常, 请稍后重试"
 msgstr " Logging  failed, please try again later"
 
-#: paasng/bk_plugins/pluginscenter/exceptions.py:68
-#: paasng/utils/error_codes.py:186
+#: paasng/bk_plugins/pluginscenter/exceptions.py:69
+#: paasng/utils/error_codes.py:193
 msgid "| 错误码 | 描述 |"
 msgstr "| Error Code | Description |"
 
@@ -1041,7 +1080,7 @@ msgstr "Failed to sync version information, cannot create new version"
 
 #: paasng/bk_plugins/pluginscenter/releases/executor.py:54
 #: tests/paasng/bk_plugins/pluginscenter/release/test_executor.py:124
-#: tests/paasng/bk_plugins/pluginscenter/test_integration.py:90
+#: tests/paasng/bk_plugins/pluginscenter/test_integration.py:153
 msgid "当前阶段未执行成功, 不允许进入下一阶段"
 msgstr ""
 "The current stage has not been executed successfully, and it is not allowed "
@@ -1116,51 +1155,57 @@ msgstr "User voluntarily terminates publishing"
 
 #: paasng/bk_plugins/pluginscenter/releases/stages.py:72
 #: paasng/bk_plugins/pluginscenter/releases/stages.py:98
-#: paasng/bk_plugins/pluginscenter/releases/stages.py:255
-#: paasng/bk_plugins/pluginscenter/releases/stages.py:272
-#: paasng/bk_plugins/pluginscenter/releases/stages.py:317
+#: paasng/bk_plugins/pluginscenter/releases/stages.py:256
+#: paasng/bk_plugins/pluginscenter/releases/stages.py:273
+#: paasng/bk_plugins/pluginscenter/releases/stages.py:318
 msgid "当前步骤状态异常"
 msgstr "Current step status is abnormal"
 
-#: paasng/bk_plugins/pluginscenter/releases/stages.py:147
+#: paasng/bk_plugins/pluginscenter/releases/stages.py:148
 msgid "当前阶段并非部署阶段"
 msgstr "The current phase is not a deployment phase"
 
-#: paasng/bk_plugins/pluginscenter/releases/stages.py:245
-#: paasng/bk_plugins/pluginscenter/releases/stages.py:250
+#: paasng/bk_plugins/pluginscenter/releases/stages.py:246
+#: paasng/bk_plugins/pluginscenter/releases/stages.py:251
 msgid "构建失败"
 msgstr "Build failed"
 
-#: paasng/bk_plugins/pluginscenter/releases/stages.py:410
+#: paasng/bk_plugins/pluginscenter/releases/stages.py:411
 msgid "插件已发布成功"
 msgstr "The plugin has been published successfully"
 
-#: paasng/bk_plugins/pluginscenter/serializers.py:63
+#: paasng/bk_plugins/pluginscenter/serializers.py:76
 msgid "context `pd` is required"
 msgstr ""
 
-#: paasng/bk_plugins/pluginscenter/serializers.py:90
+#: paasng/bk_plugins/pluginscenter/serializers.py:103
 #, fuzzy
 #| msgid "{} 为 {} 的应用已存在"
 msgid "{} 为 {} 的插件已存在"
 msgstr "{} for {} already exists"
 
-#: paasng/bk_plugins/pluginscenter/serializers.py:93
+#: paasng/bk_plugins/pluginscenter/serializers.py:106
 msgid "attrs `{}` is required"
 msgstr ""
 
-#: paasng/bk_plugins/pluginscenter/serializers.py:388
+#: paasng/bk_plugins/pluginscenter/serializers.py:419
 #, python-brace-format
 msgid "版本号不符合，下一个 {label} 版本是 {revision}"
 msgstr "Revision numbers do not match, next {label} revision is {revision}"
 
-#: paasng/bk_plugins/pluginscenter/serializers.py:401
+#: paasng/bk_plugins/pluginscenter/serializers.py:445
 msgid "版本号必须与代码分支一致"
 msgstr "The version number must match the code branch"
 
-#: paasng/bk_plugins/pluginscenter/serializers.py:404
+#: paasng/bk_plugins/pluginscenter/serializers.py:448
 msgid "版本号必须与提交哈希一致"
 msgstr "The version number must match the commit hash"
+
+#: paasng/bk_plugins/pluginscenter/serializers.py:451
+#, fuzzy
+#| msgid "版本号必须与代码分支一致"
+msgid "版本号必须以代码分支开头"
+msgstr "The version number must match the code branch"
 
 #: paasng/bk_plugins/pluginscenter/shim.py:111
 msgid "同名仓库已存在"
@@ -1176,25 +1221,25 @@ msgstr "Tc_git interface request timeout"
 msgid "工蜂接口请求异常"
 msgstr "Tc_git interface request exception"
 
-#: paasng/bk_plugins/pluginscenter/views.py:371
+#: paasng/bk_plugins/pluginscenter/views.py:372
 #, fuzzy
 #| msgid "插件已下架, 无法进行该操作"
 msgid "插件已下架，不能再执行下架操作"
 msgstr "The plug-in has been removed, and this operation cannot be performed"
 
-#: paasng/bk_plugins/pluginscenter/views.py:397
+#: paasng/bk_plugins/pluginscenter/views.py:398
 msgid "插件未下架，不能重新上架"
 msgstr "Plugin not unlisted, cannot be relisted."
 
-#: paasng/bk_plugins/pluginscenter/views.py:716
+#: paasng/bk_plugins/pluginscenter/views.py:733
 msgid "仅支持重试当前阶段"
 msgstr "Only supports retrying the current phase"
 
-#: paasng/bk_plugins/pluginscenter/views.py:830
+#: paasng/bk_plugins/pluginscenter/views.py:847
 msgid "用户 {} 已存在"
 msgstr ""
 
-#: paasng/bk_plugins/pluginscenter/views.py:858
+#: paasng/bk_plugins/pluginscenter/views.py:875
 msgid "插件成员 {} 不存在"
 msgstr ""
 
@@ -1223,6 +1268,7 @@ msgid "不允许访问服务的用户"
 msgstr "Users not allowed access"
 
 #: paasng/infras/accounts/constants.py:51
+#: paasng/platform/evaluation/constants.py:26
 msgid "平台管理员"
 msgstr ""
 
@@ -1286,7 +1332,7 @@ msgstr ""
 msgid "允许从源码部署云原生应用"
 msgstr "Allows creation of S-mart APP"
 
-#: paasng/infras/accounts/middlewares.py:66
+#: paasng/infras/accounts/middlewares.py:68
 msgid "产品灰度测试中，尚未开放，敬请期待"
 msgstr "The product is in grayscale testing, not yet open, so stay tuned"
 
@@ -1857,7 +1903,7 @@ msgid "已上线"
 msgstr "Now online"
 
 #: paasng/plat_admin/numbers/app.py:540
-#: paasng/platform/applications/views.py:890
+#: paasng/platform/applications/views.py:894
 msgid "已下架"
 msgstr "Archived"
 
@@ -1865,7 +1911,7 @@ msgstr "Archived"
 msgid "测试中"
 msgstr "Testing in progress"
 
-#: paasng/plat_admin/system/views.py:162 paasng/plat_admin/system/views.py:254
+#: paasng/plat_admin/system/views.py:179 paasng/plat_admin/system/views.py:271
 msgid "无法获取到有效的配置信息."
 msgstr "No valid configuration information is available."
 
@@ -1875,6 +1921,10 @@ msgstr ""
 
 #: paasng/platform/applications/constants.py:104
 msgid "开启出口 IP 管理"
+msgstr ""
+
+#: paasng/platform/applications/constants.py:107
+msgid "开启持久存储挂载卷"
 msgstr ""
 
 #: paasng/platform/applications/exceptions.py:25
@@ -1967,6 +2017,7 @@ msgid "你无法使用高级创建选项"
 msgstr "You cannot use the advanced creation option"
 
 #: paasng/platform/applications/views.py:421
+#: paasng/platform/applications/views.py:511
 msgid "当前版本下无法创建蓝鲸插件应用"
 msgstr "The  bk-plugin APP cannot be created under the current version"
 
@@ -1976,45 +2027,57 @@ msgstr "The  bk-plugin APP cannot be created under the current version"
 msgid "你无法创建云原生应用"
 msgstr "You cannot create a S-mart APP"
 
-#: paasng/platform/applications/views.py:585
+#: paasng/platform/applications/views.py:589
 msgid "你无法在所指定的 region 中创建应用"
 msgstr "You cannot create an application in the specified region"
 
-#: paasng/platform/applications/views.py:608
+#: paasng/platform/applications/views.py:612
 #, python-format
 msgid "集群未配置默认的根域名, 请检查 region=%s 下的集群配置是否合理."
 msgstr ""
 
-#: paasng/platform/applications/views.py:708
+#: paasng/platform/applications/views.py:712
 #: paasng/platform/modules/views.py:318
 msgid "你无法使用非默认的源码来源"
 msgstr "You cannot use non-default source code sources"
 
-#: paasng/platform/applications/views.py:886
+#: paasng/platform/applications/views.py:890
 msgid "开发中"
 msgstr "Developing"
 
-#: paasng/platform/applications/views.py:887
+#: paasng/platform/applications/views.py:891
 #: paasng/platform/engine/constants.py:41
 msgid "预发布环境"
 msgstr " Stag Env "
 
-#: paasng/platform/applications/views.py:888
+#: paasng/platform/applications/views.py:892
 #: paasng/platform/engine/constants.py:42
 msgid "生产环境"
 msgstr "Prod Env"
 
-#: paasng/platform/applications/views.py:889
+#: paasng/platform/applications/views.py:893
 msgid "应用市场"
 msgstr " Market "
 
-#: paasng/platform/bkapp_model/serializers.py:118
-msgid "应用{attrs[\"bkAppCode\"]}或模块{attrs[\"moduleName\"]}不存在"
-msgstr ""
+#: paasng/platform/bkapp_model/serializers.py:119
+msgid "应用{}不存在"
+msgstr "The application {} cannot be found."
 
-#: paasng/platform/bkapp_model/serializers.py:141
+#: paasng/platform/bkapp_model/serializers.py:124
+msgid "模块{}不存在"
+msgstr "The module {} cannot be found."
+
+#: paasng/platform/bkapp_model/serializers.py:139
+msgid "服务发现列表中存在重复项：{}"
+msgstr "Duplicate entries found in svc-discovery list: {}"
+
+#: paasng/platform/bkapp_model/serializers.py:158
 msgid "至少需要提供一个有效值：nameservers 或 host_aliases"
 msgstr ""
+
+#: paasng/platform/bkapp_model/serializers.py:164
+msgid "BkApp 配置信息"
+msgstr "config info"
 
 #: paasng/platform/bkapp_model/services.py:113
 #, fuzzy
@@ -2051,36 +2114,41 @@ msgstr ""
 "abnormally in the market. Please turn off the market switch and operate "
 "again."
 
-#: paasng/platform/declarative/application/resources.py:135
+#: paasng/platform/declarative/application/resources.py:126
 msgid "当前应用未定义主模块"
 msgstr "The current APP does not define a default module"
 
-#: paasng/platform/declarative/application/validations.py:116
-#: paasng/platform/declarative/serializers.py:155
+#: paasng/platform/declarative/application/validations/v2.py:125
+#: paasng/platform/declarative/application/validations/v3.py:141
+#: paasng/platform/declarative/serializers.py:157
 msgid "格式错误，只能包含小写字母(a-z)、数字(0-9)和半角连接符(-)和下划线(_)"
 msgstr ""
 "Format error, can only contain lowercase letters (a-z), numbers (0-9), and "
 "half-width hyphens (-) and underscores ()"
 
-#: paasng/platform/declarative/application/validations.py:137
+#: paasng/platform/declarative/application/validations/v2.py:149
+#: paasng/platform/declarative/application/validations/v3.py:166
 msgid "一个应用只能有一个主模块"
 msgstr "An app can only have one default module"
 
-#: paasng/platform/declarative/application/validations.py:140
+#: paasng/platform/declarative/application/validations/v2.py:152
+#: paasng/platform/declarative/application/validations/v3.py:169
 msgid "一个应用必须有一个主模块"
 msgstr "An APP must have a default module"
 
-#: paasng/platform/declarative/application/validations.py:146
+#: paasng/platform/declarative/application/validations/v2.py:159
+#: paasng/platform/declarative/application/validations/v3.py:176
 msgid "提供共享增强服务的模块不存在"
 msgstr "module providing shared Add-ons does not exist"
 
-#: paasng/platform/declarative/deployment/validations.py:102
+#: paasng/platform/declarative/deployment/validations/v2.py:117
 msgid "至少需要指定一个有效的探活检测机制"
 msgstr ""
 
-#: paasng/platform/declarative/handlers.py:121
-#: paasng/platform/declarative/handlers.py:132
-#: paasng/platform/declarative/handlers.py:134
+#: paasng/platform/declarative/handlers.py:128
+#: paasng/platform/declarative/handlers.py:191
+#: paasng/platform/declarative/handlers.py:202
+#: paasng/platform/declarative/handlers.py:204
 msgid "内容不能为空"
 msgstr "content cannot be empty"
 
@@ -2089,7 +2157,7 @@ msgid "通过描述文件定义的应用不支持该操作"
 msgstr ""
 "This operation is not supported by the APP defined by the description file"
 
-#: paasng/platform/declarative/serializers.py:142
+#: paasng/platform/declarative/serializers.py:144
 msgid ""
 "格式错误，只能以 \"BKAPP_\" 开头，由大写字母、数字与下划线组成，长度不超过 "
 "50。"
@@ -2174,7 +2242,7 @@ msgstr "Ongoing archive tasks exist"
 msgid "The Pre-release command is not configured, skip the Pre-release phase."
 msgstr ""
 
-#: paasng/platform/engine/deploy/building.py:130
+#: paasng/platform/engine/deploy/building.py:132
 #, python-brace-format
 msgid ""
 "The source directory '{source_dir}' is not a legal directory,please check "
@@ -2182,14 +2250,14 @@ msgid ""
 msgstr ""
 
 #: paasng/platform/engine/deploy/building.py:158
-#: paasng/platform/engine/deploy/image_release.py:200
+#: paasng/platform/engine/deploy/image_release.py:204
 #, fuzzy
 #| msgid "分析应用描述文件异常"
 msgid "应用描述文件解析异常: {}"
 msgstr "Analyzing APP Description File Exceptions"
 
 #: paasng/platform/engine/deploy/building.py:166
-#: paasng/platform/engine/deploy/image_release.py:206
+#: paasng/platform/engine/deploy/image_release.py:210
 msgid "处理应用描述文件时出现异常, 请检查应用描述文件"
 msgstr ""
 "An exception occurred while processing the app description file, please "
@@ -2202,7 +2270,7 @@ msgid ""
 "not enabled, please check if they need to be enabled"
 msgstr ""
 
-#: paasng/platform/engine/deploy/building.py:331
+#: paasng/platform/engine/deploy/building.py:329
 #: paasng/platform/engine/deploy/building.py:435
 msgid "发布时自动构建"
 msgstr "Automatically build when deploying"
@@ -2317,16 +2385,16 @@ msgstr ""
 msgid "无效的排序选项：%s"
 msgstr "Invalid sort option: %s"
 
-#: paasng/platform/engine/utils/source.py:164
+#: paasng/platform/engine/utils/source.py:159
 msgid ""
 "Warning: Process definition conflict, will use the one defined in `Procfile`"
 msgstr ""
 
-#: paasng/platform/engine/utils/source.py:169
+#: paasng/platform/engine/utils/source.py:163
 msgid "Missing process definition"
 msgstr ""
 
-#: paasng/platform/engine/utils/source.py:253
+#: paasng/platform/engine/utils/source.py:247
 #, python-brace-format
 msgid ""
 "WARNING: 应用源码包体积过大（>{warning_threshold}MB），将严重影响部署性能，请"
@@ -2375,12 +2443,12 @@ msgstr "{code} does not have an unlisted record with id {uuid}"
 msgid "服务异常"
 msgstr "Engine service exception"
 
-#: paasng/platform/engine/workflow/flow.py:95
+#: paasng/platform/engine/workflow/flow.py:96
 #, python-brace-format
 msgid "步骤 [{title}] 出错了，原因：{reason}。"
 msgstr "Error in step [{title}], reason: {reason}."
 
-#: paasng/platform/engine/workflow/flow.py:99
+#: paasng/platform/engine/workflow/flow.py:100
 #, python-brace-format
 msgid "步骤 [{title}] 出错了，请稍候重试。"
 msgstr "Error in step [{title}], please try again later"
@@ -2420,11 +2488,33 @@ msgstr ""
 "The current user does not have permission to deploy this environment, please "
 "contact the APP administrator"
 
-#: paasng/platform/mgrlegacy/app_migrations/basic.py:52
+#: paasng/platform/evaluation/constants.py:27
+#, fuzzy
+#| msgid "系统 API 用户：具有轻应用管理权限"
+msgid "应用管理员"
+msgstr "System API users: have mini-app management permissions"
+
+#: paasng/platform/evaluation/constants.py:33
+msgid "无"
+msgstr ""
+
+#: paasng/platform/evaluation/constants.py:34
+msgid "无主"
+msgstr ""
+
+#: paasng/platform/evaluation/constants.py:35
+msgid "不活跃"
+msgstr ""
+
+#: paasng/platform/evaluation/constants.py:36
+msgid "配置错误"
+msgstr ""
+
+#: paasng/platform/mgrlegacy/app_migrations/basic.py:55
 msgid "创建应用对象"
 msgstr "Creating APP objects"
 
-#: paasng/platform/mgrlegacy/app_migrations/basic.py:106
+#: paasng/platform/mgrlegacy/app_migrations/basic.py:109
 msgid "同步应用基本信息"
 msgstr "Basic information about the Sync APP"
 
@@ -2595,25 +2685,25 @@ msgid "同步SVN版本库信息"
 msgstr "Sync SVN repository information"
 
 #: paasng/platform/mgrlegacy/legacy_proxy.py:80
-#: paasng/platform/mgrlegacy/legacy_proxy_te.py:103
+#: paasng/platform/mgrlegacy/legacy_proxy_te.py:102
 msgid "暂不支持轻应用迁移"
 msgstr " Mini-APP migration is not currently supported"
 
 #: paasng/platform/mgrlegacy/legacy_proxy.py:84
-#: paasng/platform/mgrlegacy/legacy_proxy_te.py:109
+#: paasng/platform/mgrlegacy/legacy_proxy_te.py:108
 msgid "暂不支持该类型应用迁移"
 msgstr "This type of APP migration is not currently supported"
 
 #: paasng/platform/mgrlegacy/legacy_proxy.py:87
-#: paasng/platform/mgrlegacy/legacy_proxy_te.py:118
+#: paasng/platform/mgrlegacy/legacy_proxy_te.py:117
 msgid "目前仅支持Python应用迁移"
 msgstr "Previously only supported Python APP migration"
 
-#: paasng/platform/mgrlegacy/legacy_proxy_te.py:122
+#: paasng/platform/mgrlegacy/legacy_proxy_te.py:121
 msgid "该项目没有trunk分支，请先添加trunk分支"
 msgstr ""
 
-#: paasng/platform/mgrlegacy/legacy_proxy_te.py:130
+#: paasng/platform/mgrlegacy/legacy_proxy_te.py:129
 msgid "未知原因, 请联系管理员处理"
 msgstr "No known reason, please contact the administrator"
 
@@ -2621,34 +2711,34 @@ msgstr "No known reason, please contact the administrator"
 msgid "已确认后的应用无法回滚"
 msgstr "APP that have been confirmed cannot be rolled back"
 
-#: paasng/platform/modules/manager.py:360
-#: paasng/platform/modules/manager.py:403
+#: paasng/platform/modules/manager.py:363
+#: paasng/platform/modules/manager.py:406
 msgid "服务暂时不可用，请稍候再试"
 msgstr "Service is temporarily unavailable, please try again later"
 
-#: paasng/platform/modules/manager.py:363
-#: paasng/platform/modules/manager.py:439
+#: paasng/platform/modules/manager.py:366
+#: paasng/platform/modules/manager.py:442
 msgid "绑定初始增强服务失败，请稍候再试"
 msgstr "Failed to bind the initial Add-ons, please try again later"
 
-#: paasng/platform/modules/manager.py:368
-#: paasng/platform/modules/manager.py:429
-#: paasng/platform/modules/manager.py:433
+#: paasng/platform/modules/manager.py:371
+#: paasng/platform/modules/manager.py:432
+#: paasng/platform/modules/manager.py:436
 msgid "绑定初始运行环境失败，请稍候再试"
 msgstr "Failed to bind the initial runtime environment, please try again later"
 
-#: paasng/platform/modules/manager.py:373
-#: paasng/platform/modules/manager.py:442
+#: paasng/platform/modules/manager.py:376
+#: paasng/platform/modules/manager.py:445
 #, fuzzy
 #| msgid "代码初始化过程失败，请稍候再试"
 msgid "初始化应用模型失败, 请稍候再试"
 msgstr "Code initialization process failed, please wait and try again"
 
-#: paasng/platform/modules/manager.py:409
+#: paasng/platform/modules/manager.py:412
 msgid "代码初始化过程失败，请稍候再试"
 msgstr "Code initialization process failed, please wait and try again"
 
-#: paasng/platform/modules/manager.py:436
+#: paasng/platform/modules/manager.py:439
 msgid "配置镜像 Registry 失败，请稍候再试"
 msgstr "Failed to configure mirror Registry, please try again later"
 
@@ -2791,14 +2881,14 @@ msgid "应用描述文件内容不是有效 YAML 格式"
 msgstr "The content of the app description file is not in valid YAML format"
 
 #: paasng/platform/smart_app/management/commands/smart_tool.py:57
-#: paasng/platform/smart_app/views.py:181
-#: paasng/platform/smart_app/views.py:226
+#: paasng/platform/smart_app/views.py:176
+#: paasng/platform/smart_app/views.py:221
 msgid "缺失应用市场配置（market)!"
 msgstr "Missing  Market  configuration (market)!"
 
 #: paasng/platform/smart_app/management/commands/smart_tool.py:59
-#: paasng/platform/smart_app/views.py:183
-#: paasng/platform/smart_app/views.py:228
+#: paasng/platform/smart_app/views.py:178
+#: paasng/platform/smart_app/views.py:223
 msgid "请检查源码包是否存在 app_desc.yaml 文件"
 msgstr "Please check if the source package has an app_desc.yaml file"
 
@@ -2814,25 +2904,25 @@ msgstr ""
 msgid "找不到任何有效的应用描述信息"
 msgstr "No valid APP descriptions found"
 
-#: paasng/platform/smart_app/views.py:73 paasng/platform/smart_app/views.py:202
+#: paasng/platform/smart_app/views.py:74 paasng/platform/smart_app/views.py:197
 #: paasng/platform/sourcectl/views.py:286
 msgid "请联系管理员"
 msgstr "Please contact administrator"
 
-#: paasng/platform/smart_app/views.py:84
+#: paasng/platform/smart_app/views.py:85
 msgid "你无法创建 SMart 应用"
 msgstr "You cannot create a S-mart APP"
 
-#: paasng/platform/smart_app/views.py:133
+#: paasng/platform/smart_app/views.py:128
 msgid "你无法创建 S-Mart 应用"
 msgstr "You cannot create a S-mart APP"
 
-#: paasng/platform/smart_app/views.py:179
+#: paasng/platform/smart_app/views.py:174
 #, python-brace-format
 msgid "应用ID: {appid} 的应用已存在!"
 msgstr "APP ID: {appid} of the APP already exists!"
 
-#: paasng/platform/smart_app/views.py:224
+#: paasng/platform/smart_app/views.py:219
 #, python-brace-format
 msgid "应用ID: {appid} 的应用不存在!"
 msgstr "APP ID: {appid} of the APP does not exist!"
@@ -3509,6 +3599,10 @@ msgstr ""
 msgid "暂不支持修改该配置"
 msgstr "This feature is not supported at the moment"
 
+#: paasng/utils/error_codes.py:177
+msgid "导入应用模型失败"
+msgstr ""
+
 #: paasng/utils/error_message.py:92
 #, python-brace-format
 msgid "错误码: {code_num}, {msg}"
@@ -3533,14 +3627,35 @@ msgstr ""
 msgid "参数格式错误"
 msgstr "Parameter format error"
 
-#: tests/paasng/bk_plugins/pluginscenter/test_serializers.py:90
-#: tests/paasng/bk_plugins/pluginscenter/test_serializers.py:102
+#: tests/paasng/bk_plugins/pluginscenter/test_serializers.py:91
+#: tests/paasng/bk_plugins/pluginscenter/test_serializers.py:103
 msgid "This value does not match the required pattern."
 msgstr ""
 
 #: tests/paasng/platform/sourcectl/packages/test_utils.py:47
 msgid "zh-cn"
 msgstr ""
+
+#~ msgid "进程类型"
+#~ msgstr "Process Type"
+
+#~ msgid "旧副本数"
+#~ msgstr "Old replicas"
+
+#~ msgid "新副本数"
+#~ msgstr "New replicas"
+
+#~ msgid "进程副本数变化"
+#~ msgstr "Replica Change"
+
+#~ msgid "挂载卷内容"
+#~ msgstr "Mount volume content"
+
+#~ msgid "Failed to deploy bkapp"
+#~ msgstr "Failed to deploy bkapp"
+
+#~ msgid "Failed to find bkapp in Kubernetes"
+#~ msgstr "Failed to find bkapp in Kubernetes"
 
 #~ msgid "engine_params.source_init_template: 必须选择一个应用模板"
 #~ msgstr ""

--- a/apiserver/paasng/paasng/platform/bkapp_model/serializers.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/serializers.py
@@ -136,7 +136,10 @@ class SvcDiscConfigSLZ(serializers.Serializer):
         for item in value:
             pair = (item["bkAppCode"], item["moduleName"] or "")
             if pair in seen:
-                raise serializers.ValidationError(_("服务发现列表中存在重复项：{}").format(pair))
+                pair_for_display = f"AppID: {pair[0]}"
+                if pair[1]:
+                    pair_for_display += f", ModuleName: {pair[1]}"
+                raise serializers.ValidationError(_("服务发现列表中存在重复项：{}").format(f"[{pair_for_display}]"))
             seen.add(pair)
         return value
 

--- a/apiserver/paasng/paasng/platform/bkapp_model/serializers.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/serializers.py
@@ -15,14 +15,17 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+from typing import Dict, List, Optional
+
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
+from typing_extensions import TypeAlias
 
 from paas_wl.bk_app.cnative.specs.constants import ScalingPolicy
 from paas_wl.bk_app.processes.serializers import MetricSpecSLZ
 from paas_wl.workloads.autoscaling.constants import DEFAULT_METRICS
-from paasng.platform.modules.constants import DeployHookType, ModuleName
-from paasng.platform.modules.models.module import Module
+from paasng.platform.applications.models import Application
+from paasng.platform.modules.constants import DeployHookType
 
 
 class GetManifestInputSLZ(serializers.Serializer):
@@ -106,22 +109,36 @@ class SvcDiscEntryBkSaaSSLZ(serializers.Serializer):
     """A service discovery entry that represents an application and an optional module."""
 
     bk_app_code = serializers.CharField(help_text="被服务发现的应用 code", max_length=20, source="bkAppCode")
-    module_name = serializers.CharField(
-        help_text="被服务发现的应用模块", max_length=20, default=ModuleName.DEFAULT.value, source="moduleName"
-    )
+    module_name = serializers.CharField(help_text="被服务发现的模块", max_length=20, source="moduleName", default=None)
 
     def validate(self, attrs):
         """校验应用和模块存在，否则抛出异常"""
-        # NOTE: 在整个链路中，应用下的模块配置错误都没有提示，因此在创建应用时，提示错误
-        # 判断应用或者模块是否存在
-        if not Module.objects.filter(application__code=attrs["bkAppCode"], name=attrs["moduleName"]).exists():
-            raise serializers.ValidationError(_(f'应用{attrs["bkAppCode"]}或模块{attrs["moduleName"]}不存在'))
+        try:
+            application = Application.objects.get(code=attrs["bkAppCode"])
+        except Application.DoesNotExist:
+            raise serializers.ValidationError(_("应用{}不存在").format(attrs["bkAppCode"]))
 
+        # Check if module exists when the "module_name" is set
+        if module_name := attrs["moduleName"]:  # noqa: SIM102
+            if not application.modules.filter(name=module_name).exists():
+                raise serializers.ValidationError(_("模块{}不存在").format(module_name))
         return attrs
+
+
+BkSaaSList: TypeAlias = List[Dict[str, Optional[str]]]
 
 
 class SvcDiscConfigSLZ(serializers.Serializer):
     bk_saas = serializers.ListField(help_text="服务发现列表", child=SvcDiscEntryBkSaaSSLZ())
+
+    def validate_bk_saas(self, value: BkSaaSList) -> BkSaaSList:
+        seen = set()
+        for item in value:
+            pair = (item["bkAppCode"], item["moduleName"] or "")
+            if pair in seen:
+                raise serializers.ValidationError(_("服务发现列表中存在重复项：{}").format(pair))
+            seen.add(pair)
+        return value
 
 
 class HostAliasSLZ(serializers.Serializer):

--- a/apiserver/paasng/paasng/platform/bkapp_model/views.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/views.py
@@ -245,7 +245,7 @@ class ModuleDeployHookViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
 
 
 class SvcDiscConfigViewSet(viewsets.GenericViewSet, ApplicationCodeInPathMixin):
-    permission_classes = [IsAuthenticated, application_perm_class(AppAction.VIEW_BASIC_INFO)]
+    permission_classes = [IsAuthenticated, application_perm_class(AppAction.BASIC_DEVELOP)]
 
     @swagger_auto_schema(responses={200: SvcDiscConfigSLZ()})
     def retrieve(self, request, code):
@@ -273,7 +273,7 @@ class SvcDiscConfigViewSet(viewsets.GenericViewSet, ApplicationCodeInPathMixin):
 
 
 class DomainResolutionViewSet(viewsets.GenericViewSet, ApplicationCodeInPathMixin):
-    permission_classes = [IsAuthenticated, application_perm_class(AppAction.VIEW_BASIC_INFO)]
+    permission_classes = [IsAuthenticated, application_perm_class(AppAction.BASIC_DEVELOP)]
 
     @swagger_auto_schema(responses={200: DomainResolutionSLZ()})
     def retrieve(self, request, code):


### PR DESCRIPTION
- Disallow duplicate entries when upsert svc-disc config
- Changed the behavior of `SvcDiscEntryBkSaaSSLZ`: it sets `module_name` to None instead of `default', because `None` means that the **default module** is always used, while `default' refers to the module named "default" even if it is not the real "default" module.
- Change the permission level for APIs: DomainResolutionViewSet / SvcDiscConfigViewSet
- Some translation issues fixed