### PR TITLE
fix: smart image app use version_type=image when deploying

### DIFF
--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/sourcectl/tencent.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/sourcectl/tencent.py
@@ -110,7 +110,7 @@ class PluginRepoAccessor:
         """
         if ":" not in smart_revision:
             return smart_revision
-        version_type, version_name = smart_revision.split(":")
+        _, version_name = smart_revision.split(":")
         commit = self.get_last_commit(self.project, version_name)
         return commit["id"]
 

--- a/apiserver/paasng/paasng/platform/engine/constants.py
+++ b/apiserver/paasng/paasng/platform/engine/constants.py
@@ -179,7 +179,7 @@ class NoPrefixAppRunTimeBuiltinEnv(str, StructuredEnum):
 class VersionType(str, StructuredEnum):
     """版本类型. 对应 VersionInfo.version_type"""
 
-    TAG = EnumField("tag", label="用于 Git 仓库、云原生镜像应用、旧镜像应用")
+    TAG = EnumField("tag", label="用于 Git 仓库、云原生镜像应用、旧镜像应用、镜像模式的 S-Mart 应用")
     BRANCH = EnumField("branch", label="用于 SVN 仓库、Git 仓库")
     TRUNK = EnumField("trunk", label="用于 SVN 仓库")
     IMAGE = EnumField("image", label="用于云原生应用选择已构建的镜像部署时")

--- a/apiserver/paasng/paasng/platform/engine/constants.py
+++ b/apiserver/paasng/paasng/platform/engine/constants.py
@@ -182,5 +182,5 @@ class VersionType(str, StructuredEnum):
     TAG = EnumField("tag", label="用于 Git 仓库、云原生镜像应用、旧镜像应用、镜像模式的 S-Mart 应用")
     BRANCH = EnumField("branch", label="用于 SVN 仓库、Git 仓库")
     TRUNK = EnumField("trunk", label="用于 SVN 仓库")
-    IMAGE = EnumField("image", label="用于云原生应用选择已构建的镜像部署时")
-    PACKAGE = EnumField("package", label="用于 lesscode 应用和 S-Mart 应用")
+    IMAGE = EnumField("image", label="仅用于云原生应用选择已构建的镜像部署时")
+    PACKAGE = EnumField("package", label="用于 lesscode 应用和二进制的 S-Mart 应用")

--- a/apiserver/paasng/paasng/platform/engine/deploy/start.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/start.py
@@ -22,7 +22,7 @@ from typing import Dict, Optional
 from paas_wl.bk_app.cnative.specs.models import AppModelResource
 from paasng.platform.applications.constants import ApplicationType
 from paasng.platform.applications.models import ModuleEnvironment
-from paasng.platform.engine.constants import OperationTypes, RuntimeType
+from paasng.platform.engine.constants import OperationTypes, RuntimeType, VersionType
 from paasng.platform.engine.deploy.building import start_build, start_build_error_callback
 from paasng.platform.engine.deploy.image_release import release_without_build
 from paasng.platform.engine.models.deployment import Deployment
@@ -135,7 +135,7 @@ class DeployTaskRunner:
             return False
         elif (
             self.module.get_source_origin() == SourceOrigin.S_MART
-            and self.deployment.version_info.version_type == "image"
+            and self.deployment.version_info.version_type == VersionType.TAG.value
         ):
             return False
         # 如部署时指定了 build_id, 说明是选择了历史版本(镜像)进行发布, 则无需构建

--- a/apiserver/paasng/paasng/platform/engine/models/deployment.py
+++ b/apiserver/paasng/paasng/platform/engine/models/deployment.py
@@ -260,7 +260,7 @@ class Deployment(OperationVersionBase):
         :raise ValueError: 当无法获取到版本信息时抛此异常
         """
         # s-mart 镜像应用, 对平台而言还是源码包部署
-        if self.source_version_type != "image":
+        if self.source_version_type != VersionType.IMAGE.value:
             version_type = self.source_version_type
             version_name = self.source_version_name
             # Backward compatibility

--- a/apiserver/paasng/paasng/platform/engine/models/deployment.py
+++ b/apiserver/paasng/paasng/platform/engine/models/deployment.py
@@ -28,9 +28,8 @@ from jsonfield import JSONField
 
 from paasng.misc.metrics import DEPLOYMENT_STATUS_COUNTER, DEPLOYMENT_TIME_CONSUME_HISTOGRAM
 from paasng.platform.applications.models import ModuleEnvironment
-from paasng.platform.engine.constants import BuildStatus, ImagePullPolicy, JobStatus
+from paasng.platform.engine.constants import BuildStatus, ImagePullPolicy, JobStatus, VersionType
 from paasng.platform.engine.models.base import OperationVersionBase
-from paasng.platform.modules.constants import SourceOrigin
 from paasng.platform.modules.models.deploy_config import HookList, HookListField
 from paasng.platform.sourcectl.models import VersionInfo
 from paasng.utils.models import make_json_field, make_legacy_json_field
@@ -260,9 +259,8 @@ class Deployment(OperationVersionBase):
 
         :raise ValueError: 当无法获取到版本信息时抛此异常
         """
-        module = self.app_environment.module
         # s-mart 镜像应用, 对平台而言还是源码包部署
-        if self.source_version_type != "image" or module.source_origin == SourceOrigin.S_MART:
+        if self.source_version_type != "image":
             version_type = self.source_version_type
             version_name = self.source_version_name
             # Backward compatibility
@@ -273,7 +271,7 @@ class Deployment(OperationVersionBase):
 
         # 查询第一个引用 build_id 的 Deployment
         ref = Deployment.objects.filter(build_id=self.build_id).exclude(id=self.id).order_by("created").first()
-        if not ref or ref.source_version_type == "image":
+        if not ref or ref.source_version_type == VersionType.IMAGE.value:
             raise ValueError("unknown version info")
         return ref.get_version_info()
 

--- a/apiserver/paasng/paasng/platform/engine/views/deploy.py
+++ b/apiserver/paasng/paasng/platform/engine/views/deploy.py
@@ -41,7 +41,7 @@ from paasng.infras.iam.permissions.resources.application import AppAction
 from paasng.misc.metrics import DEPLOYMENT_INFO_COUNTER
 from paasng.platform.applications.mixins import ApplicationCodeInPathMixin
 from paasng.platform.declarative.exceptions import DescriptionValidationError
-from paasng.platform.engine.constants import RuntimeType
+from paasng.platform.engine.constants import RuntimeType, VersionType
 from paasng.platform.engine.deploy.interruptions import interrupt_deployment
 from paasng.platform.engine.deploy.start import DeployTaskRunner, initialize_deployment
 from paasng.platform.engine.exceptions import DeployInterruptionFailed
@@ -174,7 +174,7 @@ class DeploymentViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
             # TODO: 解决这种奇怪的问题, 不管是让 initialize_deployment 不依赖 VersionInfo 或者让这里构造的 VersionInfo 变得有意义
             image_tag = build.image_tag or ""
             return VersionInfo(
-                version_type="image",
+                version_type=VersionType.IMAGE.value,
                 version_name=image_tag,
                 revision=image_tag,
             )

--- a/apiserver/paasng/paasng/platform/sourcectl/controllers/docker.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/controllers/docker.py
@@ -128,7 +128,7 @@ class DockerRegistryController:
     def extract_smart_revision(self, smart_revision: str) -> str:
         if ":" not in smart_revision:
             return smart_revision
-        version_type, version_name = smart_revision.split(":")
+        _, version_name = smart_revision.split(":")
         return version_name
 
     def build_url(self, version_info: VersionInfo) -> str:

--- a/apiserver/paasng/paasng/platform/sourcectl/controllers/gitee.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/controllers/gitee.py
@@ -98,7 +98,7 @@ class GiteeRepoController(BaseGitRepoController):
         """解析组合 revision 信息（如 branch:master, tag:v1.2），获取更加具体的 commit id（hash）"""
         if ":" not in smart_revision:
             return smart_revision
-        version_type, version_name = smart_revision.split(":")
+        _, version_name = smart_revision.split(":")
         commit = self.api_client.repo_last_commit(self.project, version_name)
         return commit["sha"]
 

--- a/apiserver/paasng/paasng/platform/sourcectl/controllers/github.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/controllers/github.py
@@ -112,7 +112,7 @@ class GitHubRepoController(BaseGitRepoController):
         """解析组合 revision 信息（如 branch:master, tag:v1.2），获取更加具体的 commit id（hash）"""
         if ":" not in smart_revision:
             return smart_revision
-        version_type, version_name = smart_revision.split(":")
+        _, version_name = smart_revision.split(":")
         commit = self.api_client.repo_last_commit(self.project, version_name)
         return commit["sha"]
 

--- a/apiserver/paasng/paasng/platform/sourcectl/controllers/package.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/controllers/package.py
@@ -86,7 +86,7 @@ class PackageController:
         items = [
             AlternativeVersion(
                 name=info.package_name,
-                type="package" if info.storage_engine != "docker" else "image",
+                type="package" if info.storage_engine != "docker" else "tag",
                 revision=info.version,
                 url=info.storage_url,
                 last_update=info.updated,
@@ -105,7 +105,7 @@ class PackageController:
         info = self.module.packages.get(version=version)
         return AlternativeVersion(
             name=info.package_name,
-            type="package" if info.storage_engine != "docker" else "image",
+            type="package" if info.storage_engine != "docker" else "tag",
             revision=info.version,
             url=info.storage_url,
             last_update=info.updated,
@@ -118,7 +118,7 @@ class PackageController:
     def extract_smart_revision(self, smart_revision: str) -> str:
         if ":" not in smart_revision:
             return smart_revision
-        version_type, package_name = smart_revision.split(":", 1)
+        _, package_name = smart_revision.split(":", 1)
         # NOTE: 为了兼容 svn/git 的交互协议, 允许通过传递 package_name 来部署最后一个以 package_name 命名的版本。
         if self.module.packages.filter(package_name=package_name).exists():
             return self.module.packages.filter(package_name=package_name).last().version

--- a/apiserver/paasng/paasng/platform/sourcectl/models.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/models.py
@@ -445,6 +445,13 @@ class VersionInfo:
 
         样例数据: VersionInfo(revision="2.2.1", version_name="2.2.1", version_type="package")
 
+    对于采用了镜像模式的 S-Mart 应用:
+        revision 是当前包的 semver
+        version_name 是镜像的 tag
+        version_type 是 Literal[tag]
+
+        样例数据: VersionInfo(revision="2.2.1", version_name="2.2.1", version_type="tag")
+
     对于云原生镜像而言:
         revision 为空串
         version_name 是镜像的 tag

--- a/apiserver/paasng/tests/paasng/platform/engine/test_deployment.py
+++ b/apiserver/paasng/tests/paasng/platform/engine/test_deployment.py
@@ -50,13 +50,11 @@ class TestDeploymentVersion:
         deployment = G(
             Deployment,
             app_environment=bk_stag_env,
-            source_version_type="image",
+            source_version_type="tag",
             source_version_name="v1.2.3",
             source_revision="hash",
         )
-        assert deployment.get_version_info() == VersionInfo(
-            revision="hash", version_name="v1.2.3", version_type="image"
-        )
+        assert deployment.get_version_info() == VersionInfo(revision="hash", version_name="v1.2.3", version_type="tag")
 
     def test_image(self, bk_module, bk_stag_env, bk_prod_env):
         """测试发布历史镜像时, 查询镜像对应的源码版本信息"""


### PR DESCRIPTION
背景 pr #1281：
- 镜像模式的 smart 应用，其 `version_type`，由 image 调整为 tag

说明：根据现在  `Deployment.get_version_info` 的实现，`version_type` 值为 `image` 时 只用于云原生应用选择已构建的镜像部署时的场景