### PR TITLE
fix: show the correct message when process name defined in app_desc.yaml is too long

### DIFF
--- a/apiserver/paasng/paasng/platform/declarative/deployment/validations/v2.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/validations/v2.py
@@ -223,7 +223,7 @@ class DeploymentDescSLZ(serializers.Serializer):
                 )
             if len(proc_type) > PROC_TYPE_MAX_LENGTH:
                 raise ValidationError(
-                    f"Invalid proc type: {proc_type}, must be less than {PROC_TYPE_MAX_LENGTH} characters"
+                    f"Invalid proc type: {proc_type}, cannot be longer than {PROC_TYPE_MAX_LENGTH} characters"
                 )
 
         # Formalize procfile data and return

--- a/apiserver/paasng/paasng/platform/declarative/deployment/validations/v2.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/validations/v2.py
@@ -16,6 +16,7 @@ limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+
 import shlex
 
 import cattr
@@ -218,11 +219,11 @@ class DeploymentDescSLZ(serializers.Serializer):
         for proc_type in processes:
             if not PROC_TYPE_PATTERN.match(proc_type):
                 raise ValidationError(
-                    f"Invalid proc type: {proc_type}, must match " f"pattern {PROC_TYPE_PATTERN.pattern}"
+                    f"Invalid proc type: {proc_type}, must match pattern {PROC_TYPE_PATTERN.pattern}"
                 )
             if len(proc_type) > PROC_TYPE_MAX_LENGTH:
                 raise ValidationError(
-                    f"Invalid proc type: {proc_type}, must not " f"longer than {PROC_TYPE_MAX_LENGTH} characters"
+                    f"Invalid proc type: {proc_type}, must be less than {PROC_TYPE_MAX_LENGTH} characters"
                 )
 
         # Formalize procfile data and return


### PR DESCRIPTION
If the developer defines a process with a name longer than the maximum allowed value, the deployment will fail. But the error message will be "cannot read procfile" instead of "process name is invalid". That's because the "handle-description" phase always failed silently for non-cnative apps, and the real cause was swallowed and another not-so-related exception was thrown instead, which generates a more vague error message.

This PR changes that behavior by always raising the validation error when handling the app description file.