### PR TITLE
fix：普通应用-部署分支为 image 时，部署弹框 imagePullPolicy 没有展示出来

### DIFF
--- a/webfe/package_vue/src/views/dev-center/app/engine/deployment/comps/deploy-action/index.vue
+++ b/webfe/package_vue/src/views/dev-center/app/engine/deployment/comps/deploy-action/index.vue
@@ -3215,7 +3215,7 @@ export default {
 
     getBranchInfoType() {
       const branchInfo = this.branchesMap[this.branchSelection];
-      this.branchInfoType = branchInfo.type;
+      this.branchInfoType = branchInfo.display_type;
     },
 
     async getLessCode() {


### PR DESCRIPTION
- 普通应用-部署分支为 image 时，部署弹框 imagePullPolicy 没有展示出来