### PR TITLE
fix：云原生仅镜像应用部署时，version_type 统一设置值为 tag、模块基本信息接口路补充

### DIFF
--- a/webfe/package_vue/src/store/modules/module.js
+++ b/webfe/package_vue/src/store/modules/module.js
@@ -60,7 +60,7 @@ export default {
          * 获取模块基本信息
          */
     getModuleBasicInfo({  }, { appCode, modelName }, config = {}) {
-      const url = `${BACKEND_URL}/api/bkapps/applications/${appCode}/modules/${modelName}`;
+      const url = `${BACKEND_URL}/api/bkapps/applications/${appCode}/modules/${modelName}/`;
       return http.get(url, config);
     },
 

--- a/webfe/package_vue/src/views/dev-center/app/engine/cloud-deploy-manage/comps/deploy-dialog.vue
+++ b/webfe/package_vue/src/views/dev-center/app/engine/cloud-deploy-manage/comps/deploy-dialog.vue
@@ -1042,14 +1042,14 @@ export default {
           // 可以自己编辑选择镜像
           if (!this.allowMultipleImage) {
             params = {
-              version_type: 'image',
+              version_type: 'tag',
               version_name: this.tagData.tagValue,
               advanced_options: advancedOptions,
             };
             this.deploymentInfoBackUp.version_info.version_name = this.tagData.tagValue;
           } else {
             params = {
-              version_type: 'manifest',
+              version_type: 'tag',
               version_name: 'manifest',
               advanced_options: advancedOptions,
             };


### PR DESCRIPTION
 - 云原生仅镜像应用部署时，version_type 统一设置值为 tag
 - 模块基本信息接口路补充