### PR TITLE
fix: perm_insure checking missing late extend django apps

### DIFF
--- a/apiserver/paasng/paasng/infras/accounts/permissions/application.py
+++ b/apiserver/paasng/paasng/infras/accounts/permissions/application.py
@@ -69,8 +69,7 @@ def application_perm_class(action: AppAction) -> Type[BasePermission]:
             elif isinstance(obj, Module):
                 return user_has_app_action_perm(request.user, obj.application, action)
             else:
-                logger.error("Application permission checked on incorrect object, type: %s", type(obj))
-                return False
+                raise TypeError(f"Permission check on incorrect type: {type(obj)}")
 
     return AppModulePermission
 
@@ -101,8 +100,7 @@ def app_view_actions_perm(
             elif isinstance(obj, Module):
                 return user_has_app_action_perm(request.user, obj.application, action)
             else:
-                logger.error("Application permission checked on incorrect object, type: %s", type(obj))
-                return False
+                raise TypeError(f"Permission check on incorrect type: {type(obj)}")
 
     return AppViewActionsPermission
 

--- a/apiserver/paasng/paasng/settings/__init__.py
+++ b/apiserver/paasng/paasng/settings/__init__.py
@@ -176,13 +176,16 @@ INSTALLED_APPS = [
     "paas_wl.infras.resources.generation",
     # 蓝鲸通知中心
     "bk_notice_sdk",
-    # This app helps us to make sure the permission was configured correctly
-    "paasng.infras.perm_insure",
 ]
 
 # Allow extending installed apps
 EXTRA_INSTALLED_APPS = settings.get("EXTRA_INSTALLED_APPS", [])
 INSTALLED_APPS += EXTRA_INSTALLED_APPS
+
+# The "perm_insure" module helps us to make sure that the permission is configured
+# correctly, put it at the end of the list to make sure that all URL confs have been
+# added to the root url before the perm checking starts.
+INSTALLED_APPS.append("paasng.infras.perm_insure")
 
 MIDDLEWARE = [
     "django_prometheus.middleware.PrometheusBeforeMiddleware",


### PR DESCRIPTION
- fix: perm_insure checking missing late extend django apps

The project supports registering additional applications using the `settings.EXTRA_INSTALLED_APPS` configuration. These applications may extend the root URLs. Change the order of "perm_insure" to the last to make sure it can check all URLs.