### PR TITLE
Fix: list_remote() failed to parse the result when warning message showed up

### DIFF
--- a/apiserver/paasng/paasng/platform/sourcectl/controllers/bare_git.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/controllers/bare_git.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 import logging
 import operator
 from typing import TYPE_CHECKING, Generator, Iterator, List, Optional, Tuple
@@ -77,7 +78,7 @@ class BareGitRepoController:
         """检查仓库权限"""
         try:
             # 使用 ls-remote 来提速
-            self.client.list_remote(self.repo_url)
+            self.client.list_remote_raw(self.repo_url)
         except GitCommandExecutionError as e:
             if "authentication failed" in str(e).lower():
                 raise BasicAuthError("wrong username or password")

--- a/apiserver/paasng/tests/paasng/platform/sourcectl/git/test_git_client.py
+++ b/apiserver/paasng/tests/paasng/platform/sourcectl/git/test_git_client.py
@@ -138,6 +138,18 @@ class TestGitClient:
             mock_run.return_value = cmd_result
             assert client.list_remote("http://example.com/foo.git") == expected
 
+    def test_list_remote_with_warning_and_invalid(self, client):
+        # The command output a warning message sometimes
+        with patch.object(client, "run") as mock_run:
+            mock_run.return_value = dedent(
+                """\
+                warning: redirecting to http://example.com/foo.git/
+                0123456789   HEAD
+                <some random invalid output>
+"""
+            )
+            assert client.list_remote("http://example.com/foo.git") == [("0123456789", "HEAD")]
+
     @pytest.mark.parametrize(
         ("commits", "expected"),
         [


### PR DESCRIPTION
- Let touch() call list_remote_raw(), a new function that only run `ls-remote` and don't parse the output
- Update list_remote() so that it never failed on parsing