### PR TITLE
fix: 日志体验提单修复

### DIFF
--- a/webfe/package_vue/src/store/modules/log.js
+++ b/webfe/package_vue/src/store/modules/log.js
@@ -51,7 +51,7 @@ const mutations = {
     }];
     const timestamps = data.timestamps.map((item) => {
       // 时间处理
-      item = moment.unix(item).format('YYYY/MM/DD hh:mm:ss');
+      item = moment.unix(item).format('YYYY-MM-DD HH:mm:ss');
       return item.substring(5);
     });
     chartOptions.xAxis.data = timestamps;

--- a/webfe/package_vue/src/views/dev-center/app/engine/log/access-log.vue
+++ b/webfe/package_vue/src/views/dev-center/app/engine/log/access-log.vue
@@ -52,7 +52,7 @@
         </div>
 
         <!-- 查询结果 start -->
-        <div ref="tableBox" v-bkloading="{ isLoading: isLogListLoading }" class="table-wrapper">
+        <div ref="tableBox" v-bkloading="{ isLoading: isLogListLoading }" class="table-wrapper log-scroll-cls">
           <table id="log-table" :key="renderIndex" class="ps-table ps-table-default ps-log-table">
             <thead>
               <tr>
@@ -188,10 +188,17 @@
             </tbody>
           </table>
         </div>
-        <div v-if="pagination.count" class="ps-page ml0 mr0">
+        <div v-if="pagination.count > 9" class="ps-page ml0 mr0">
           <bk-pagination
-            size="small" align="right" :current.sync="pagination.current" :count="pagination.count"
-            :limit="pagination.limit" @change="handlePageChange" @limit-change="handlePageSizeChange" />
+            size="small"
+            align="right"
+            :current.sync="pagination.current"
+            :count="pagination.count"
+            :limit="pagination.limit"
+            :show-total-count="true"
+            @change="handlePageChange"
+            @limit-change="handlePageSizeChange"
+          />
         </div>
       </div>
     </div>
@@ -202,7 +209,7 @@
 import xss from 'xss';
 import appBaseMixin from '@/mixins/app-base-mixin';
 import logFilter from './comps/log-filter.vue';
-import { formatDate } from '@/common/tools';
+import { throttle } from 'lodash';
 
 const xssOptions = {
   whiteList: {
@@ -400,17 +407,15 @@ export default {
         this.contentHeight = height;
       }
       this.initTableBox();
-      window.onresize = () => {
-        this.initTableBox();
-      };
+      window.addEventListener('resize', throttle(this.initTableBox, 100));
     },
 
     initTableBox() {
-      setTimeout(() => {
+      if (this.$refs.logMain) {
         const width = this.$refs.logMain.getBoundingClientRect().width - 220;
         this.$refs.tableBox.style.width = `${width}px`;
         this.$refs.tableBox.style.maxWidth = `${width}px`;
-      }, 1000);
+      }
     },
 
     /**
@@ -828,7 +833,7 @@ export default {
     },
 
     formatTime(time) {
-      return time ? formatDate(time * 1000) : '--';
+      return time ? moment.unix(time).format('YYYY-MM-DD HH:mm:ss') : '--';
     },
 
     handleTrigger(propObj) {
@@ -1218,7 +1223,17 @@ export default {
 
 .table-wrapper {
   width: auto;
-  overflow-x: auto;
+  overflow: auto;
+
+  &.log-scroll-cls {
+    max-height: 465px;
+
+    table thead {
+      position: sticky;
+      top: 0;
+      z-index: 99;
+    }
+  }
 }
 
 .tooltip-icon {


### PR DESCRIPTION
- 日志查询-结构化日志/访问日志访问记录表格时间和纪录时间制不一致
- 日志查询-标准化日志点击漏斗不能收回搜索框，参考访问日志漏斗
- 日志查询表格在数据量小于等于10条时，建议隐藏分页器
- 日志检索表格缺少计数统计，不符合设计规范
- 日志标题&字段设置吸顶