### PR TITLE
enhance: improve the error msg when no plans can be found binding service

### DIFF
--- a/apiserver/paasng/paasng/accessories/servicehub/exceptions.py
+++ b/apiserver/paasng/paasng/accessories/servicehub/exceptions.py
@@ -62,3 +62,7 @@ class DuplicatedServiceBoundError(BaseServicesException):
     """
     when user try to create a sharing relation for an already bound service or verse-vise. Raise this error
     """
+
+
+class BindServiceNoPlansError(Exception):
+    """When binding a service, appropriate plans cannot be found for all environments."""

--- a/apiserver/paasng/tests/paasng/accessories/servicehub/test_manager.py
+++ b/apiserver/paasng/tests/paasng/accessories/servicehub/test_manager.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 import datetime
 from json import dumps
 from typing import Dict
@@ -26,7 +27,7 @@ import pytest
 from django_dynamic_fixture import G
 
 from paasng.accessories.servicehub.constants import Category
-from paasng.accessories.servicehub.exceptions import ServiceObjNotFound
+from paasng.accessories.servicehub.exceptions import BindServiceNoPlansError, ServiceObjNotFound
 from paasng.accessories.servicehub.local import LocalServiceMgr, LocalServiceObj
 from paasng.accessories.servicehub.manager import mixed_service_mgr
 from paasng.accessories.servicehub.models import ServiceEngineAppAttachment
@@ -263,7 +264,7 @@ class TestLocalRabbitMQMgr(BaseTestCaseWithApp):
         mgr = LocalServiceMgr()
         service = mgr.get(self.svc.uuid, region=self.module.region)
 
-        with self.assertRaisesMessage(RuntimeError, "can not bind a plan"):
+        with pytest.raises(BindServiceNoPlansError):
             mgr.bind_service(service, self.module)
 
     def test_list_by_category(self):


### PR DESCRIPTION
- enhance: improve the error msg when no plans can be found binding service

Currently, users might see "增强服务绑定失败: can not bind a plan" error message when trying to bind a service using the wrong spec.