### PR TITLE
update: 应用市场可见范围为空时应该提示默认全局可见

### DIFF
--- a/webfe/package_vue/src/views/dev-center/app/market/visible-range.vue
+++ b/webfe/package_vue/src/views/dev-center/app/market/visible-range.vue
@@ -12,7 +12,9 @@
       </div>
       <div class="content">
         <div class="top-wrapper">
+          <p class="info" v-if="departments.length === 0 && users.length === 0">{{ $t('默认全员可见') }}</p>
           <p
+            v-else
             class="info"
             v-html="infoMsg"
           ></p>


### PR DESCRIPTION
- 应用市场可见范围为空时应该提示默认全局可见