### PR TITLE
fix: fixed templates filling logic in admin42

### DIFF
--- a/apiserver/paasng/paasng/plat_admin/admin42/serializers/templates.py
+++ b/apiserver/paasng/paasng/plat_admin/admin42/serializers/templates.py
@@ -73,11 +73,8 @@ class TemplateSLZ(serializers.ModelSerializer):
         if not isinstance(blob_url_conf, dict):
             raise ValidationError(_("二进制包存储配置必须为 Dict 格式"))
 
-        # 模板类型为插件的情况下，二进制包存储配置可为空
-        if attrs["type"] == TemplateType.PLUGIN and (blob_url_conf == {} or not blob_url_conf):
-            return attrs
-
-        if regions := set(enabled_regions) - blob_url_conf.keys():
+        # 模板类型为插件的情况下，无需检查二进制包存储配置
+        if attrs["type"] != TemplateType.PLUGIN and (regions := set(enabled_regions) - blob_url_conf.keys()):
             raise ValidationError(_("Region {} 不存在对应的二进制包存储路径").format(regions))
 
         return attrs

--- a/apiserver/paasng/paasng/plat_admin/admin42/serializers/templates.py
+++ b/apiserver/paasng/paasng/plat_admin/admin42/serializers/templates.py
@@ -74,7 +74,8 @@ class TemplateSLZ(serializers.ModelSerializer):
             raise ValidationError(_("二进制包存储配置必须为 Dict 格式"))
 
         # 模板类型为插件的情况下，无需检查二进制包存储配置
-        if attrs["type"] != TemplateType.PLUGIN and (regions := set(enabled_regions) - blob_url_conf.keys()):
-            raise ValidationError(_("Region {} 不存在对应的二进制包存储路径").format(regions))
+        if attrs["type"] != TemplateType.PLUGIN:  # noqa: SIM102
+            if regions := set(enabled_regions) - blob_url_conf.keys():
+                raise ValidationError(_("Region {} 不存在对应的二进制包存储路径").format(regions))
 
         return attrs

--- a/apiserver/paasng/paasng/plat_admin/admin42/serializers/templates.py
+++ b/apiserver/paasng/paasng/plat_admin/admin42/serializers/templates.py
@@ -22,6 +22,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
 from paasng.core.region.models import get_all_regions
+from paasng.platform.templates.constants import TemplateType
 from paasng.platform.templates.models import Template
 
 
@@ -71,6 +72,10 @@ class TemplateSLZ(serializers.ModelSerializer):
         blob_url_conf = attrs["blob_url"]
         if not isinstance(blob_url_conf, dict):
             raise ValidationError(_("二进制包存储配置必须为 Dict 格式"))
+
+        # 模板类型为插件的情况下，二进制包存储配置可为空
+        if attrs["type"] == TemplateType.PLUGIN and (blob_url_conf == {} or not blob_url_conf):
+            return attrs
 
         if regions := set(enabled_regions) - blob_url_conf.keys():
             raise ValidationError(_("Region {} 不存在对应的二进制包存储路径").format(regions))

--- a/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/configuration/templates.html
+++ b/apiserver/paasng/paasng/plat_admin/admin42/templates/admin42/configuration/templates.html
@@ -12,6 +12,7 @@
             <template slot-scope="props">
                 <span v-if="props.row.type === 'normal'">普通应用</span>
                 <span v-if="props.row.type === 'scene'">场景模板</span>
+                <span v-if="props.row.type === 'plugin'">插件模板</span>
             </template>
         </bk-table-column>
         <bk-table-column label="展示用名称">

--- a/apiserver/paasng/paasng/platform/templates/models.py
+++ b/apiserver/paasng/paasng/platform/templates/models.py
@@ -45,7 +45,7 @@ class Template(AuditedModel):
     language = models.CharField(verbose_name=_("开发语言"), max_length=32)
     market_ready = models.BooleanField(verbose_name=_("能否发布到应用集市"), default=False)
     preset_services_config = models.JSONField(verbose_name=_("预设增强服务配置"), blank=True, default=dict)
-    blob_url = models.JSONField(verbose_name=_("不同版本二进制包存储路径"))
+    blob_url = models.JSONField(verbose_name=_("不同版本二进制包存储路径"), default={})
     enabled_regions = models.JSONField(verbose_name=_("允许被使用的版本"), blank=True, default=list)
     required_buildpacks = models.JSONField(verbose_name=_("必须的构建工具"), blank=True, default=list)
     processes = models.JSONField(verbose_name=_("进程配置"), blank=True, default=dict)


### PR DESCRIPTION
fix: 模板类型为插件的情况下，二进制包存储配置可为空
fix: 前端模板类型为插件时不显示