### PR TITLE
feat: add shared services support when generating manifest

### DIFF
--- a/apiserver/paasng/paas_wl/bk_app/cnative/specs/crd/bk_app.py
+++ b/apiserver/paasng/paas_wl/bk_app/cnative/specs/crd/bk_app.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 """Resource Definition of `BkApplication` kind.
 
 Use `pydantic` to get good JSON-Schema support, which is essential for CRD.
@@ -269,11 +270,16 @@ class BkAppAddonSpec(BaseModel):
 
 
 class BkAppAddon(BaseModel):
-    """Addon for BkApp"""
+    """Addon for BkApp
+
+    :param name: The name of the addon.
+    :param specs: The specs of the addon.
+    :param sharedFromModule: The module name the addon is shared from.
+    """
 
     name: str
     specs: List[BkAppAddonSpec] = Field(default_factory=list)
-    sharedFrom: Optional[str] = None
+    sharedFromModule: Optional[str] = None
 
 
 @register

--- a/apiserver/paasng/paasng/accessories/servicehub/sharing.py
+++ b/apiserver/paasng/paasng/accessories/servicehub/sharing.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 """Shared service across modules"""
 import logging
 from typing import Dict, Iterable, Optional, Sequence
@@ -41,7 +42,10 @@ logger = logging.getLogger(__name__)
 
 
 class ServiceSharingManager:
-    """Manage shared service attachments by module"""
+    """Manage shared service attachments by module
+
+    :param module: The module that shares other module's service
+    """
 
     def __init__(self, module: Module):
         self.module = module
@@ -55,9 +59,9 @@ class ServiceSharingManager:
     def create(self, service: ServiceObj, ref_module: Module) -> SharedServiceAttachment:
         """Create a shared service relationship from given module
 
-        :param ref_module: referenced module
-        :raises `ReferencedAttachmentNotFound` when referenced relationship not found, `SharedAttachmentAlreadyExists`
-            when shared attachment already exists
+        :param ref_module: referenced module that holds the REAL service binding relationship.
+        :raises ReferencedAttachmentNotFound: when referenced relationship not found
+        :raises SharedAttachmentAlreadyExists: when shared attachment already exists
         """
         if ref_module == self.module:
             raise RuntimeError("module can not share from itself")

--- a/apiserver/paasng/paasng/platform/bkapp_model/importer/addons.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/importer/addons.py
@@ -1,0 +1,38 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+
+import logging
+from typing import List
+
+from paas_wl.bk_app.cnative.specs.crd.bk_app import BkAppAddon
+from paasng.platform.modules.models import Module
+
+from .entities import CommonImportResult
+
+logger = logging.getLogger(__name__)
+
+
+def import_addons(module: Module, addons: List[BkAppAddon]) -> CommonImportResult:
+    """Import addon configs, existing services that is not in the input list may be removed.
+
+    :param addons: The addons.
+    :return: A result object.
+    """
+    # TODO: Implement import for addons
+    logger.warning("Import addons is not implemented, skip.")
+    return CommonImportResult()

--- a/apiserver/paasng/paasng/platform/bkapp_model/importer/importer.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/importer/importer.py
@@ -15,11 +15,13 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 from typing import Dict
 
 import yaml
 from rest_framework.exceptions import ValidationError
 
+from paasng.platform.bkapp_model.importer.addons import import_addons
 from paasng.platform.bkapp_model.importer.build import import_build
 from paasng.platform.bkapp_model.importer.domain_resolution import import_domain_resolution
 from paasng.platform.bkapp_model.importer.env_overlays import import_env_overlays
@@ -77,6 +79,8 @@ def import_manifest(module: Module, input_data: Dict):
         import_hooks(module, hooks)
     if env_vars or overlay_env_vars:
         import_env_vars(module, env_vars, overlay_env_vars)
+    if addons := validated_data.get("addons"):
+        import_addons(module, addons)
     if mounts or overlay_mounts:
         import_mounts(module, mounts, overlay_mounts)
     if svc_discovery := validated_data.get("svcDiscovery"):

--- a/apiserver/paasng/paasng/platform/bkapp_model/importer/serializers.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/importer/serializers.py
@@ -50,7 +50,7 @@ class EnvVarOverlayInputSLZ(BaseEnvVarFields):
 class AddonSpecInputSLZ(serializers.Serializer):
     """Validate the items in the `addons.specs` field."""
 
-    key = serializers.CharField(required=True)
+    name = serializers.CharField(required=True)
     value = serializers.CharField(required=True)
 
 

--- a/apiserver/paasng/paasng/platform/bkapp_model/importer/serializers.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/importer/serializers.py
@@ -15,6 +15,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 from rest_framework import serializers
 
 from paas_wl.bk_app.cnative.specs.constants import ResQuotaPlan, ScalingPolicy
@@ -44,6 +45,21 @@ class EnvVarOverlayInputSLZ(BaseEnvVarFields):
     def to_internal_value(self, data) -> bk_app.EnvVarOverlay:
         d = super().to_internal_value(data)
         return bk_app.EnvVarOverlay(**d)
+
+
+class AddonSpecInputSLZ(serializers.Serializer):
+    """Validate the items in the `addons.specs` field."""
+
+    key = serializers.CharField(required=True)
+    value = serializers.CharField(required=True)
+
+
+class AddonInputSLZ(serializers.Serializer):
+    """Validate the items in the `addons` field."""
+
+    name = serializers.CharField(required=True)
+    specs = serializers.ListField(child=AddonSpecInputSLZ(), default=None)
+    sharedFromModule = serializers.CharField(default=None)
 
 
 class BaseMountFields(serializers.Serializer):
@@ -218,6 +234,7 @@ class BkAppSpecInputSLZ(serializers.Serializer):
     build = BuildInputSLZ(allow_null=True, default=None)
     processes = serializers.ListField(child=ProcessInputSLZ())
     configuration = ConfigurationInputSLZ(required=False)
+    addons = serializers.ListField(child=AddonInputSLZ(), required=False, allow_empty=True)
     mounts = serializers.ListField(child=MountInputSLZ(), required=False, allow_empty=True)
     hooks = HooksInputSLZ(allow_null=True, default=None)
     envOverlay = EnvOverlayInputSLZ(required=False)

--- a/apiserver/paasng/paasng/platform/bkapp_model/manifest.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/manifest.py
@@ -16,7 +16,6 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
-import json
 import logging
 import shlex
 from abc import ABC, abstractmethod
@@ -32,7 +31,6 @@ from paas_wl.bk_app.cnative.specs.constants import (
     BKAPP_CODE_ANNO_KEY,
     BKAPP_NAME_ANNO_KEY,
     BKAPP_REGION_ANNO_KEY,
-    BKPAAS_ADDONS_ANNO_KEY,
     BKPAAS_DEPLOY_ID_ANNO_KEY,
     ENVIRONMENT_ANNO_KEY,
     IMAGE_CREDENTIALS_REF_ANNO_KEY,
@@ -129,9 +127,6 @@ class AddonsManifestConstructor(ManifestConstructor):
         for info in ServiceSharingManager(module).list_all_shared_info():
             annot_names.append(info.service.name)
             model_res.spec.addons.append(BkAppAddon(name=info.service.name, sharedFromModule=info.ref_module.name))
-
-        # Modify the annotation for backward compatibility
-        model_res.metadata.annotations[BKPAAS_ADDONS_ANNO_KEY] = json.dumps(annot_names)
 
 
 class AccessControlManifestConstructor(ManifestConstructor):

--- a/apiserver/paasng/paasng/platform/declarative/application/validations/v3.py
+++ b/apiserver/paasng/paasng/platform/declarative/application/validations/v3.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 from typing import Dict, List
 
 from django.utils.translation import gettext_lazy as _
@@ -116,7 +117,7 @@ class ModuleDescriptionSLZ(serializers.Serializer):
                 {
                     "name": addon.name,
                     "specs": {spec.name: spec.value for spec in addon.specs},
-                    "shared_from": addon.sharedFrom,
+                    "shared_from": addon.sharedFromModule,
                 }
             )
 

--- a/apiserver/paasng/tests/conftest.py
+++ b/apiserver/paasng/tests/conftest.py
@@ -795,7 +795,8 @@ def create_custom_app():
 
 
 @pytest.fixture()
-def create_module(bk_app):
+def bk_module_2(bk_app):
+    """Another module other than the default one, for testing."""
     module = Module.objects.create(region=bk_app.region, application=bk_app, name=generate_random_string(length=8))
     initialize_module(module)
     return module

--- a/apiserver/paasng/tests/paasng/misc/monitoring/alert_rules/conftest.py
+++ b/apiserver/paasng/tests/paasng/misc/monitoring/alert_rules/conftest.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 from pathlib import Path
 from typing import Dict
 from unittest import mock
@@ -59,8 +60,8 @@ def wl_namespaces(bk_stag_env, bk_prod_env, _with_wl_apps) -> Dict[str, str]:
 
 
 @pytest.fixture()
-def create_module_for_alert(create_module, _with_wl_apps):
-    return create_module
+def create_module_for_alert(bk_module_2, _with_wl_apps):
+    return bk_module_2
 
 
 @pytest.fixture()

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/importer/test_importer.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/importer/test_importer.py
@@ -15,6 +15,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 import pytest
 
 from paas_wl.bk_app.cnative.specs.constants import ResQuotaPlan, ScalingPolicy
@@ -78,6 +79,27 @@ class TestEnvVars:
 
         import_manifest(bk_module, base_manifest)
         assert ConfigVar.objects.count() == 2
+
+
+class TestAddons:
+    def test_invalid_value(self, bk_module, base_manifest):
+        base_manifest["spec"]["addons"] = [{"foo": "bar"}]
+        with pytest.raises(ManifestImportError) as e:
+            import_manifest(bk_module, base_manifest)
+
+        assert "addons.0.name" in str(e)
+
+    def test_invalid_spec(self, bk_module, base_manifest):
+        base_manifest["spec"]["addons"] = [{"name": "mysql", "specs": [{"foo": "bar"}]}]
+        with pytest.raises(ManifestImportError) as e:
+            import_manifest(bk_module, base_manifest)
+
+        assert "addons.0.specs" in str(e)
+
+    def test_normal(self, bk_module, base_manifest):
+        base_manifest["spec"]["addons"] = [{"name": "mysql"}]
+        import_manifest(bk_module, base_manifest)
+        # TODO: Add assertion to verify the addons have been imported successfully
 
 
 class TestMounts:

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/test_manifest.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/test_manifest.py
@@ -15,6 +15,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 import functools
 from unittest import mock
 
@@ -29,6 +30,7 @@ from paas_wl.bk_app.cnative.specs.constants import (
     VolumeSourceType,
 )
 from paas_wl.bk_app.cnative.specs.crd.bk_app import (
+    BkAppAddon,
     BkAppHooks,
     BkAppResource,
     BkAppSpec,
@@ -49,6 +51,7 @@ from paas_wl.bk_app.cnative.specs.models import Mount
 from paas_wl.bk_app.processes.models import initialize_default_proc_spec_plans
 from paas_wl.core.resource import generate_bkapp_name
 from paasng.accessories.servicehub.manager import mixed_service_mgr
+from paasng.accessories.servicehub.sharing import ServiceSharingManager
 from paasng.accessories.services.models import Plan, Service, ServiceCategory
 from paasng.platform.bkapp_model.manifest import (
     DEFAULT_SLUG_RUNNER_ENTRYPOINT,
@@ -137,6 +140,19 @@ class TestAddonsManifestConstructor:
         annots = blank_resource.metadata.annotations
         assert annots["bkapp.paas.bk.tencent.com/addons"] == '["mysql"]'
         assert len(blank_resource.spec.addons) == 1
+        assert blank_resource.spec.addons[0] == BkAppAddon(name="mysql")
+
+    def test_with_shared_addons(self, bk_module, bk_module_2, blank_resource, local_service):
+        # Let bk_module share a service with bk_module_2
+        mixed_service_mgr.bind_service(local_service, bk_module_2)
+        ServiceSharingManager(bk_module).create(local_service, bk_module_2)
+
+        AddonsManifestConstructor().apply_to(blank_resource, bk_module)
+
+        annots = blank_resource.metadata.annotations
+        assert annots["bkapp.paas.bk.tencent.com/addons"] == '["mysql"]'
+        assert len(blank_resource.spec.addons) == 1
+        assert blank_resource.spec.addons[0] == BkAppAddon(name="mysql", sharedFromModule=bk_module_2.name)
 
 
 class TestEnvVarsManifestConstructor:

--- a/apiserver/paasng/tests/paasng/platform/declarative/application/v3/test_controller.py
+++ b/apiserver/paasng/tests/paasng/platform/declarative/application/v3/test_controller.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 from typing import Dict
 
 import pytest
@@ -362,7 +363,7 @@ class TestServicesField:
         decorator.with_module(
             random_name + "1",
             is_default=False,
-            module_spec={"addons": [{"name": "mysql", "sharedFrom": random_name}]},
+            module_spec={"addons": [{"name": "mysql", "sharedFromModule": random_name}]},
         )(app_desc)
 
         controller = AppDeclarativeController(bk_user)
@@ -381,7 +382,7 @@ class TestServicesField:
         decorator.with_module(
             random_name + "1",
             is_default=False,
-            module_spec={"addons": [{"name": "mysql", "sharedFrom": random_name + "2"}]},
+            module_spec={"addons": [{"name": "mysql", "sharedFromModule": random_name + "2"}]},
         )(app_desc)
         with pytest.raises(DescriptionValidationError):
             get_app_description(app_desc)

--- a/apiserver/paasng/tests/paasng/platform/declarative/application/v3/test_validations.py
+++ b/apiserver/paasng/tests/paasng/platform/declarative/application/v3/test_validations.py
@@ -15,6 +15,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 from typing import Dict
 
 import pytest
@@ -91,7 +92,7 @@ class TestValidateBadCase:
             decorator.with_module(
                 module_name="foo",
                 is_default=True,
-                module_spec={"addons": [{"name": "openai", "sharedFrom": "bar"}]},
+                module_spec={"addons": [{"name": "openai", "sharedFromModule": "bar"}]},
             ),
         )
         with pytest.raises(

--- a/apiserver/paasng/tests/paasng/platform/declarative/test_slzs.py
+++ b/apiserver/paasng/tests/paasng/platform/declarative/test_slzs.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 from typing import Dict
 
 import pytest
@@ -103,7 +104,7 @@ class TestAppDescriptionSLZ:
                 language="nodejs",
                 module_spec={
                     "processes": [{"name": "web", "command": ["npm", "run", "server"]}],
-                    "addons": [{"name": "mysql", "sharedFrom": "python"}],
+                    "addons": [{"name": "mysql", "sharedFromModule": "python"}],
                 },
             ),
             v3_decorator.with_module(


### PR DESCRIPTION
- feat: add shared services support when generating manifest
- feat: bkapp model import support addons field(not implemented)