### PR TITLE
Fix: the pre-release pod missing svc-disc env variables

### DIFF
--- a/operator/pkg/controllers/bkapp/deploy_action.go
+++ b/operator/pkg/controllers/bkapp/deploy_action.go
@@ -106,8 +106,7 @@ func (r *DeployActionReconciler) Reconcile(ctx context.Context, bkapp *paasv1alp
 // validate that there are no running hooks currently, return error if found any running hooks.
 func (r *DeployActionReconciler) validateNoRunningHooks(ctx context.Context, bkapp *paasv1alpha2.BkApp) error {
 	// Check pre-release hook
-	hook := hookres.BuildPreReleaseHook(bkapp, bkapp.Status.FindHookStatus(paasv1alpha2.HookPreRelease))
-	if hook != nil && hook.Progressing() {
+	if hookres.IsPreReleaseProgressing(bkapp) {
 		_, err := hooks.CheckAndUpdatePreReleaseHookStatus(
 			ctx,
 			r.Client,

--- a/operator/pkg/controllers/bkapp/hooks/hooks.go
+++ b/operator/pkg/controllers/bkapp/hooks/hooks.go
@@ -39,6 +39,8 @@ import (
 	"bk.tencent.com/paas-app-operator/pkg/controllers/bkapp/common/labels"
 	"bk.tencent.com/paas-app-operator/pkg/controllers/bkapp/common/names"
 	hookres "bk.tencent.com/paas-app-operator/pkg/controllers/bkapp/hooks/resources"
+	"bk.tencent.com/paas-app-operator/pkg/controllers/bkapp/svcdisc"
+
 	"bk.tencent.com/paas-app-operator/pkg/health"
 	"bk.tencent.com/paas-app-operator/pkg/metrics"
 )
@@ -104,6 +106,11 @@ func (r *HookReconciler) Reconcile(ctx context.Context, bkapp *paasv1alpha2.BkAp
 
 	hook := hookres.BuildPreReleaseHook(bkapp, bkapp.Status.FindHookStatus(paasv1alpha2.HookPreRelease))
 	if hook != nil {
+		// Apply service discovery related changes
+		if ok := svcdisc.NewWorkloadsMutator(r.Client, bkapp).ApplyToPod(ctx, hook.Pod); ok {
+			log.V(1).Info("Applied svc-discovery related changes to the pre-release pod.")
+		}
+
 		if err := r.ExecuteHook(ctx, bkapp, hook); err != nil {
 			return r.Result.WithError(err)
 		}

--- a/operator/pkg/controllers/bkapp/hooks/hooks.go
+++ b/operator/pkg/controllers/bkapp/hooks/hooks.go
@@ -40,7 +40,6 @@ import (
 	"bk.tencent.com/paas-app-operator/pkg/controllers/bkapp/common/names"
 	hookres "bk.tencent.com/paas-app-operator/pkg/controllers/bkapp/hooks/resources"
 	"bk.tencent.com/paas-app-operator/pkg/controllers/bkapp/svcdisc"
-
 	"bk.tencent.com/paas-app-operator/pkg/health"
 	"bk.tencent.com/paas-app-operator/pkg/metrics"
 )

--- a/operator/pkg/controllers/bkapp/hooks/resources/hooks.go
+++ b/operator/pkg/controllers/bkapp/hooks/resources/hooks.go
@@ -90,6 +90,16 @@ func (i *HookInstance) TimeoutExceededFailed(timeout time.Duration) bool {
 		i.Status.StartTime.Add(timeout).Before(time.Now())
 }
 
+// IsPreReleaseProgressing checks if the pre-release hook of the current app is in "progressing" status.
+// Return false if the app does not have any pre-release hook.
+func IsPreReleaseProgressing(bkapp *paasv1alpha2.BkApp) bool {
+	if bkapp.Spec.Hooks == nil || bkapp.Spec.Hooks.PreRelease == nil {
+		return false
+	}
+	status := bkapp.Status.FindHookStatus(paasv1alpha2.HookPreRelease)
+	return status != nil && status.Phase == paasv1alpha2.HealthProgressing
+}
+
 // BuildPreReleaseHook 从应用描述中解析 Pre-Release-Hook 对象
 func BuildPreReleaseHook(bkapp *paasv1alpha2.BkApp, status *paasv1alpha2.HookStatus) *HookInstance {
 	if bkapp.Spec.Hooks == nil || bkapp.Spec.Hooks.PreRelease == nil {

--- a/operator/pkg/controllers/bkapp/svcdisc/mutator.go
+++ b/operator/pkg/controllers/bkapp/svcdisc/mutator.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -52,27 +53,32 @@ type WorkloadsMutator struct {
 
 // ApplyToDeployment mutates the given deployment, it try to inject service discovery information
 // to the env variables and volumes of the deployment, it mutate the deployments in-place.
-// return whether the mutation is performed.
+// Return whether the mutation is performed.
 func (w *WorkloadsMutator) ApplyToDeployment(ctx context.Context, d *appsv1.Deployment) bool {
-	log := logf.FromContext(ctx)
-
-	if w.bkapp.Spec.SvcDiscovery == nil {
+	if !w.validateConfigMap(ctx) {
 		return false
 	}
 
-	configmap, err := w.GetConfigMap(ctx)
-	if err != nil {
-		log.V(1).Info("unable to get configmap, skip apply.", "error", err)
-		return false
-	}
-	if _, ok := configmap.Data[DataKeyBkSaaS]; !ok {
-		log.V(1).Info("configmap data invalid, skip apply.")
+	w.updateContainers(d.Spec.Template.Spec.Containers)
+	return true
+}
+
+// ApplyToPod mutates the given pod, it try to inject service discovery information
+// to the env variables and volumes of the pod, it mutate the pod in-place.
+// Return whether the mutation is performed.
+func (w *WorkloadsMutator) ApplyToPod(ctx context.Context, d *corev1.Pod) bool {
+	if !w.validateConfigMap(ctx) {
 		return false
 	}
 
-	for i, container := range d.Spec.Template.Spec.Containers {
-		// Use the index to modify the container structure in-place
-		d.Spec.Template.Spec.Containers[i].Env = append(container.Env, v1.EnvVar{
+	w.updateContainers(d.Spec.Containers)
+	return true
+}
+
+// Update a list of containers to add the svc-discovery related env variables
+func (w *WorkloadsMutator) updateContainers(containers []corev1.Container) {
+	for i, container := range containers {
+		containers[i].Env = append(container.Env, v1.EnvVar{
 			Name: EnvKeyBkSaaS,
 			ValueFrom: &v1.EnvVarSource{
 				ConfigMapKeyRef: &v1.ConfigMapKeySelector{
@@ -82,13 +88,32 @@ func (w *WorkloadsMutator) ApplyToDeployment(ctx context.Context, d *appsv1.Depl
 			},
 		})
 	}
+}
+
+// Validate if the configmap that required for svc-discovery exists and it's data is valid.
+func (w *WorkloadsMutator) validateConfigMap(ctx context.Context) bool {
+	log := logf.FromContext(ctx)
+
+	if w.bkapp.Spec.SvcDiscovery == nil {
+		return false
+	}
+
+	configmap, err := w.getConfigMap(ctx)
+	if err != nil {
+		log.V(1).Info("failed to validate svc-discovery configmap.", "appName", w.bkapp.GetName(), "error", err)
+		return false
+	}
+	if _, ok := configmap.Data[DataKeyBkSaaS]; !ok {
+		log.V(1).Info("failed to validate svc-discovery configmap, data invalid.", "appName", w.bkapp.GetName())
+		return false
+	}
 	return true
 }
 
-// GetConfigMap get the configmap that contains the svc-discovery results, the results was written by the
+// getConfigMap get the configmap that contains the svc-discovery results, the results was written by the
 // apiserver service of bk-paas earlier.
 // return nil if the configmap resource does not exist or an error occurred.
-func (w *WorkloadsMutator) GetConfigMap(ctx context.Context) (*v1.ConfigMap, error) {
+func (w *WorkloadsMutator) getConfigMap(ctx context.Context) (*v1.ConfigMap, error) {
 	c := v1.ConfigMap{}
 	name := w.configMapResourceName()
 	if err := w.client.Get(ctx, client.ObjectKey{Namespace: w.bkapp.Namespace, Name: name}, &c); err != nil {


### PR DESCRIPTION
- Fix: the pre-release pod missing svc-disc env variables.
- Refactor: replace `BuildPreReleaseHook` call in deploy_action.go with `IsPreReleaseProgressing`