### PR TITLE
feat: 支持 Codecc 插件正式版本发布

### DIFF
--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/constants.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/constants.py
@@ -182,3 +182,12 @@ class StatusPollingMethod(str, StructuredEnum):
 
     API = EnumField("api", label=_("后台 API 轮询"))
     FRONTEND = EnumField("frontend", label=_("前端轮询，如通过 Iframe message 通信等"))
+
+
+class PluginRevisionType(str, StructuredEnum):
+    """代码版本类型"""
+
+    ALL = EnumField("all", label=_("不限制"))
+    MASTER = EnumField("master", label=_("仅可选择主分支发布"))
+    TAG = EnumField("tag", label=_("Tag 发布"))
+    TESTED_VERSION = EnumField("tested_version", label=_("已经测试通过的版本"))

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/definitions.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/definitions.py
@@ -198,9 +198,12 @@ class PluginMarketInfoDefinition(BaseModel):
 class ReleaseRevisionDefinition(BaseModel):
     """发布版本定义"""
 
-    revisionType: Literal["all", "master", "tag", "tested_version"] = Field(
-        description="代码版本类型(all, 不限制; master 仅可选择主分支发布; tag Tag发布)"
-    )
+    revisionType: Literal[
+        constants.PluginRevisionType.ALL,
+        constants.PluginRevisionType.MASTER,
+        constants.PluginRevisionType.TAG,
+        constants.PluginRevisionType.TESTED_VERSION,
+    ] = Field(description="代码版本类型(all, 不限制; master 仅可选择主分支发布; tag Tag发布)")
     revisionPattern: Optional[str] = Field(description="代码版本正则表达式模板, 留空则不校验")
     revisionPolicy: Optional[Literal["disallow_released_source_version", "disallow_releasing_source_version"]] = Field(
         description="代码版本选择策略, 留空则不校验"

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/itsm_adaptor/constants.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/itsm_adaptor/constants.py
@@ -21,12 +21,23 @@ from django.utils.translation import gettext_lazy as _
 
 
 class ApprovalServiceName(str, StructuredEnum):
-    """审批流程服务名"""
+    """审批流程服务名
+        Full release: Platform administrator approval
+    Gray release: Plugin administrator approval
+    Organizational gray release: Approval by the leader of the publisher's group
+    """
 
     CREATE_APPROVAL = EnumField("create_approval", label=_("插件上线审批"))
     ONLINE_APPROVAL = EnumField("online_approval", label=_("插件创建审批流程"))
     VISIBLE_RANGE_APPROVAL = EnumField("visible_range_approval", label=_("插件可见范围修改审批流程"))
-    CANARY_APPROVAL = EnumField("canary_approval", label=_("插件灰度发布审批流程"))
+    # 全量发布：平台管理员审批
+    CODECC_FULL_RELEASE_APPROVAL = EnumField("codecc_full_release_approval", label=_("Codecc 全量发布审批流程"))
+    # 灰度审批：插件管理员审批
+    CODECC_GRAY_RELEASE_APPROVAL = EnumField("codecc_gray_release_approval", label=_("Codecc 灰度发布审批流程"))
+    # 按组织灰度审批：发布者 leader 审批
+    CODECC_ORG_GRAY_RELEASE_APPROVAL = EnumField(
+        "codecc_org_gray_release_approval", label=_("Codecc 按组织灰度发布审批流程")
+    )
 
 
 class ItsmTicketStatus(str, StructuredEnum):

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/itsm_adaptor/constants.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/itsm_adaptor/constants.py
@@ -26,6 +26,7 @@ class ApprovalServiceName(str, StructuredEnum):
     CREATE_APPROVAL = EnumField("create_approval", label=_("插件上线审批"))
     ONLINE_APPROVAL = EnumField("online_approval", label=_("插件创建审批流程"))
     VISIBLE_RANGE_APPROVAL = EnumField("visible_range_approval", label=_("插件可见范围修改审批流程"))
+    CANARY_APPROVAL = EnumField("canary_approval", label=_("插件灰度发布审批流程"))
 
 
 class ItsmTicketStatus(str, StructuredEnum):

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/itsm_adaptor/utils.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/itsm_adaptor/utils.py
@@ -96,10 +96,10 @@ def submit_canary_release_ticket(
     pd: PluginDefinition, plugin: PluginInstance, version: PluginRelease, operator: str
 ) -> "ItsmDetail":
     """提交灰度发布申请单据"""
-    # # 可见范围
+    # 可见范围
     # visible_range_obj, _c = PluginVisibleRange.objects.get_or_create(plugin=plugin)
-    # # 发布策略
-    # release_strategy = version.release.latest_release_strategy
+    # 发布策略
+    release_strategy = version.release.latest_release_strategy
 
     # 组装提单数据,包含插件的基本信息和灰度发布信息
     basic_fields = _get_basic_fields(pd, plugin)
@@ -107,7 +107,7 @@ def submit_canary_release_ticket(
     fields = basic_fields + title_fields
 
     # 查询上线审批服务ID
-    service_id = ApprovalService.objects.get(service_name=ApprovalServiceName.CANARY_APPROVAL.value).service_id
+    service_id = ApprovalService.objects.get(service_name=release_strategy.get_itsm_service_name()).service_id
 
     # 单据结束的时候，itsm 会调用 callback_url 告知审批结果，回调地址为开发者中心后台 API 的地址
     paas_url = f"{settings.BK_IAM_RESOURCE_API_HOST}/backend"

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/models/instances.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/models/instances.py
@@ -34,6 +34,7 @@ from translated_fields import TranslatedFieldWithFallback
 
 from paasng.bk_plugins.pluginscenter import constants
 from paasng.bk_plugins.pluginscenter.definitions import PluginCodeTemplate, PluginoverviewPage, find_stage_by_id
+from paasng.bk_plugins.pluginscenter.itsm_adaptor.constants import ApprovalServiceName
 from paasng.core.core.storages.object_storage import plugin_logo_storage
 from paasng.utils.models import AuditedModel, BkUserField, ProcessedImageField, UuidAuditedModel, make_json_field
 
@@ -376,6 +377,15 @@ class PluginReleaseStrategy(AuditedModel):
     # ]
     organization = models.JSONField(verbose_name="组织架构", blank=True, null=True)
     itsm_detail: Optional[ItsmDetail] = ItsmDetailField(default=None, null=True)
+
+    def get_itsm_service_name(self):
+        """根据发布策略的设置获取对应的 ITSM 审批流程"""
+        if self.strategy == constants.PluginReleaseStrategy.FULL:
+            return ApprovalServiceName.CODECC_FULL_RELEASE_APPROVAL
+
+        if self.organization:
+            return ApprovalServiceName.CODECC_ORG_GRAY_RELEASE_APPROVAL
+        return ApprovalServiceName.CODECC_GRAY_RELEASE_APPROVAL
 
 
 class ApprovalService(UuidAuditedModel):

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/models/instances.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/models/instances.py
@@ -141,6 +141,10 @@ class PluginInstance(UuidAuditedModel):
     def has_test_version(self) -> bool:
         return self.pd.test_release_revision is not None
 
+    @property
+    def latest_release_strategy(self):
+        return self.release_strategies.latest()
+
     class Meta:
         unique_together = ("pd", "id")
 
@@ -347,7 +351,7 @@ class PluginReleaseStrategy(AuditedModel):
     """插件版本的发布策略"""
 
     release = models.ForeignKey(
-        PluginRelease, on_delete=models.CASCADE, db_constraint=False, related_name="release_strategy"
+        PluginRelease, on_delete=models.CASCADE, db_constraint=False, related_name="release_strategies"
     )
     strategy = models.CharField(
         verbose_name="发布策略", max_length=32, choices=constants.PluginReleaseStrategy.get_choices()
@@ -371,6 +375,7 @@ class PluginReleaseStrategy(AuditedModel):
     #     }
     # ]
     organization = models.JSONField(verbose_name="组织架构", blank=True, null=True)
+    itsm_detail: Optional[ItsmDetail] = ItsmDetailField(default=None, null=True)
 
 
 class ApprovalService(UuidAuditedModel):

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/releases/stages.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/releases/stages.py
@@ -221,19 +221,7 @@ class CanaryWithItsm(BaseStageController):
     invoke_method = constants.ReleaseStageInvokeMethod.CANARY_WIHT_ITSM
 
     def execute(self, operator: str):
-        current_stage = self.release.current_stage
-        if not current_stage or current_stage.invoke_method != constants.ReleaseStageInvokeMethod.CANARY_WIHT_ITSM:
-            raise ValueError("this stage is not invoked by canary with itsm")
-        if current_stage.status != constants.PluginReleaseStatus.INITIAL:
-            raise ValueError("canary with its stage is not an initialization state and cannot be triggered")
-        if not self.release.latest_release_strategy:
-            raise ValueError("canary with its stage is not an initialization state and cannot be triggered")
-
-        itsm_detail = submit_canary_release_ticket(self.pd, self.plugin, self.release, operator)
-
-        current_stage.status = constants.PluginReleaseStatus.PENDING
-        current_stage.itsm_detail = itsm_detail
-        current_stage.save(update_fields=["status", "itsm_detail"])
+        submit_canary_release_ticket(self.pd, self.plugin, self.release, operator)
 
     # def render_to_view(self) -> Dict:
     #     basic_info = super().render_to_view()

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/serializers.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/serializers.py
@@ -868,3 +868,9 @@ class PluginVisibleRangeUpdateSLZ(serializers.Serializer):
         child=serializers.CharField(), help_text="格式：['1111', '222222']", required=False, allow_null=True
     )
     organization = serializers.ListField(child=serializers.DictField(), required=False, allow_null=True)
+
+
+class PluginReleaseStrategySLZ(serializers.ModelSerializer):
+    class Meta:
+        model = PluginReleaseStrategy
+        fields = "__all__"

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/utils.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/utils.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions and
+limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+from typing import List
+
+from paasng.bk_plugins.pluginscenter.constants import PluginReleaseStatus, PluginRevisionType
+from paasng.bk_plugins.pluginscenter.models import PluginInstance
+from paasng.bk_plugins.pluginscenter.sourcectl import get_plugin_repo_accessor
+from paasng.bk_plugins.pluginscenter.sourcectl.base import AlternativeVersion
+
+
+def get_source_hash_by_plugin_version(
+    plugin: PluginInstance, version_type: str, version_name: str, revision_type: str, release_id: str
+) -> str:
+    if revision_type == PluginRevisionType.TESTED_VERSION:
+        return plugin.test_versions.get(id=release_id).source_hash
+    return get_plugin_repo_accessor(plugin).extract_smart_revision(f"{version_type}:{version_name}")
+
+
+def get_testd_versions(plugin: PluginInstance, revision_type: str) -> List[AlternativeVersion]:
+    result = []
+    # 获取所有已经测试成功的版本
+    tested_release_list = plugin.test_versions.filter(status=PluginReleaseStatus.SUCCESSFUL).order_by("-updated")
+    for release in tested_release_list:
+        result.append(
+            AlternativeVersion(
+                name=release.version,
+                type=revision_type,
+                revision=release.source_hash,
+                last_update=release.updated,
+                url=f"release_id={release.id}",
+                extra={"release_id": release.id},
+            )
+        )
+    return result

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/views.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/views.py
@@ -588,6 +588,7 @@ class PluginReleaseViewSet(PluginInstanceMixin, mixins.ListModelMixin, GenericVi
         )
         if release_strategy:
             PluginReleaseStrategy.objects.create(release=release, **release_strategy)
+
         PluginReleaseExecutor(release).initial(operator=request.user.username)
 
         # 操作记录: 新建 xx 版本

--- a/apiserver/paasng/tests/paasng/bk_plugins/pluginscenter/test_integration.py
+++ b/apiserver/paasng/tests/paasng/bk_plugins/pluginscenter/test_integration.py
@@ -98,7 +98,7 @@ class TestReleaseStages:
             ).count()
             == 1
         )
-        with mock.patch("paasng.bk_plugins.pluginscenter.views.get_plugin_repo_accessor") as get_plugin_repo_accessor:
+        with mock.patch("paasng.bk_plugins.pluginscenter.utils.get_plugin_repo_accessor") as get_plugin_repo_accessor:
             get_plugin_repo_accessor().extract_smart_revision.return_value = "hash"
             # 创建测试版本发布
             resp = api_client.post(
@@ -125,7 +125,7 @@ class TestReleaseStages:
             ).count()
             == 0
         )
-        with mock.patch("paasng.bk_plugins.pluginscenter.views.get_plugin_repo_accessor") as get_plugin_repo_accessor:
+        with mock.patch("paasng.bk_plugins.pluginscenter.utils.get_plugin_repo_accessor") as get_plugin_repo_accessor:
             get_plugin_repo_accessor().extract_smart_revision.return_value = "hash"
             # 创建正式版本发布
             resp = api_client.post(

--- a/apiserver/paasng/tests/paasng/bk_plugins/pluginscenter/test_serializers.py
+++ b/apiserver/paasng/tests/paasng/bk_plugins/pluginscenter/test_serializers.py
@@ -17,6 +17,7 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 from typing import Dict
+from unittest import mock
 
 import cattr
 import pytest
@@ -26,6 +27,7 @@ from django.utils.translation import gettext as _
 from rest_framework.exceptions import ErrorDetail
 
 from paasng.bk_plugins.pluginscenter import serializers
+from paasng.bk_plugins.pluginscenter.constants import PluginRevisionType
 from paasng.bk_plugins.pluginscenter.definitions import PluginCodeTemplate
 from paasng.utils.i18n import to_translated_field
 
@@ -34,6 +36,12 @@ pytestmark = pytest.mark.django_db
 
 def make_translate_fields(field, value) -> Dict:
     return {to_translated_field(field, language_code=language[0]): value for language in settings.LANGUAGES}
+
+
+@pytest.fixture()
+def mocked_plugin_repo_accessor():
+    with mock.patch("paasng.bk_plugins.pluginscenter.utils.get_plugin_repo_accessor") as mocked:
+        yield mocked
 
 
 @pytest.mark.parametrize(
@@ -161,7 +169,7 @@ COMMON_DATA = {"source_version_name": "...", "source_version_type": "...", "comm
         ("0.1.2", {"semver_type": "patch", "version": "0.1.3.4", **COMMON_DATA}, False),
     ],
 )
-def test_validate_automatic_semver(plugin, previous_version, data, is_valid):
+def test_validate_automatic_semver(plugin, previous_version, data, is_valid, mocked_plugin_repo_accessor):
     plugin.pd.release_revision.versionNo = "automatic"
     slz = serializers.make_create_release_version_slz_class(plugin, "prod")(
         data=data, context={"previous_version": previous_version}
@@ -179,7 +187,7 @@ def test_validate_automatic_semver(plugin, previous_version, data, is_valid):
         ({"version": "1.0.0", **COMMON_DATA, "source_version_name": "2.0.0"}, False),
     ],
 )
-def test_validate_revision_eq_source_revision(plugin, data, is_valid):
+def test_validate_revision_eq_source_revision(plugin, data, is_valid, mocked_plugin_repo_accessor):
     plugin.pd.release_revision.versionNo = "revision"
     slz = serializers.make_create_release_version_slz_class(plugin, "prod")(data=data)
     if is_valid:
@@ -203,15 +211,36 @@ def test_validate_revision_eq_source_revision(plugin, data, is_valid):
         ),
     ],
 )
-def test_validate_revision_eq_commit_hash(plugin, source_hash, data, is_valid):
+def test_validate_revision_eq_commit_hash(plugin, source_hash, data, is_valid, mocked_plugin_repo_accessor):
     plugin.pd.release_revision.versionNo = "commit-hash"
-    slz = serializers.make_create_release_version_slz_class(plugin, "prod")(
-        data=data, context={"source_hash": source_hash}
-    )
+    mocked_plugin_repo_accessor().extract_smart_revision.return_value = source_hash
+    slz = serializers.make_create_release_version_slz_class(plugin, "prod")(data=data)
     if is_valid:
         slz.is_valid(raise_exception=True)
     else:
         assert not slz.is_valid()
+
+
+@pytest.mark.parametrize(
+    ("data", "is_valid"),
+    [
+        ({"release_id": "1", "version": "1.0.0", **COMMON_DATA, "source_version_name": "1.0.0"}, True),
+        ({"release_id": "", "version": "1.0.0", **COMMON_DATA, "source_version_name": "1.0.0"}, False),
+        ({"version": "1.0.0", **COMMON_DATA, "source_version_name": "2.0.0"}, False),
+    ],
+)
+def test_validate_tested_version(plugin, data, is_valid):
+    plugin.pd.release_revision.revisionType = PluginRevisionType.TESTED_VERSION
+    plugin.pd.release_revision.versionNo = "revision"
+
+    with mock.patch(
+        "paasng.bk_plugins.pluginscenter.serializers.get_source_hash_by_plugin_version", return_value="hash"
+    ):
+        slz = serializers.make_create_release_version_slz_class(plugin, "prod")(data=data)
+        if is_valid:
+            slz.is_valid(raise_exception=True)
+        else:
+            assert not slz.is_valid()
 
 
 @pytest.mark.parametrize(
@@ -230,7 +259,7 @@ def test_validate_revision_eq_commit_hash(plugin, source_hash, data, is_valid):
         ),
     ],
 )
-def test_validate_release_policy(plugin, release, data, revision_policy, is_valid):
+def test_validate_release_policy(plugin, release, data, revision_policy, is_valid, mocked_plugin_repo_accessor):
     plugin.pd.release_revision.versionNo = "self-fill"
     plugin.pd.release_revision.revisionPolicy = revision_policy
     slz = serializers.make_create_release_version_slz_class(plugin, "prod")(data=data)


### PR DESCRIPTION
1. 新建版本：在代码仓库分支、TAG 的基础上新增：测试通过的版本
2. 新建版本时，同时设置灰度范围，且审批通过后才能继续灰度或者全量
3. 版本新增
- 设为稳定版本
- 启用、禁用