### PR TITLE
出海版插件支持 go 语言、favicon应该和logo一致、其他体验问题修复

### DIFF
--- a/webfe/package_vue/index.html
+++ b/webfe/package_vue/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>开发者中心</title>
     <link rel="stylesheet" type="text/css" href="/static/css/base.css">
-    <link href="/static/images/favicon.ico" rel="Shortcut Icon">
+    <link href="/static/images/logo.svg" rel="Shortcut Icon">
   </head>
   <body>
     <div id="app"></div>

--- a/webfe/package_vue/src/components/paas-app-nav.vue
+++ b/webfe/package_vue/src/components/paas-app-nav.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script>import { PAAS_STATIC_CONFIG as staticData } from '../../static/json/paas_static.js';
-import _ from 'lodash';
+import { cloneDeep } from 'lodash';
 
 export default {
   data() {
@@ -120,15 +120,11 @@ export default {
     },
   },
   watch: {
-    curAppInfo() {
-      this.init();
-    },
     'curAppInfo.feature': {
       handler(newValue, oldValue) {
         if (!Object.keys(newValue).length) {
-          this.curAppInfo.feature = _.cloneDeep(oldValue);
+          this.curAppInfo.feature = cloneDeep(oldValue);
         }
-        this.init();
       },
       deep: true,
     },

--- a/webfe/package_vue/src/components/paas-header.vue
+++ b/webfe/package_vue/src/components/paas-header.vue
@@ -794,7 +794,8 @@ export default {
             width: 242px;
             position: relative;
             margin-left: 16px;
-            padding: 10px 0;
+            display: flex;
+            align-items: center;
             .logo-warp{
               display: flex;
               align-items: center;

--- a/webfe/package_vue/src/components/usage-guide/index.vue
+++ b/webfe/package_vue/src/components/usage-guide/index.vue
@@ -1,14 +1,7 @@
 <template>
-  <div
-    :class="['usage-guide-wrapper', { 'not-cloud-native-app': !isCloudNative }]"
-    :style="{
-      '--default-height': `${isShowNotice ? GLOBAL.NOTICE_HEIGHT + 102 : 102}px`,
-      '--cloud-height': `${isShowNotice ? GLOBAL.NOTICE_HEIGHT + 136 : 136}px`,
-      'width': `${isExpand ? '400px' : 0}`,
-    }"
-  >
+  <div :class="['usage-guide-wrapper', { 'not-cloud-native-app': !isCloudNative }]">
     <div
-      :class="['usage-guide-content', { 'not-cloud-native-app': !isCloudNative }, { hide: !isExpand }]"
+      class="usage-guide-content"
       v-bkloading="{ isLoading: isLoading, zIndex: 10 }"
     >
       <div
@@ -20,20 +13,6 @@
           v-html="data"
         />
       </div>
-    </div>
-    <ul class="ellipsis">
-      <li
-        v-for="i in 4"
-        :key="i"
-      ></li>
-    </ul>
-    <div
-      :class="['floating-button', { expand: isExpand }]"
-      @click="isExpand = !isExpand"
-    >
-      <!-- 需要处理英文情况 -->
-      <span :class="{ 'vertical-rl': localLanguage === 'en' }">{{ $t('使用指南') }}</span>
-      <i class="paasng-icon paasng-angle-line-up"></i>
     </div>
   </div>
 </template>
@@ -57,17 +36,7 @@ export default {
   data() {
     return {
       serviceMarkdown: `## ${this.$t('暂无使用说明')}`,
-      isExpand: true,
     };
-  },
-  computed: {
-    // 是否显示通知中心
-    isShowNotice() {
-      return this.$store.state.isShowNotice;
-    },
-    localLanguage() {
-      return this.$store.state.localLanguage;
-    },
   },
 };
 </script>
@@ -75,79 +44,23 @@ export default {
 <style lang="scss" scoped>
 .usage-guide-wrapper {
   position: relative;
+  height: 100%;
   &.not-cloud-native-app {
     .usage-guide-content {
       padding: 24px 24px 80px;
     }
-    .floating-button,
-    .ellipsis {
-      top: calc(50% - 24px);
-    }
+  }
+  &.isExpand {
+    display: none;
   }
 }
 
 .usage-guide-content {
-  position: absolute !important;
-  top: 0px;
-  right: 0;
-  width: 400px;
-  // 减去通知中心的高度
+  width: 100%;
   height: 100%;
   background: #ffffff;
   overflow-y: auto;
   box-shadow: 0 2px 4px 0 #1919290d;
   padding-bottom: 50px;
-
-  .hide {
-    display: none;
-  }
-}
-.ellipsis {
-  position: absolute;
-  left: 8px;
-  top: calc(50% - 34px);
-  transform: translateY(-50%);
-  width: 2px;
-  li {
-    width: 2px;
-    height: 2px;
-    background: #63656e;
-    margin-bottom: 2px;
-  }
-}
-.floating-button {
-  width: 24px;
-  position: absolute;
-  padding: 11px 0;
-  text-align: center;
-  font-size: 12px;
-  color: #63656e;
-  line-height: 13px;
-  left: -24px;
-  top: calc(50% - 34px);
-  transform: translateY(-50%);
-  background: #fafbfd;
-  border: 1px solid #dcdee5;
-  border-radius: 8px 0 0 8px;
-  cursor: pointer;
-  &.expand {
-    i {
-      transform: rotateZ(90deg);
-    }
-  }
-  i {
-    margin-top: 5px;
-    color: #979ba5;
-    transform: rotateZ(-90deg);
-  }
-  &:hover {
-    color: #3A84FF;
-    i {
-      color: #3A84FF;
-    }
-  }
-  .vertical-rl {
-    writing-mode: vertical-rl;
-  }
 }
 </style>

--- a/webfe/package_vue/src/store/modules/cloud-api.js
+++ b/webfe/package_vue/src/store/modules/cloud-api.js
@@ -223,5 +223,14 @@ export default {
       const url = `${BACKEND_URL}/api/bkapps/applications/${appCode}/oauth/token/prod/`;
       return http.get(url, config);
     },
+
+    /**
+     * 获取蓝鲸插件模板信息
+     * @param {Object} params 请求参数：region
+     */
+    getPluginTmpls({}, { region }, config = {}) {
+      const url = `${BACKEND_URL}/api/bkapps/plugin/tmpls/?region=${region}`;
+      return http.get(url, config);
+    },
   },
 };

--- a/webfe/package_vue/src/views/dev-center/app/engine/cloud-deployment/index.vue
+++ b/webfe/package_vue/src/views/dev-center/app/engine/cloud-deployment/index.vue
@@ -18,26 +18,7 @@
         class="app-container middle overview"
         :class="{ 'enhanced-service': !isTab }"
       >
-        <template v-if="!isTab">
-          <div
-            class="top-return-bar flex-row align-items-center"
-            @click="handleGoBack"
-          >
-            <i
-              class="paasng-icon paasng-arrows-left icon-cls-back mr5"
-            />
-            <h4>{{ $t('返回上一页') }}</h4>
-          </div>
-          <!-- 动态数据 -->
-          <bk-alert
-            v-if="instanceTipsConfig.isShow"
-            class="instance-alert-cls"
-            type="info"
-            :title="instanceTipsConfig.tips">
-          </bk-alert>
-        </template>
-
-        <section :class="['deploy-panel', 'deploy-main', 'mt5', { 'instance-details-cls': !isTab }]">
+        <section :class="['deploy-panel', 'deploy-main', { 'instance-details-cls': !isTab }]">
           <!-- 增强服务实例详情隐藏tab -->
           <bk-tab
             v-show="isTab"
@@ -61,7 +42,7 @@
             ></bk-tab-panel>
           </bk-tab>
 
-          <div class="deploy-content">
+          <div :class="['deploy-content', { 'details-router-cls': !isTab }]">
             <router-view
               :ref="routerRefs"
               :key="renderIndex"
@@ -70,22 +51,11 @@
               @cancel="handleCancel"
               @hide-tab="isTab = false"
               @tab-change="handleGoPage"
-              @set-markdown="setMarkdown"
-              @set-tooltips="setTooltips"
-              @set-loading="setMarkdownLoading"
+              @route-back="handleGoBack"
             />
           </div>
         </section>
-
-
       </paas-content-loader>
-
-      <usage-guide
-        v-if="isShowUsageGuide && isCloudNativeApp"
-        :data="serviceMarkdown"
-        :is-cloud-native="isCloudNativeApp"
-        :is-loading="isMarkdownLoading"
-      />
     </section>
 
     <bk-dialog
@@ -109,15 +79,12 @@
 <script>import moduleTopBar from '@/components/paas-module-bar';
 import appBaseMixin from '@/mixins/app-base-mixin.js';
 import deployYaml from './deploy-yaml';
-import usageGuide from '@/components/usage-guide';
 import { throttle } from 'lodash';
-import { bus } from '@/common/bus';
 
 export default {
   components: {
     moduleTopBar,
     deployYaml,
-    usageGuide,
   },
   mixins: [appBaseMixin],
   data() {
@@ -145,10 +112,6 @@ export default {
       isTab: true,
       dialogCloudAppData: [],
       topBarIndex: 0,
-      isShowUsageGuide: false,
-      serviceMarkdown: `## ${this.$t('暂无使用说明')}`,
-      instanceTipsConfig: {},
-      isMarkdownLoading: false,
     };
   },
   computed: {
@@ -211,9 +174,6 @@ export default {
       // eslint-disable-next-line no-plusplus
       this.renderIndex++;
       this.$store.commit('cloudApi/updatePageEdit', false);
-      if (this.isShowUsageGuide) {
-        this.handleCloseUsageGuide();
-      }
     },
     appCode() {
       this.topBarIndex += 1;
@@ -228,12 +188,6 @@ export default {
         name: this.active || this.firstTabActiveName,
       });
     }
-    bus.$on('show-usage-guide', () => {
-      this.isShowUsageGuide = true;
-    });
-    bus.$on('close-usage-guide', () => {
-      this.isShowUsageGuide = false;
-    });
   },
   mounted() {
     this.handleWindowResize();
@@ -278,7 +232,6 @@ export default {
     handleGoBack() {
       this.handleGoPage('appServices');
       this.isTab = true;
-      this.handleCloseUsageGuide();
     },
 
     handleWindowResize() {
@@ -297,25 +250,8 @@ export default {
       }
     },
 
-    handleCloseUsageGuide() {
-      this.isShowUsageGuide = false;
-    },
-
     handleTabChange() {
-      this.handleCloseUsageGuide();
       this.isTab = true;
-    },
-
-    setMarkdown(markdown) {
-      this.serviceMarkdown = markdown;
-    },
-
-    setTooltips(data) {
-      this.instanceTipsConfig = data;
-    },
-
-    setMarkdownLoading(loading) {
-      this.isMarkdownLoading = loading;
     },
   },
 };
@@ -330,6 +266,8 @@ export default {
   .enhanced-service {
     flex: 1;
     min-width: 0;
+    padding: 0;
+    margin: 0;
   }
 }
 
@@ -384,25 +322,14 @@ export default {
   box-shadow: 0 2px 4px 0 #1919290d;
 
   &.instance-details-cls {
-    height: auto;
+    // 高度问题·
+    height: 100%;
     min-height: auto;
-  }
-}
+    background: #F5F7FA;
 
-.top-return-bar {
-  background: #F5F7FA;
-  cursor: pointer;
-  margin-bottom: 16px;
-  h4 {
-    font-size: 14px;
-    color: #313238;
-    font-weight: 400;
-    padding: 0;
-  }
-  .icon-cls-back{
-    color: #3A84FF;
-    font-size: 14px;
-    font-weight: bold;
+    .details-router-cls {
+      height: 100%;
+    }
   }
 }
 .instance-alert-cls {

--- a/webfe/package_vue/src/views/dev-center/app/services/instance.vue
+++ b/webfe/package_vue/src/views/dev-center/app/services/instance.vue
@@ -8,161 +8,192 @@
     />
 
     <section :class="['instance-detail', { 'default-instance-detail-cls': !isCloudNativeApp }]">
-      <div class="instance-container-cls">
-        <bk-alert
-          v-if="delAppDialog.moduleList.length > 0 && !isCloudNativeApp"
-          style="margin-bottom: 10px;"
-          type="info"
-          :title="pageTips"
-        />
+      <bk-resize-layout
+        ref="resizeLayoutRef"
+        :placement="'right'"
+        :max="980"
+        :collapsible="true"
+        ext-cls="instance-resize-layout-cls"
+        style="width: 100%;height: 100%;"
+        @collapse-change="handleCollapseChange">
+        <div class="instance-container-cls" slot="main">
+          <!-- 云原生 -->
+          <div
+            v-if="isCloudNativeApp"
+            @click="handleGoBack"
+            class="top-return-bar flex-row align-items-center"
+          >
+            <i
+              class="paasng-icon paasng-arrows-left icon-cls-back mr5"
+            />
+            <h4>{{ $t('返回上一页') }}</h4>
+          </div>
 
-        <section class="instance-tab-container">
-          <p class="title">{{ $t('实例详情') }}</p>
-          <!-- 写入环境变量 -->
-          <div class="env-variables-wrapper">
-            <span class="sub-title">{{ $t('写入环境变量') }}</span>
-            <div @click.stop="handleSwitcherChange">
-              <bk-switcher
-                v-model="credentialsDisabled"
-                theme="primary"
-                size="small"
-                :pre-check="() => false"
-              ></bk-switcher>
-            </div>
-            <span class="tips">
-              <i class="paasng-icon paasng-info-line mr5"></i>
-              {{ $t('若不写入，将无法从环境变量获取实例的凭证信息') }}
-            </span>
-          </div>
-          <!-- 编辑 -->
-          <div class="instance-info" v-if="specifications.length">
-            <div class="item" v-for="item in specifications" :key="item.name">
-              <span>{{ item.name }}：</span>
-              <span class="value" v-bk-overflow-tips>{{ item.value }}</span>
-            </div>
-            <span
-              v-bk-tooltips="{ content: $t('增强服务实例已分配，不能再修改配置信息'), disabled: canEditConfig }"
-              :class="['edit-icon', { 'disabled': !canEditConfig }]"
-              @click="handleEditInstance">
-              <i class="paasng-icon paasng-edit-2"></i>
-            </span>
-          </div>
-          <bk-table
-            :data="instanceList"
-            v-bkloading="{ isLoading: isTableLoading, zIndex: 10 }"
-            size="large"
-            style="margin-top: 15px;"
-            ext-cls="instance-details-table-cls"
-            :outer-border="false">
-            <div slot="empty" class="paas-loading-panel">
-              <div class="text">
-                <table-empty
-                  class="table-empty-cls"
-                  :empty-title="$t('暂无增强服务配置信息')"
-                  empty
-                />
-                <p class="sub-title">
-                  {{ $t('服务启用后，将在下一次部署过程中申请实例，请先进行应用部署。') }}
-                </p>
+          <bk-alert
+            v-if="delAppDialog.moduleList.length > 0"
+            style="margin-bottom: 16px;"
+            type="info"
+            :title="pageTips"
+          />
+
+          <section class="instance-tab-container">
+            <p class="title">{{ $t('实例详情') }}</p>
+            <!-- 写入环境变量 -->
+            <div class="env-variables-wrapper">
+              <span class="sub-title">{{ $t('写入环境变量') }}</span>
+              <div @click.stop="handleSwitcherChange">
+                <bk-switcher
+                  v-model="credentialsDisabled"
+                  theme="primary"
+                  size="small"
+                  :pre-check="() => false"
+                ></bk-switcher>
               </div>
+              <span class="tips">
+                <i class="paasng-icon paasng-info-line mr5"></i>
+                {{ $t('若不写入，将无法从环境变量获取实例的凭证信息') }}
+              </span>
             </div>
-            <bk-table-column :label="$t('实例 ID')" width="100">
-              <template slot-scope="{ $index }">
-                #{{ $index + 1 }}
-              </template></bk-table-column>
-            <bk-table-column :label="$t('凭证信息')" prop="ip" min-width="300">
-              <template slot-scope="{ row, $index }">
-                <template
-                  v-if="row.service_instance.config.hasOwnProperty('is_done')
-                    && !row.service_instance.config.is_done">
-                  <p class="mt15 mb15">
-                    {{ $t('服务正在创建中，请通过“管理入口”查看进度') }}
+            <!-- 编辑 -->
+            <div class="instance-info" v-if="specifications.length">
+              <div class="item" v-for="item in specifications" :key="item.name">
+                <span>{{ item.name }}：</span>
+                <span class="value" v-bk-overflow-tips>{{ item.value }}</span>
+              </div>
+              <span
+                v-bk-tooltips="{ content: $t('增强服务实例已分配，不能再修改配置信息'), disabled: canEditConfig }"
+                :class="['edit-icon', { 'disabled': !canEditConfig }]"
+                @click="handleEditInstance">
+                <i class="paasng-icon paasng-edit-2"></i>
+              </span>
+            </div>
+            <bk-table
+              :data="instanceList"
+              v-bkloading="{ isLoading: isTableLoading, zIndex: 10 }"
+              size="large"
+              style="margin-top: 15px;"
+              ext-cls="instance-details-table-cls"
+              :outer-border="false">
+              <div slot="empty" class="paas-loading-panel">
+                <div class="text">
+                  <table-empty
+                    class="table-empty-cls"
+                    :empty-title="$t('暂无增强服务配置信息')"
+                    empty
+                  />
+                  <p class="sub-title">
+                    {{ $t('服务启用后，将在下一次部署过程中申请实例，请先进行应用部署。') }}
                   </p>
-                </template>
-                <template v-else>
-                  <section class="credential-information">
-                    <div
-                      v-for="(value, key) in row.service_instance.credentials"
-                      :key="key"
-                      class="config-width"
-                    >
-                      <span class="gray">{{ key }}: </span><span class="break-all">{{ value }}</span><br>
-                    </div>
-                    <div
-                      v-for="(key, fieldsIndex) in row.service_instance.sensitive_fields"
-                      :key="fieldsIndex"
-                    >
-                      <span class="gray">{{ key }}: </span>******
-                      <i
-                        v-bk-tooltips="$t('敏感字段，请参考下方使用指南，通过环境变量获取')"
-                        class="paasng-icon paasng-question-circle"
-                      />
-                    </div>
-                    <div
-                      v-for="(value, key) in row.service_instance.hidden_fields"
-                      :key="key"
-                    >
-                      <span class="gray">{{ key }}: </span>
-                      <span
-                        v-if="hFieldstoggleStatus[$index][key]"
-                        class="break-all"
-                      >
-                        {{ value }}
-                      </span>
-                      <span
-                        v-else
-                        class="break-all"
-                      >******</span>
-                      <button
-                        v-bk-tooltips="$t('敏感字段，点击后显示')"
-                        class="btn-display-hidden-field ps-btn ps-btn-default ps-btn-xs"
-                        @click="$set(hFieldstoggleStatus[$index], key, !hFieldstoggleStatus[$index][key])"
-                      >
-                        {{ hFieldstoggleText[hFieldstoggleStatus[$index][key] || false] }}
-                      </button>
-                    </div>
-                  </section>
-                  <div
-                    v-if="!row.service_instance.sensitive_fields.length"
-                    class="copy-container"
-                  >
-                    <i class="paasng-icon paasng-general-copy" @click="handleCopy(row)" />
-                  </div>
-                </template>
-              </template>
-            </bk-table-column>
-            <bk-table-column :label="$t('使用环境')" prop="ip">
-              <template slot-scope="{ row }">
-                {{ row.environment_name }}
-              </template>
-            </bk-table-column>
-            <bk-table-column :label="$t('操作')" :width="localLanguage === 'en' ? 180 : 150">
-              <template slot-scope="{ row }">
-                <p>
-                  <template v-if="row.service_instance.config.admin_url">
-                    <a
-                      :href="row.service_instance.config.admin_url"
-                      class="blue"
-                      target="_blank"
-                    > {{ $t('查看管理入口') }} </a>
+                </div>
+              </div>
+              <bk-table-column :label="$t('实例 ID')" width="100">
+                <template slot-scope="{ $index }">
+                  #{{ $index + 1 }}
+                </template></bk-table-column>
+              <bk-table-column :label="$t('凭证信息')" prop="ip" min-width="300">
+                <template slot-scope="{ row, $index }">
+                  <template
+                    v-if="row.service_instance.config.hasOwnProperty('is_done')
+                      && !row.service_instance.config.is_done">
+                    <p class="mt15 mb15">
+                      {{ $t('服务正在创建中，请通过“管理入口”查看进度') }}
+                    </p>
                   </template>
                   <template v-else>
-                    --
+                    <section class="credential-information">
+                      <div
+                        v-for="(value, key) in row.service_instance.credentials"
+                        :key="key"
+                        class="config-width"
+                      >
+                        <span class="gray">{{ key }}: </span><span class="break-all">{{ value }}</span><br>
+                      </div>
+                      <div
+                        v-for="(key, fieldsIndex) in row.service_instance.sensitive_fields"
+                        :key="fieldsIndex"
+                      >
+                        <span class="gray">{{ key }}: </span>******
+                        <i
+                          v-bk-tooltips="$t('敏感字段，请参考下方使用指南，通过环境变量获取')"
+                          class="paasng-icon paasng-question-circle"
+                        />
+                      </div>
+                      <div
+                        v-for="(value, key) in row.service_instance.hidden_fields"
+                        :key="key"
+                      >
+                        <span class="gray">{{ key }}: </span>
+                        <span
+                          v-if="hFieldstoggleStatus[$index][key]"
+                          class="break-all"
+                        >
+                          {{ value }}
+                        </span>
+                        <span
+                          v-else
+                          class="break-all"
+                        >******</span>
+                        <button
+                          v-bk-tooltips="$t('敏感字段，点击后显示')"
+                          class="btn-display-hidden-field ps-btn ps-btn-default ps-btn-xs"
+                          @click="$set(hFieldstoggleStatus[$index], key, !hFieldstoggleStatus[$index][key])"
+                        >
+                          {{ hFieldstoggleText[hFieldstoggleStatus[$index][key] || false] }}
+                        </button>
+                      </div>
+                    </section>
+                    <div
+                      v-if="!row.service_instance.sensitive_fields.length"
+                      class="copy-container"
+                    >
+                      <i class="paasng-icon paasng-general-copy" @click="handleCopy(row)" />
+                    </div>
                   </template>
-                </p>
-              </template>
-            </bk-table-column>
-          </bk-table>
-        </section>
-      </div>
+                </template>
+              </bk-table-column>
+              <bk-table-column :label="$t('使用环境')" prop="ip">
+                <template slot-scope="{ row }">
+                  {{ row.environment_name }}
+                </template>
+              </bk-table-column>
+              <bk-table-column :label="$t('操作')" :width="localLanguage === 'en' ? 180 : 150">
+                <template slot-scope="{ row }">
+                  <p>
+                    <template v-if="row.service_instance.config.admin_url">
+                      <a
+                        :href="row.service_instance.config.admin_url"
+                        class="blue"
+                        target="_blank"
+                      > {{ $t('查看管理入口') }} </a>
+                    </template>
+                    <template v-else>
+                      --
+                    </template>
+                  </p>
+                </template>
+              </bk-table-column>
+            </bk-table>
+          </section>
+        </div>
 
-      <!-- 使用指南 -->
-      <usage-guide
-        v-if="!isCloudNativeApp"
-        :data="compiledMarkdown"
-        :is-cloud-native="isCloudNativeApp"
-        :is-loading="isTableLoading"
-      />
+        <!-- 使用指南 -->
+        <usage-guide
+          slot="aside"
+          :class="{ isExpand: !isExpand }"
+          :data="compiledMarkdown"
+          :is-cloud-native="isCloudNativeApp"
+          :is-loading="isTableLoading"
+          @set-collapse="handleSetCollapse"
+        />
+
+        <div
+          :class="['floating-button', { expand: !isExpand }]"
+          slot="collapse-trigger"
+          @click="handleSetCollapse">
+          <span :class="{ 'vertical-rl': localLanguage === 'en' }">{{ $t('使用指南') }}</span>
+          <i class="paasng-icon paasng-angle-line-up"></i>
+        </div>
+      </bk-resize-layout>
     </section>
 
     <bk-dialog
@@ -258,6 +289,7 @@ export default {
       },
       isTableLoading: false,
       credentialsDisabled: false,
+      isExpand: true,
     };
   },
   computed: {
@@ -305,7 +337,6 @@ export default {
     this.fetchEnableSpecs();
     this.fetchServicesShareDetail();
     this.getCredentialsEnabled();
-    bus.$emit('show-usage-guide');
   },
   methods: {
     async fetchServicesShareDetail() {
@@ -578,6 +609,22 @@ export default {
         });
       }
     },
+
+    // 返回上一级
+    handleGoBack() {
+      this.$emit('route-back', 'appServices');
+    },
+
+    handleSetCollapse() {
+      this.$refs.resizeLayoutRef?.setCollapse();
+    },
+
+    handleCollapseChange(data) {
+      const updateExpand = () => {
+        this.isExpand = !data;
+      };
+      data ? updateExpand() : setTimeout(updateExpand, 200);
+    },
   },
 };
 
@@ -757,10 +804,34 @@ export default {
         }
     }
 
+    .instance-detail {
+      .bk-resize-layout-border {
+        border-top-color: transparent;
+      }
+      .instance-container-cls {
+        margin: 16px 24px 0;
+        .top-return-bar {
+          background: #F5F7FA;
+          cursor: pointer;
+          margin-bottom: 16px;
+          h4 {
+            font-size: 14px;
+            color: #313238;
+            font-weight: 400;
+            padding: 0;
+          }
+          .icon-cls-back{
+            color: #3A84FF;
+            font-size: 14px;
+            font-weight: bold;
+          }
+        }
+      }
+    }
+
     .default-instance-detail-cls {
       display: flex;
       .instance-container-cls {
-        margin: 16px 24px 0;
         flex: 1;
       }
     }
@@ -1041,6 +1112,46 @@ export default {
       .paas-loading-panel .text {
         .sub-title {
           font-size: 12px;
+        }
+      }
+    }
+    .instance-resize-layout-cls {
+      .bk-resize-layout-aside .bk-resize-layout-aside-content {
+        overflow: unset;
+      }
+      .floating-button {
+        position: absolute;
+        left: -24px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 24px;
+        padding: 11px 0;
+        text-align: center;
+        font-size: 12px;
+        color: #63656e;
+        line-height: 13px;
+        background: #fafbfd;
+        border: 1px solid #dcdee5;
+        border-radius: 8px 0 0 8px;
+        cursor: pointer;
+        &.expand {
+          i {
+            transform: rotateZ(90deg);
+          }
+        }
+        i {
+          margin-top: 5px;
+          color: #979ba5;
+          transform: rotateZ(-90deg);
+        }
+        &:hover {
+          color: #3A84FF;
+          i {
+            color: #3A84FF;
+          }
+        }
+        .vertical-rl {
+          writing-mode: vertical-rl;
         }
       }
     }

--- a/webfe/package_vue/src/views/dev-center/create-app/cloud.scss
+++ b/webfe/package_vue/src/views/dev-center/create-app/cloud.scss
@@ -217,6 +217,9 @@
     &:first-child {
       margin-top: 0;
     }
+    .f12 {
+      color: #979ba5;
+    }
   }
 }
 .construction-manner {

--- a/webfe/package_vue/src/views/dev-center/create-app/cloud.scss
+++ b/webfe/package_vue/src/views/dev-center/create-app/cloud.scss
@@ -208,9 +208,16 @@
 }
 .plugin-container{
   background: #FAFBFD;
-  padding: 20px 20px 5px 20px;
-  height: 80px;
+  padding: 20px;
   margin-left: 100px;
+
+  .plugin-item {
+    margin-top: 16px;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
 }
 .construction-manner {
   display: flex;

--- a/webfe/package_vue/src/views/dev-center/create-app/cloud.vue
+++ b/webfe/package_vue/src/views/dev-center/create-app/cloud.vue
@@ -230,23 +230,20 @@
                   class="plugin-container"
                 >
                   <ul class="establish-main-list">
-                    <li>
-                      <label class="pointer">
-                        <bk-radio-group v-model="isOpenSupportPlus">
-                          <bk-radio
-                            :value="'yes'"
-                            disabled
-                          > {{ $t('Python 语言') }} </bk-radio>
-                        </bk-radio-group>
-                      </label>
-                      <p class="f12">
-                        <a
-                          target="_blank"
-                          :href="GLOBAL.LINK.BK_PLUGIN"
-                          style="color: #3a84ff"
-                        >Python + bk-plugin-framework，{{ $t('集成插件开发框架，插件版本管理，插件运行时等模块') }}</a>
-                      </p>
-                    </li>
+                    <bk-radio-group v-model="curPluginTemplate">
+                      <li class="plugin-item" v-for="item in pluginTmpls" :key="item.name">
+                        <label class="pointer">
+                          <bk-radio :value="item.name"> {{ item.display_name }} </bk-radio>
+                        </label>
+                        <p class="f12 mt5">
+                          <a
+                            target="_blank"
+                            :href="item.repo_url"
+                            style="color: #3a84ff"
+                          >{{ item.description }}</a>
+                        </p>
+                      </li>
+                    </bk-radio-group>
                   </ul>
                 </div>
               </bk-form>
@@ -800,8 +797,9 @@ export default {
       },
       curCodeSource: 'default',
       activeIndex: 1,
-      isOpenSupportPlus: 'yes',
       isShowAdvancedOptions: false,
+      pluginTmpls: [],
+      curPluginTemplate: '',
     };
   },
   computed: {
@@ -869,6 +867,9 @@ export default {
     curExtendConfig() {
       return this.gitExtendConfig[this.sourceControlTypeItem];
     },
+    platformFeature() {
+      return this.$store.state.platformFeature;
+    },
   },
   watch: {
     'formData.sourceOrigin'(value) {
@@ -908,6 +909,9 @@ export default {
     isShowAdvancedOptions(value) {
       this.$store.commit('createApp/updateAdvancedOptions', value);
     },
+    'platformFeature.REGION_DISPLAY'() {
+      this.getPluginTmpls();
+    },
   },
   mounted() {
     this.init();
@@ -918,6 +922,7 @@ export default {
         this.fetchLanguageInfo(),
         this.fetchSourceControlTypesData(),
         this.fetchAdvancedOptions(),
+        this.getPluginTmpls(),
       ]);
       // 收集依赖
       const data = this.collectDependencies();
@@ -1185,12 +1190,12 @@ export default {
       }
       this.formLoading = true;
       const params = {
-        is_plugin_app: !!this.isBkPlugin,
+        is_plugin_app: this.isBkPlugin,
         region: this.regionChoose,
         code: this.formData.code,
         name: this.formData.name,
         source_config: {
-          source_init_template: this.formData.sourceInitTemplate,
+          source_init_template: this.isBkPlugin ? this.curPluginTemplate : this.formData.sourceInitTemplate,
           source_control_type: this.sourceControlTypeItem,
           source_repo_url: this.formData.sourceRepoUrl,
           source_origin: this.sourceOrigin,
@@ -1312,6 +1317,7 @@ export default {
           path,
           query: {
             method: params.bkapp_spec.build_config.build_method,
+            template: params.source_config.source_init_template,
             objectKey,
           },
         });
@@ -1442,6 +1448,23 @@ export default {
     async handleBeforeFunction() {
       const data = this.collectDependencies();
       return this.$isSidebarClosed(JSON.stringify(data));
+    },
+
+    // 获取蓝鲸插件模板信息
+    async getPluginTmpls() {
+      try {
+        const region = this.platformFeature?.REGION_DISPLAY ? 'ieod' : 'default';
+        const res = await this.$store.dispatch('cloudApi/getPluginTmpls', {
+          region,
+        });
+        this.curPluginTemplate = res[0]?.name || '';
+        this.pluginTmpls = res;
+      } catch (e) {
+        this.$paasMessage({
+          theme: 'error',
+          message: e.detail || e.message || this.$t('接口异常'),
+        });
+      }
     },
   },
 };

--- a/webfe/package_vue/src/views/dev-center/create-app/cloud.vue
+++ b/webfe/package_vue/src/views/dev-center/create-app/cloud.vue
@@ -236,11 +236,7 @@
                           <bk-radio :value="item.name"> {{ item.display_name }} </bk-radio>
                         </label>
                         <p class="f12 mt5">
-                          <a
-                            target="_blank"
-                            :href="item.repo_url"
-                            style="color: #3a84ff"
-                          >{{ item.description }}</a>
+                          {{ item.description }}
                         </p>
                       </li>
                     </bk-radio-group>

--- a/webfe/package_vue/src/views/dev-center/create-app/success-git.vue
+++ b/webfe/package_vue/src/views/dev-center/create-app/success-git.vue
@@ -210,9 +210,11 @@ export default {
       ].join('\n');
     },
     pluginTips() {
+      const queryTemplate = this.$route.query?.template;
+      const s = queryTemplate === 'bk-saas-plugin-go' ? 'bk-plugin-framework-go' : 'bk-plugin-framework-python';
       return [
         'pip install cookiecutter',
-        'cookiecutter https://github.com/TencentBlueKing/bk-plugin-framework-python/ --directory template',
+        `cookiecutter https://github.com/TencentBlueKing/${s}/ --directory template`,
       ].join('\n');
     },
     initTips() {


### PR DESCRIPTION
- 出海版插件支持 go 语言
- 切换应用时，左侧菜单频繁折叠打开
- favicon应该和logo一致
- 增强服务实例详情：使用指南的宽度可以拖动
- 云原生仅镜像应用部署时，version_type 统一设置值为 tag
- 模块基本信息接口路补充 