### PR TITLE
fix: scale not work when deploy again for old image app

### DIFF
--- a/apiserver/paasng/paas_wl/bk_app/deploy/processes.py
+++ b/apiserver/paasng/paas_wl/bk_app/deploy/processes.py
@@ -122,8 +122,11 @@ class AppProcessesController:
         spec_updater = ProcSpecUpdater(self.env, proc_type)
         spec_updater.change_replicas(target_replicas)
 
-        # Update the module specs also to keep the bkapp model in sync.
-        ModuleProcessSpecManager(self.env.module).set_replicas(proc_type, self.env.environment, target_replicas)
+        # 旧镜像应用需要同步副本数到 ModuleProcessSpec 中
+        try:
+            ModuleProcessSpecManager(self.env.module).set_replicas(proc_type, self.env.environment, target_replicas)
+        except Exception:
+            logger.exception(f"Failed to sync replicas to ModuleProcessSpec for app({self.env.application.code})")
 
         proc_spec = spec_updater.spec_object
         try:

--- a/apiserver/paasng/paas_wl/bk_app/deploy/processes.py
+++ b/apiserver/paasng/paas_wl/bk_app/deploy/processes.py
@@ -121,6 +121,10 @@ class AppProcessesController:
 
         spec_updater = ProcSpecUpdater(self.env, proc_type)
         spec_updater.change_replicas(target_replicas)
+
+        # Update the module specs also to keep the bkapp model in sync.
+        ModuleProcessSpecManager(self.env.module).set_replicas(proc_type, self.env.environment, target_replicas)
+
         proc_spec = spec_updater.spec_object
         try:
             proc_config = get_mapper_proc_config_latest(self.app, proc_spec.name)

--- a/apiserver/paasng/paasng/platform/engine/constants.py
+++ b/apiserver/paasng/paasng/platform/engine/constants.py
@@ -145,7 +145,7 @@ class DeployConditions(ChoicesEnum):
 class RuntimeType(str, StructuredEnum):
     BUILDPACK = EnumField("buildpack", label=_("使用 Buildpacks 构建"))
     DOCKERFILE = EnumField("dockerfile", label=_("使用 Dockerfile 构建"))
-    CUSTOM_IMAGE = EnumField("custom_image", label="Custom Image")
+    CUSTOM_IMAGE = EnumField("custom_image", label="Custom Image(云原生和旧镜像应用)")
 
 
 class ImagePullPolicy(str, StructuredEnum):
@@ -174,3 +174,13 @@ class NoPrefixAppRunTimeBuiltinEnv(str, StructuredEnum):
     """Built-in envs without prefix in the app runtime"""
 
     PORT = EnumField("PORT", label=_("目标端口号，值为 5000"))
+
+
+class VersionType(str, StructuredEnum):
+    """版本类型. 对应 VersionInfo.version_type"""
+
+    TAG = EnumField("tag", label="用于 Git 仓库、云原生镜像应用、旧镜像应用")
+    BRANCH = EnumField("branch", label="用于 SVN 仓库、Git 仓库")
+    TRUNK = EnumField("trunk", label="用于 SVN 仓库")
+    IMAGE = EnumField("image", label="用于云原生应用选择已构建的镜像部署时")
+    PACKAGE = EnumField("package", label="用于 lesscode 应用和 S-Mart 应用")

--- a/apiserver/paasng/paasng/platform/engine/serializers.py
+++ b/apiserver/paasng/paasng/platform/engine/serializers.py
@@ -91,7 +91,7 @@ class CreateDeploymentSLZ(serializers.Serializer):
     def validate(self, attrs):
         attrs = super().validate(attrs)
 
-        if attrs["version_type"] == VersionType.IMAGE.value and not self._is_sha256(attrs.get("revision")):
+        if attrs["version_type"] == VersionType.IMAGE.value and not self._is_image_digest(attrs.get("revision")):
             # 云原生应用选择已构建的镜像部署时, version_type 传入了 image
             # 这里加上强制校验, 保证 image 类型被正确使用(仅用于云原生应用选择已构建镜像时),
             # 否则会导致 Deployment.get_version_info 抛出 ValueError("unknown version info")
@@ -99,7 +99,7 @@ class CreateDeploymentSLZ(serializers.Serializer):
         return attrs
 
     @staticmethod
-    def _is_sha256(revision):
+    def _is_image_digest(revision):
         if not revision:
             return False
 

--- a/apiserver/paasng/paasng/platform/engine/serializers.py
+++ b/apiserver/paasng/paasng/platform/engine/serializers.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+import re
 from datetime import datetime
 
 import yaml
@@ -37,6 +38,7 @@ from paasng.platform.engine.constants import (
     JobStatus,
     MetricsType,
     RuntimeType,
+    VersionType,
 )
 from paasng.platform.engine.models import DeployPhaseTypes
 from paasng.platform.engine.models.config_var import ENVIRONMENT_ID_FOR_GLOBAL, ENVIRONMENT_NAME_FOR_GLOBAL, ConfigVar
@@ -73,7 +75,9 @@ class DeploymentAdvancedOptionsSLZ(serializers.Serializer):
 class CreateDeploymentSLZ(serializers.Serializer):
     """创建部署"""
 
-    version_type = serializers.CharField(required=True, help_text="版本类型, 如 branch/tag/trunk")
+    version_type = serializers.ChoiceField(
+        choices=VersionType.get_choices(), required=True, help_text="版本类型, 如 branch/tag/trunk"
+    )
     version_name = serializers.CharField(
         required=True, help_text="版本名称: 如 Tag Name/Branch Name/trunk/package_name"
     )
@@ -83,6 +87,22 @@ class CreateDeploymentSLZ(serializers.Serializer):
     )
 
     advanced_options = DeploymentAdvancedOptionsSLZ(required=False, default={})
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+
+        if attrs["version_type"] == VersionType.IMAGE.value and not self._is_sha256(attrs.get("revision")):
+            # 云原生应用选择已构建的镜像部署时, version_type 传入了 image
+            # 这里加上强制校验, 保证 image 类型被正确使用, 否则会导致 Deployment.get_version_info 异常
+            raise ValidationError(_("version_type 为 image 时，revision 必须为 sha256 开头的镜像 digest"))
+        return attrs
+
+    @staticmethod
+    def _is_sha256(revision):
+        if not revision:
+            return False
+
+        return bool(re.match(r"^sha256:[0-9a-f]{64}$", revision))
 
 
 class CreateDeploymentResponseSLZ(serializers.Serializer):

--- a/apiserver/paasng/paasng/platform/engine/serializers.py
+++ b/apiserver/paasng/paasng/platform/engine/serializers.py
@@ -76,7 +76,10 @@ class CreateDeploymentSLZ(serializers.Serializer):
     """创建部署"""
 
     version_type = serializers.ChoiceField(
-        choices=VersionType.get_choices(), required=True, help_text="版本类型, 如 branch/tag/trunk"
+        choices=VersionType.get_choices(),
+        required=True,
+        error_messages={"invalid_choice": f"Invalid choice. Valid choices are {VersionType.get_values()}"},
+        help_text="版本类型, 如 branch/tag/trunk",
     )
     version_name = serializers.CharField(
         required=True, help_text="版本名称: 如 Tag Name/Branch Name/trunk/package_name"

--- a/apiserver/paasng/paasng/platform/engine/serializers.py
+++ b/apiserver/paasng/paasng/platform/engine/serializers.py
@@ -93,7 +93,8 @@ class CreateDeploymentSLZ(serializers.Serializer):
 
         if attrs["version_type"] == VersionType.IMAGE.value and not self._is_sha256(attrs.get("revision")):
             # 云原生应用选择已构建的镜像部署时, version_type 传入了 image
-            # 这里加上强制校验, 保证 image 类型被正确使用, 否则会导致 Deployment.get_version_info 异常
+            # 这里加上强制校验, 保证 image 类型被正确使用(仅用于云原生应用选择已构建镜像时),
+            # 否则会导致 Deployment.get_version_info 抛出 ValueError("unknown version info")
             raise ValidationError(_("version_type 为 image 时，revision 必须为 sha256 开头的镜像 digest"))
         return attrs
 

--- a/apiserver/paasng/paasng/platform/modules/constants.py
+++ b/apiserver/paasng/paasng/platform/modules/constants.py
@@ -41,6 +41,7 @@ class SourceOrigin(int, StructuredEnum):
     AUTHORIZED_VCS = EnumField(1, "Authorized VCS")
     BK_LESS_CODE = EnumField(2, "BK-Lesscode")
     S_MART = EnumField(3, "S-Mart")
+    # 旧镜像应用(非云原生)
     IMAGE_REGISTRY = EnumField(4, "Image Registry")
     # 场景模板
     SCENE = EnumField(5, "Scene")

--- a/apiserver/paasng/paasng/platform/sourcectl/models.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/models.py
@@ -445,6 +445,24 @@ class VersionInfo:
 
         样例数据: VersionInfo(revision="2.2.1", version_name="2.2.1", version_type="package")
 
+    对于云原生镜像而言:
+        revision 为空串
+        version_name 是镜像的 tag
+        version_type 是 Literal[tag]
+
+        样例数据: VersionInfo(revision="", version_name="v1", version_type="tag")
+
+    对于云原生应用选择已构建的镜像部署时(模块本身非镜像):
+        revision 当前的 sha256 digest
+        version_name 是镜像的 tag
+        version_type 是 Literal[image]
+
+        样例数据:
+        VersionInfo(revision="sha256:a2c6683598be55e2ddd7be53acd820b68cf8db95f84e38cd511f0683feb114a8",
+        version_name="master-2404091749", version_type="image")
+        返回给前端时, 会进行源码构建追溯成:
+        VersionInfo(revision="1304382d8c60220869624cc6b", version_name="master", version_type="branch")
+
     对于镜像仓库而言(旧的镜像应用)
         revision 是镜像的 tag *注: 这里没有实现成 存储镜像hash 是因为暂时没有地方用到*
         version_name 是镜像的 tag

--- a/apiserver/paasng/paasng/platform/sourcectl/models.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/models.py
@@ -471,6 +471,7 @@ class VersionInfo:
         样例数据: VersionInfo(revision="2.2.1", version_name="2.2.1", version_type="tag")
     """
 
+    # TODO 在 VersionInfo 构建阶段增加值校验
     revision: str
     version_name: str
     version_type: str

--- a/apiserver/paasng/paasng/platform/sourcectl/models.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/models.py
@@ -471,7 +471,7 @@ class VersionInfo:
         样例数据: VersionInfo(revision="2.2.1", version_name="2.2.1", version_type="tag")
     """
 
-    # TODO 在 VersionInfo 构建阶段增加值校验
+    # TODO 在 VersionInfo 构建阶段增加值校验, 同时增加 source_origin 表示来源类型 ?
     revision: str
     version_name: str
     version_type: str

--- a/apiserver/paasng/tests/api/test_engine.py
+++ b/apiserver/paasng/tests/api/test_engine.py
@@ -26,6 +26,7 @@ from django.urls import reverse
 from django_dynamic_fixture import G
 
 from paasng.platform.applications.constants import ApplicationRole
+from paasng.platform.engine.constants import VersionType
 from paasng.platform.engine.models.deployment import Deployment
 from paasng.platform.engine.workflow import DeploymentCoordinator
 from paasng.platform.environments.constants import EnvRoleOperation
@@ -173,15 +174,23 @@ class TestDeploymentViewSet:
 
     def test_deploy_no_revision(self, api_client, bk_app, bk_module):
         url = reverse("api.deploy", kwargs={"code": bk_app.code, "environment": "stag"})
-        resp = api_client.post(url, data={"version_type": "foo", "version_name": "bar"})
+        resp = api_client.post(url, data={"version_type": VersionType.BRANCH.value, "version_name": "bar"})
         assert resp.status_code == 400
         assert resp.json() == {"code": "CANNOT_GET_REVISION", "detail": "无法获取代码版本"}
+
+    def test_deploy_with_image_type(self, api_client, bk_app, bk_module):
+        url = reverse("api.deploy", kwargs={"code": bk_app.code, "environment": "stag"})
+        resp = api_client.post(url, data={"version_type": VersionType.IMAGE.value, "version_name": "bar"})
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "version_type 为 image 时，revision 必须为 sha256 开头的镜像 digest"
 
     @pytest.mark.usefixtures("_init_tmpls")
     def test_deploy(self, api_client, bk_app_full, bk_module_full):
         url = reverse("api.deploy", kwargs={"code": bk_app_full.code, "environment": "stag"})
         with mock.patch("paasng.platform.engine.views.deploy.DeployTaskRunner"):
-            resp = api_client.post(url, data={"version_type": "foo", "version_name": "bar", "revision": "baz"})
+            resp = api_client.post(
+                url, data={"version_type": VersionType.BRANCH.value, "version_name": "bar", "revision": "baz"}
+            )
 
         coordinator = DeploymentCoordinator(bk_module_full.get_envs("stag"))
         deployment = coordinator.get_current_deployment()
@@ -196,7 +205,9 @@ class TestDeploymentViewSet:
         coordinator = DeploymentCoordinator(bk_stag_env)
 
         assert coordinator.acquire_lock()
-        resp = api_client.post(url, data={"version_type": "foo", "version_name": "bar", "revision": "baz"})
+        resp = api_client.post(
+            url, data={"version_type": VersionType.BRANCH.value, "version_name": "bar", "revision": "baz"}
+        )
         coordinator.release_lock()
 
         assert resp.status_code == 400
@@ -207,6 +218,8 @@ class TestDeploymentViewSet:
 
     def test_deploy_exception(self, api_client, bk_app, bk_module):
         url = reverse("api.deploy", kwargs={"code": bk_app.code, "environment": "stag"})
-        resp = api_client.post(url, data={"version_type": "foo", "version_name": "bar", "revision": "baz"})
+        resp = api_client.post(
+            url, data={"version_type": VersionType.BRANCH.value, "version_name": "bar", "revision": "baz"}
+        )
         assert resp.status_code == 400
         assert resp.json() == {"code": "CANNOT_DEPLOY_APP", "detail": "部署失败: 部署请求异常，请稍候再试"}


### PR DESCRIPTION
改动点：
- 部署接口增加对 version_type 的选项校验，处理由于误传 image 类型，导致 Deployment.get_version_info 异常的问题
- 普通应用扩缩容同步修改 ModuleProcessSpec 副本数(主要解决旧镜像应用的问题)。