### PR TITLE
fix: delete PresetEnvVariable when not set

### DIFF
--- a/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/env_vars.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/env_vars.py
@@ -81,8 +81,12 @@ def sync_preset_env_vars(
     :param global_env_vars: The default variables
     :param overlay_env_vars: The environment-specified variables
     :return: sync result
-
     """
+    ret = CommonSyncResult()
+
+    if not global_env_vars and not overlay_env_vars:
+        ret.deleted_num, _ = PresetEnvVariable.objects.filter(module=module).delete()
+        return ret
 
     config_vars: Dict[str, Dict[str, PresetEnvVariable]] = defaultdict(dict)
     for var in global_env_vars:
@@ -101,7 +105,6 @@ def sync_preset_env_vars(
             value=overlay_var.value,
         )
 
-    ret = CommonSyncResult()
     for env_name, env_config_vars in config_vars.items():
         for var in env_config_vars.values():
             _, created = PresetEnvVariable.objects.update_or_create(

--- a/apiserver/paasng/paasng/platform/bkapp_model/serializers/serializers.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/serializers/serializers.py
@@ -62,6 +62,7 @@ class ProcessSpecEnvOverlaySLZ(serializers.Serializer):
 class ModuleProcessSpecMetadataSLZ(serializers.Serializer):
     """特性开关"""
 
+    # TODO allow_multiple_image has been deprecated, remove it in the future
     allow_multiple_image = serializers.BooleanField(default=False, help_text="是否允许使用多个不同镜像")
 
 

--- a/apiserver/paasng/paasng/platform/bkapp_model/views.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/views.py
@@ -145,7 +145,6 @@ class ModuleProcessSpecViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
                 "port": proc_spec.port,
                 "env_overlay": {
                     environment_name.value: {
-                        "environment_name": environment_name.value,
                         "plan_name": proc_spec.get_plan_name(environment_name),
                         "target_replicas": proc_spec.get_target_replicas(environment_name),
                         "autoscaling": bool(proc_spec.get_autoscaling(environment_name)),
@@ -177,7 +176,7 @@ class ModuleProcessSpecViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
                 name=proc_spec["name"],
                 command=proc_spec["command"],
                 args=proc_spec["args"],
-                port=proc_spec.get("port", None),
+                target_port=proc_spec.get("port", None),
                 probes=proc_spec.get("probes", None),
             )
             for proc_spec in proc_specs

--- a/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
@@ -192,11 +192,11 @@ class DeploymentDeclarativeController:
             for process_type, process in processes.items():
                 self.update_probes(process_type=process_type, probes=process.probes)
 
-            if desc.bk_monitor:
-                self.update_bkmonitor(desc.bk_monitor)
-
         # 导入预定义环境变量
         sync_preset_env_vars(module, *get_preset_env_vars(desc.spec))
+
+        if desc.bk_monitor:
+            self.update_bkmonitor(desc.bk_monitor)
 
         return result
 

--- a/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
@@ -184,19 +184,19 @@ class DeploymentDeclarativeController:
             if svc_disc := get_svc_discovery(spec=desc.spec):
                 sync_svc_discovery(module=module, svc_disc=svc_disc)
 
+            # 为了保证 probe 对象不遗留，对 probe 进行全量删除和全量更新
+            # 对该环境下的 probe 进行全量删除
+            self.delete_probes()
+
+            # 根据配置，对 probe 进行全量更新
+            for process_type, process in processes.items():
+                self.update_probes(process_type=process_type, probes=process.probes)
+
+            if desc.bk_monitor:
+                self.update_bkmonitor(desc.bk_monitor)
+
         # 导入预定义环境变量
         sync_preset_env_vars(module, *get_preset_env_vars(desc.spec))
-
-        if desc.bk_monitor:
-            self.update_bkmonitor(desc.bk_monitor)
-
-        # 为了保证 probe 对象不遗留，对 probe 进行全量删除和全量更新
-        # 对该环境下的 probe 进行全量删除
-        self.delete_probes()
-
-        # 根据配置，对 probe 进行全量更新
-        for process_type, process in processes.items():
-            self.update_probes(process_type=process_type, probes=process.probes)
 
         return result
 

--- a/apiserver/paasng/paasng/platform/modules/manager.py
+++ b/apiserver/paasng/paasng/platform/modules/manager.py
@@ -283,7 +283,7 @@ class ModuleInitializer:
                 name=proc_spec["name"],
                 command=proc_spec["command"],
                 args=proc_spec["args"],
-                port=proc_spec.get("port", None),
+                target_port=proc_spec.get("port", None),
                 probes=proc_spec.get("probes", None),
             )
             for proc_spec in bkapp_spec["processes"]

--- a/apiserver/paasng/tests/api/bkapp_model/test_bkapp_model.py
+++ b/apiserver/paasng/tests/api/bkapp_model/test_bkapp_model.py
@@ -135,7 +135,6 @@ class TestModuleProcessSpecViewSet:
                 "port": 5000,
                 "env_overlay": {
                     "stag": {
-                        "environment_name": "stag",
                         "plan_name": "default",
                         "target_replicas": 2,
                         "autoscaling": False,
@@ -149,12 +148,10 @@ class TestModuleProcessSpecViewSet:
                 "args": ["celery", "beat"],
                 "env_overlay": {
                     "stag": {
-                        "environment_name": "stag",
                         "plan_name": "default",
                         "target_replicas": 1,
                     },
                     "prod": {
-                        "environment_name": "prod",
                         "plan_name": "default",
                         "target_replicas": 1,
                         "autoscaling": True,
@@ -185,6 +182,7 @@ class TestModuleProcessSpecViewSet:
         assert proc_specs[0]["image"] == "example.com/foo"
         assert proc_specs[0]["command"] == ["python", "-m"]
         assert proc_specs[0]["args"] == ["http.server"]
+        assert proc_specs[0]["port"] == 5000
         assert proc_specs[0]["env_overlay"]["stag"]["target_replicas"] == 2
         assert not proc_specs[0]["env_overlay"]["stag"]["autoscaling"]
         assert proc_specs[0]["probes"] == probes_cfg

--- a/apiserver/paasng/tests/api/test_modules.py
+++ b/apiserver/paasng/tests/api/test_modules.py
@@ -128,6 +128,7 @@ class TestCreateCloudNativeModule:
                                 "stag": {"environment_name": "stag", "target_replicas": 1, "plan_name": "2C1G"},
                                 "prod": {"environment_name": "prod", "target_replicas": 2, "plan_name": "2C1G"},
                             },
+                            "port": 30000,
                         }
                     ],
                     "hook": {
@@ -150,6 +151,7 @@ class TestCreateCloudNativeModule:
 
         process_spec = ModuleProcessSpec.objects.get(module=module, name="web")
         assert process_spec.command == ["bash", "/app/start_web.sh"]
+        assert process_spec.port == 30000
         assert process_spec.get_target_replicas("stag") == 1
         assert process_spec.get_target_replicas("prod") == 2
 

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/entities_syncer/test_env_vars.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/entities_syncer/test_env_vars.py
@@ -42,12 +42,7 @@ class Test__sync_env_vars:
 
 class Test__sync_preset_env_vars:
     def test_integrated(self, bk_module):
-        G(
-            PresetEnvVariable,
-            module=bk_module,
-            environment_name=ConfigVarEnvName.GLOBAL,
-            key="KEY_EXISTING",
-        )
+        G(PresetEnvVariable, module=bk_module, environment_name=ConfigVarEnvName.GLOBAL, key="KEY_EXISTING")
         global_env_vars = [EnvVar(name="KEY1", value="foo"), EnvVar(name="KEY2", value="foo")]
         overlay_env_vars = [EnvVarOverlay(env_name="stag", name="KEY3", value="foo")]
         ret = sync_preset_env_vars(bk_module, global_env_vars, overlay_env_vars)
@@ -57,3 +52,9 @@ class Test__sync_preset_env_vars:
         assert ret.updated_num == 0
         assert ret.created_num == 3
         assert ret.deleted_num == 1
+
+    def test_delete(self, bk_module):
+        G(PresetEnvVariable, module=bk_module, environment_name=ConfigVarEnvName.GLOBAL, key="FOO", value="foo")
+        G(PresetEnvVariable, module=bk_module, environment_name=ConfigVarEnvName.PROD, key="BAR", value="bar")
+        ret = sync_preset_env_vars(bk_module, [], [])
+        assert ret.deleted_num == 2

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/entities_syncer/test_processes.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/entities_syncer/test_processes.py
@@ -43,6 +43,7 @@ class Test__sync_processes:
                     replicas=1,
                     command=["./start.sh"],
                     res_quota_plan="4C1G",
+                    target_port=30000,
                     probes=ProbeSet(
                         liveness=Probe(
                             http_get=HTTPGetAction(port="${PORT}", path="/healthz"),
@@ -52,7 +53,7 @@ class Test__sync_processes:
                             success_threshold=1,
                             failure_threshold=3,
                         ),
-                        readiness=Probe(tcp_socket=TCPSocketAction(port=5000)),
+                        readiness=Probe(tcp_socket=TCPSocketAction(port=30000)),
                     ),
                 ),
                 Process(
@@ -76,10 +77,11 @@ class Test__sync_processes:
         assert specs.count() == 1
 
         spec = specs.first()
+        assert spec.port == 30000
         assert spec.probes.liveness.http_get.port == "${PORT}"
         assert spec.probes.liveness.initial_delay_seconds == 30
         assert spec.probes.liveness.period_seconds == 5
-        assert spec.probes.readiness.tcp_socket.port == 5000
+        assert spec.probes.readiness.tcp_socket.port == 30000
         assert spec.plan_name == "4C1G"
 
         spec = ModuleProcessSpec.objects.get(module=bk_module, name="sleep")

--- a/apiserver/paasng/tests/paasng/platform/declarative/handlers/v3/test_probes.py
+++ b/apiserver/paasng/tests/paasng/platform/declarative/handlers/v3/test_probes.py
@@ -20,11 +20,10 @@ from textwrap import dedent
 import pytest
 import yaml
 
-from paas_wl.bk_app.applications.models import WlApp
-from paas_wl.bk_app.processes.constants import ProbeType
-from paas_wl.bk_app.processes.models import ProcessProbe
+from paasng.platform.bkapp_model.models import ModuleProcessSpec
 from paasng.platform.declarative.handlers import CNativeAppDescriptionHandler, DescriptionHandler
 from paasng.platform.declarative.handlers import get_desc_handler as _get_desc_handler
+from tests.paasng.platform.engine.setup_utils import create_fake_deployment
 
 pytestmark = pytest.mark.django_db(databases=["default", "workloads"])
 
@@ -104,60 +103,33 @@ def get_desc_handler(yaml_content: str) -> DescriptionHandler:
 
 
 class TestSaasProbes:
-    def test_saas_probes(self, bk_deployment, yaml_content):
+    def test_saas_probes(self, bk_module, bk_deployment, yaml_content):
         """验证 saas 应用探针对象 ProcessProbe 成功创建"""
-        # bk_deployment.app_environment  外键未实例化，补全
-        name = bk_deployment.app_environment.engine_app.name
-        region = bk_deployment.app_environment.engine_app.region
-        wlapp = WlApp.objects.create(name=name, region=region)
-
         get_desc_handler(yaml_content).handle_deployment(bk_deployment)
-        liveness_probe: ProcessProbe = ProcessProbe.objects.get(
-            app=wlapp, process_type="web", probe_type=ProbeType.LIVENESS
-        )
-        readiness_probe: ProcessProbe = ProcessProbe.objects.get(
-            app=wlapp, process_type="web", probe_type=ProbeType.READINESS
-        )
 
-        assert liveness_probe.probe_handler
-        assert liveness_probe.probe_handler.exec.command == ["cat", "/tmp/healthy"]
+        spec = ModuleProcessSpec.objects.get(module=bk_module, name="web")
 
-        assert readiness_probe.probe_handler
-        assert readiness_probe.probe_handler.tcp_socket.port == "${PORT}"
+        assert spec.probes.liveness.exec.command == ["cat", "/tmp/healthy"]
+        assert spec.probes.readiness.tcp_socket.port == "${PORT}"
 
     @pytest.mark.parametrize("_mock_delete_process_probe", [True], indirect=True)
-    def test_saas_probes_changes(self, bk_deployment, bk_deployment_full, yaml_content, yaml_content_after_change):
+    def test_saas_probes_changes(self, bk_module, bk_deployment, yaml_content, yaml_content_after_change):
         """验证 saas 应用探针对象 ProcessProbe 成功修改"""
         # bk_deployment.app_environment  外键未实例化，补全
         name = bk_deployment.app_environment.engine_app.name
         region = bk_deployment.app_environment.engine_app.region
-        wlapp = WlApp.objects.create(name=name, region=region)
 
-        # bk_deployment_full.app_environment  外键未实例化，补全
-        bk_deployment_full.app_environment.engine_app.name = name
-        bk_deployment_full.app_environment.engine_app.region = region
+        # new_deployment.app_environment  外键未实例化，补全
+        new_deployment = create_fake_deployment(bk_module)
+        new_deployment.app_environment.engine_app.name = name
+        new_deployment.app_environment.engine_app.region = region
 
-        get_desc_handler(yaml_content).handle_deployment(bk_deployment_full)
+        get_desc_handler(yaml_content).handle_deployment(bk_deployment)
         # 模拟重新部署过程
-        get_desc_handler(yaml_content_after_change).handle_deployment(bk_deployment_full)
+        get_desc_handler(yaml_content_after_change).handle_deployment(new_deployment)
 
-        # liveness_probe 无变化
-        liveness_probe: ProcessProbe = ProcessProbe.objects.get(
-            app=wlapp, process_type="web", probe_type=ProbeType.LIVENESS
-        )
-        # readiness_probe 被删除
-        readiness_probe_exists: ProcessProbe = ProcessProbe.objects.filter(
-            app=wlapp, process_type="web", probe_type=ProbeType.READINESS
-        ).exists()
-        # start_probe 新增
-        start_probe: ProcessProbe = ProcessProbe.objects.get(
-            app=wlapp, process_type="web", probe_type=ProbeType.STARTUP
-        )
+        spec = ModuleProcessSpec.objects.get(module=bk_module, name="web")
 
-        assert liveness_probe.probe_handler
-        assert liveness_probe.probe_handler.exec.command == ["cat", "/tmp/healthy"]
-
-        assert not readiness_probe_exists
-
-        assert start_probe.probe_handler
-        assert start_probe.probe_handler.tcp_socket.port == "${PORT}"
+        assert spec.probes.liveness.exec.command == ["cat", "/tmp/healthy"]
+        assert not spec.probes.readiness
+        assert spec.probes.startup.tcp_socket.port == "${PORT}"


### PR DESCRIPTION
-  app_desc.yaml 未设置环境变量时，清空对应模块的 PresetEnvVariable
-  单独维护的 probes 只有普通应用解析时适用，云原生应用使用 ModuleProcessSpec 中的 probes
-  port 没有正确赋值给 target_port. 修复对应的单元测试