### PR TITLE
fix: generate incorrect command/args for smart app after introducing VER_3

### DIFF
--- a/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
@@ -112,6 +112,7 @@ class DeploymentDeclarativeController:
             # 云原生应用
             # TODO: 优化 import 方式, 例如直接接受 desc.spec
             # Warning: app_desc 中声明的 hooks 会覆盖产品上已填写的 hooks
+            # Warning: import_manifest 时, proc_command 会被置为 None, 仅 command/args 会保留
             import_manifest(
                 module,
                 input_data=convert_bkapp_spec_to_manifest(deploy_desc.spec),

--- a/apiserver/paasng/paasng/platform/declarative/deployment/validations/v2.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/validations/v2.py
@@ -161,7 +161,6 @@ class DeploymentDescSLZ(serializers.Serializer):
                     "name": proc_type,
                     "replicas": process["replicas"] or 1,
                     "resQuotaPlan": get_quota_plan(process["plan"]) if process.get("plan") else None,
-                    # 镜像已保证 entrypoint 是 /runner/init
                     "command": None,
                     "args": shlex.split(process["command"]),
                     "probes": process.get("probes"),

--- a/apiserver/paasng/paasng/platform/declarative/handlers.py
+++ b/apiserver/paasng/paasng/platform/declarative/handlers.py
@@ -52,6 +52,7 @@ def get_desc_handler(json_data: Dict) -> "DescriptionHandler":
     elif spec_version == AppSpecVersion.VER_2:
         return AppDescriptionHandler(json_data)
     else:
+        # 对应 AppSpecVersion.VER_3
         return CNativeAppDescriptionHandler(json_data)
 
 


### PR DESCRIPTION
重构 `ProcessesManifestConstructor.get_command_and_args`,  以处理 #1141 带来的新模型影响