### PR TITLE
fix: docker build fails because unexpected env var with empty value overrides the settings

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -69,19 +69,15 @@ ADD ./paasng .
 
 
 # Add extra files: static assets & I18N .mo translation file. 
-# the "BKKRILL_ENCRYPT_SECRET_KEY" settings is required for starting the project,
-# set it to a non-empty value to pass the check.
-ENV PAAS_BKKRILL_ENCRYPT_SECRET_KEY='none'
 
-# Some edition might need to add extra apps, do it by set the arg during the build process,
-# e.g. docker build . --build-arg EXTRA_INSTALLED_APPS="['foo']" ...
-ARG EXTRA_INSTALLED_APPS
-ENV PAAS_EXTRA_INSTALLED_APPS=${EXTRA_INSTALLED_APPS}
-
-RUN poetry run python manage.py collectstatic --noinput
 # "gettext" package is required for running "compilemessages"
 RUN apt-get install -y gettext
-RUN poetry run python manage.py compilemessages
+
+# the "BKKRILL_ENCRYPT_SECRET_KEY" settings is required for starting the project,
+# set it to a non-empty value to run the manage.py command.
+RUN export PAAS_BKKRILL_ENCRYPT_SECRET_KEY='none' && \
+    poetry run python manage.py collectstatic --noinput && \
+    poetry run python manage.py compilemessages
 
 
 COPY ./start.sh .

--- a/apiserver/dev_utils/unittest/Dockerfile.devops.unittest
+++ b/apiserver/dev_utils/unittest/Dockerfile.devops.unittest
@@ -66,19 +66,15 @@ COPY --from=Admin42 /build/paasng/public ./paasng/public
 WORKDIR /app/paasng
 
 # Add extra files: static assets & I18N .mo translation file. 
-# the "BKKRILL_ENCRYPT_SECRET_KEY" settings is required for starting the project,
-# set it to a non-empty value to pass the check.
-ENV PAAS_BKKRILL_ENCRYPT_SECRET_KEY='none'
 
-# Some edition might need to add extra apps, do it by set the arg during the build process,
-# e.g. docker build . --build-arg EXTRA_INSTALLED_APPS="['foo']" ...
-ARG EXTRA_INSTALLED_APPS
-ENV PAAS_EXTRA_INSTALLED_APPS=${EXTRA_INSTALLED_APPS}
-
-RUN poetry run python manage.py collectstatic --noinput
 # "gettext" package is required for running "compilemessages"
 RUN apt-get install -y gettext
-RUN poetry run python manage.py compilemessages
+
+# the "BKKRILL_ENCRYPT_SECRET_KEY" settings is required for starting the project,
+# set it to a non-empty value to run the manage.py command.
+RUN export PAAS_BKKRILL_ENCRYPT_SECRET_KEY='none' && \
+    poetry run python manage.py collectstatic --noinput && \
+    poetry run python manage.py compilemessages
 
 
 ADD ./start.sh .


### PR DESCRIPTION
fix: docker build fails because unexpected env var with empty value overrides the value in the settings file.