### PR TITLE
feat: add procCommand field to specVersion:3

### DIFF
--- a/apiserver/paasng/paas_wl/bk_app/cnative/specs/crd/bk_app.py
+++ b/apiserver/paasng/paas_wl/bk_app/cnative/specs/crd/bk_app.py
@@ -22,6 +22,7 @@ to the current version of the project delivered to anyone in the future.
 Use `pydantic` to get good JSON-Schema support, which is essential for CRD.
 """
 import datetime
+import shlex
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, validator
@@ -130,6 +131,12 @@ class BkAppProcess(BaseModel):
     # proc_command 用于向后兼容普通应用部署场景(shlex.split + shlex.join 难以保证正确性)
     proc_command: Optional[str] = Field(None)
 
+    def __init__(self, **data):
+        # 处理 specVersion: 3 中驼峰传递 procCommand
+        if proc_command := data.get("procCommand"):
+            data["proc_command"] = proc_command
+        super().__init__(**data)
+
     def get_proc_command(self) -> str:
         """get_proc_command: 生成 Procfile 文件中对应的命令行"""
         if self.proc_command:
@@ -142,6 +149,13 @@ class Hook(BaseModel):
 
     command: Optional[List[str]] = Field(default_factory=list)
     args: Optional[List[str]] = Field(default_factory=list)
+
+    def __init__(self, **data):
+        # TODO 先采用 paasng.platform.declarative.deployment.validations.v2.DeploymentDescSLZ 中的做法, 后续统一优化
+        if proc_command := data.get("procCommand"):
+            data["command"] = None
+            data["args"] = shlex.split(proc_command)
+        super().__init__(**data)
 
 
 class BkAppHooks(BaseModel):

--- a/apiserver/paasng/paasng/platform/declarative/application/validations/v3.py
+++ b/apiserver/paasng/paasng/platform/declarative/application/validations/v3.py
@@ -75,6 +75,11 @@ class MarketSLZ(serializers.Serializer):
         tag = attrs.pop("tag", None)
         if tag:
             attrs["tag_id"] = tag.pk
+
+        # 未指定有效英文简介时, 使用中文简介
+        if not attrs["introduction_en"]:
+            attrs["introduction_en"] = attrs["introduction_zh_cn"]
+
         return MarketDesc(**attrs)
 
 

--- a/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
@@ -115,7 +115,7 @@ class DeploymentDeclarativeController:
 
         application = self.deployment.app_environment.application
         module = self.deployment.app_environment.module
-        processes = desc.get_processes()
+        processes: Dict[str, Process] = desc.get_processes()
         deploy_desc, _ = DeploymentDescription.objects.update_or_create(
             deployment=self.deployment,
             defaults={

--- a/apiserver/paasng/paasng/platform/modules/models/deploy_config.py
+++ b/apiserver/paasng/paasng/platform/modules/models/deploy_config.py
@@ -40,6 +40,7 @@ class Hook:
         """get_args: 获取 hook 的命令部分
         使用场景: 云原生应用构造 manifest 时调用 -> HooksManifestConstructor
         """
+        # TODO 确认已在 HooksManifestConstructor 中使用? 看代码是 ModuleDeployHook 的 get_command
         if isinstance(self.command, str):
             # TODO: runner 的 Dockerfile 默认的入口程序为 ["/runner/init"], 理论上返回空列表即可
             return DEFAULT_SLUG_RUNNER_ENTRYPOINT
@@ -49,6 +50,7 @@ class Hook:
         """get_args: 获取 hook 的参数部分
         使用场景: 云原生应用构造 manifest 时调用 -> HooksManifestConstructor
         """
+        # TODO 确认已在 HooksManifestConstructor 中使用? 看代码是 ModuleDeployHook 的 get_args
         if isinstance(self.command, str):
             command = shlex.split(self.command)
             # 有脏数据, 移除前 len(DEFAULT_SLUG_RUNNER_ENTRYPOINT) 个元素
@@ -63,6 +65,7 @@ class Hook:
         """
         if isinstance(self.command, str):
             return self.command
+        # Warning: shlex.join 并不能简单的通过 shlex.join 合并 command 和 args 生成, 可能出现无法正常运行的问题
         return (shlex.join(self.command or []) + " " + shlex.join(self.args or [])).strip()
 
 


### PR DESCRIPTION
- 新增：specVersion: 3 版本支持 procCommand 一行命令配置进程和钩子
- 修复：introductionEn 必填的问题
- 修复：Hook 脏数据导致的 list index out of range