### PR TITLE
refactor: move some functions out of sync_entities and add docs

### DIFF
--- a/apiserver/paasng/paasng/misc/audit/service.py
+++ b/apiserver/paasng/paasng/misc/audit/service.py
@@ -64,7 +64,7 @@ def report_event_to_bk_audit(record: AppOperationRecord):
     """将操作记录中的数据上报到审计中心"""
     # 未设置审计中心相关配置则不上报
     if not settings.ENABLE_BK_AUDIT or not record.need_to_report_bk_audit:
-        logger.info(f"skip report to bk_audit, record:{record.uuid}")
+        logger.debug(f"skip report to bk_audit, record:{record.uuid}")
         return
     try:
         audit_context = AuditContext(

--- a/apiserver/paasng/paasng/platform/bkapp_model/entities/__init__.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities/__init__.py
@@ -14,6 +14,18 @@
 #
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
+"""entities 中存放着与应用模型相关的实体数据类，比如：进程、探针配置和环境变量等。大部分实体类
+的字段结构与 BkApp 应用模型定义中的对应类型对应（只是命名规则驼峰变为蛇形）。不过，请不要将它们
+简单和“应用模型规范”中的内容划等号，因为它们原则上和模型规范的“版本”（v1alpha1/v1beta1/...）无关。
+
+当前主要在“导入BkApp 资源 YAML”时，作为中转数据类使用。
+
+这些实体数据类的特点：
+
+- 使用蛇形命名法（foo_var），和项目其他内部数据类保持一致
+- 结构扁平，仅包含纯粹数据字段，比如环境变量仅有 name 和 value，没有“所属应用”信息
+- 不包含数据定义之外的复杂逻辑，仅承担数据类的简单职责
+"""
 
 from .addons import Addon, AddonSpec
 from .build import AppBuildConfig
@@ -22,7 +34,7 @@ from .env_vars import EnvVar, EnvVarOverlay
 from .hooks import HookCmd, Hooks
 from .mounts import ConfigMapSource, Mount, MountOverlay, PersistentStorage, VolumeSource
 from .probes import ExecAction, HTTPGetAction, HTTPHeader, Probe, ProbeHandler, ProbeSet, TCPSocketAction
-from .proc_env_overlays import AutoscalingOverlay, ProcEnvOverlay, ReplicasOverlay, ResQuotaOverlay
+from .proc_env_overlays import AutoscalingOverlay, ReplicasOverlay, ResQuotaOverlay
 from .processes import Process
 from .scaling_config import AutoscalingConfig
 from .svc_discovery import SvcDiscConfig, SvcDiscEntryBkSaaS
@@ -51,10 +63,10 @@ __all__ = [
     "VolumeSource",
     "Mount",
     "EnvVar",
+    # env-overlay types
     "EnvVarOverlay",
     "AutoscalingOverlay",
     "ReplicasOverlay",
     "ResQuotaOverlay",
-    "ProcEnvOverlay",
     "MountOverlay",
 ]

--- a/apiserver/paasng/paasng/platform/bkapp_model/entities/proc_env_overlays.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities/proc_env_overlays.py
@@ -16,7 +16,6 @@
 # to the current version of the project delivered to anyone in the future.
 
 import logging
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -63,21 +62,3 @@ class AutoscalingOverlay(AutoscalingConfig):
 
     env_name: str
     process: str
-
-
-class ProcEnvOverlay(BaseModel):
-    """
-    单个进程的 env overlay
-
-    :param env_name: 生效环境名
-    :param plan_name: 资源配额套餐名称
-    :param target_replicas: 副本数
-    :param autoscaling: 是否开启自动扩缩容
-    :param scaling_config: 自动扩缩容配置
-    """
-
-    env_name: str
-    plan_name: Optional[str] = None
-    target_replicas: Optional[int] = None
-    autoscaling: bool = False
-    scaling_config: Optional[AutoscalingConfig] = None

--- a/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/__init__.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/__init__.py
@@ -15,15 +15,23 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
-"""将各类资源 entities 同步到数据库 model 中"""
+"""entities_syncer 负责将 entities 中的各种数据类同步到平台的持久化存储中。目前主要在
+导入 BkApp 资源 YAML 的过程中被使用。模块内存在大量以 `sync_` 开头的同步函数。与这些函数
+相关的注意事项：
+
+- 必须返回 CommonSyncResult 结果类，方便导入成功后展示细节
+- 除模块和数据类外，不接受其他额外参数，数据的删留逻辑以“导入 BkApp”为准
+
+同步函数如不满足以上需求，建议放在其他模块中。
+"""
 
 from .addons import sync_addons
 from .build import sync_build
 from .domain_resolution import sync_domain_resolution
-from .env_vars import sync_env_vars, sync_preset_env_vars
+from .env_vars import sync_env_vars
 from .hooks import sync_hooks
 from .mounts import sync_mounts
-from .proc_env_overlays import sync_env_overlay_by_proc, sync_proc_env_overlays
+from .proc_env_overlays import sync_proc_env_overlays
 from .processes import sync_processes
 from .svc_discovery import sync_svc_discovery
 
@@ -33,8 +41,6 @@ __all__ = [
     "sync_domain_resolution",
     "sync_proc_env_overlays",
     "sync_env_vars",
-    "sync_preset_env_vars",
-    "sync_env_overlay_by_proc",
     "sync_hooks",
     "sync_mounts",
     "sync_processes",

--- a/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/domain_resolution.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/domain_resolution.py
@@ -38,6 +38,7 @@ def sync_domain_resolution(module: Module, domain_res: DomainResolution) -> Comm
 
     try:
         domain_config = DomainResolutionDB.objects.get(application=module.application)
+        # INFO/FIXME: 此处取并集，会导致条目数在修改并重复同步后，总是增多，不会减少？
         nameservers = list(set(domain_config.nameservers) | set(domain_res.nameservers))
         host_aliases = list(set(domain_config.host_aliases) | set(domain_res.host_aliases))
     except DomainResolutionDB.DoesNotExist:

--- a/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/env_vars.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/env_vars.py
@@ -15,14 +15,11 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
-from collections import defaultdict
-from typing import Dict, List
+from typing import List
 
 from paasng.platform.bkapp_model.entities import EnvVar, EnvVarOverlay
-from paasng.platform.engine.constants import ConfigVarEnvName
 from paasng.platform.engine.models.config_var import ENVIRONMENT_ID_FOR_GLOBAL, ConfigVar
 from paasng.platform.engine.models.managers import ConfigVarManager
-from paasng.platform.engine.models.preset_envvars import PresetEnvVariable
 from paasng.platform.modules.models import Module
 
 from .result import CommonSyncResult
@@ -68,58 +65,3 @@ def sync_env_vars(module: Module, env_vars: List[EnvVar], overlay_env_vars: List
     keys = [var.key for var in config_vars]
     deleted_num = var_mgr.remove_bulk(module, exclude_keys=keys)
     return CommonSyncResult(created_num=ret.create_num, updated_num=ret.overwrited_num, deleted_num=deleted_num)
-
-
-def sync_preset_env_vars(
-    module: Module, global_env_vars: List[EnvVar], overlay_env_vars: List[EnvVarOverlay]
-) -> CommonSyncResult:
-    """Sync environment variables from app_desc.yaml to PresetEnvVariable(db model), existing data that is not in the
-    input list may be removed. PresetEnvVariable 只被用来存放那些经由应用描述文件（`app_desc.yaml`）定义的变量，开发者无法通过
-    环境变量 web 页面管理它们
-
-    :param module: app module
-    :param global_env_vars: The default variables
-    :param overlay_env_vars: The environment-specified variables
-    :return: sync result
-    """
-    ret = CommonSyncResult()
-
-    if not global_env_vars and not overlay_env_vars:
-        ret.deleted_num, _ = PresetEnvVariable.objects.filter(module=module).delete()
-        return ret
-
-    config_vars: Dict[str, Dict[str, PresetEnvVariable]] = defaultdict(dict)
-    for var in global_env_vars:
-        config_vars[ConfigVarEnvName.GLOBAL][var.name] = PresetEnvVariable(
-            module=module,
-            environment_name=ConfigVarEnvName.GLOBAL,
-            key=var.name,
-            value=var.value,
-        )
-
-    for overlay_var in overlay_env_vars:
-        config_vars[ConfigVarEnvName(overlay_var.env_name)][overlay_var.name] = PresetEnvVariable(
-            module=module,
-            environment_name=ConfigVarEnvName(overlay_var.env_name),
-            key=overlay_var.name,
-            value=overlay_var.value,
-        )
-
-    for env_name, env_config_vars in config_vars.items():
-        for var in env_config_vars.values():
-            _, created = PresetEnvVariable.objects.update_or_create(
-                module=var.module,
-                environment_name=var.environment_name,
-                key=var.key,
-                defaults={
-                    "value": var.value,
-                },
-            )
-            ret.incr_by_created_flag(created)
-        deleted_num, _ = (
-            PresetEnvVariable.objects.filter(module=module, environment_name=env_name)
-            .exclude(key__in=env_config_vars.keys())
-            .delete()
-        )
-        ret.deleted_num += deleted_num
-    return ret

--- a/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/proc_env_overlays.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/proc_env_overlays.py
@@ -18,7 +18,7 @@
 import logging
 from typing import Any, Callable, Dict, List, Type, cast
 
-from paasng.platform.bkapp_model.entities import AutoscalingOverlay, ProcEnvOverlay, ReplicasOverlay, ResQuotaOverlay
+from paasng.platform.bkapp_model.entities import AutoscalingOverlay, ReplicasOverlay, ResQuotaOverlay
 from paasng.platform.bkapp_model.models import ModuleProcessSpec, ProcessSpecEnvOverlay
 from paasng.platform.modules.models import Module
 
@@ -111,33 +111,4 @@ def sync_proc_env_overlays(
 
     # Remove existing data that is not touched.
     ret.deleted_num, _ = ProcessSpecEnvOverlay.objects.filter(id__in=existing_index.values()).delete()
-    return ret
-
-
-def sync_env_overlay_by_proc(module, proc_name: str, proc_env_overlay: ProcEnvOverlay) -> CommonSyncResult:
-    """Sync proc_env_overlay to ProcessSpecEnvOverlay(db model) by one process. It will update or create
-    ProcessSpecEnvOverlay by one process, not delete.
-
-    :param module: module
-    :param proc_name: process name to set env_overlay
-    :param proc_env_overlay: proc env_overlay data
-    :return: sync result
-    """
-
-    ret = CommonSyncResult()
-
-    proc_spec = ModuleProcessSpec.objects.get(module=module, name=proc_name)
-
-    _, created = ProcessSpecEnvOverlay.objects.update_or_create(
-        proc_spec=proc_spec,
-        environment_name=proc_env_overlay.env_name,
-        defaults={
-            "target_replicas": proc_env_overlay.target_replicas,
-            "plan_name": proc_env_overlay.plan_name,
-            "autoscaling": proc_env_overlay.autoscaling,
-            "scaling_config": proc_env_overlay.scaling_config.dict() if proc_env_overlay.scaling_config else None,
-        },
-    )
-    ret.incr_by_created_flag(created)
-
     return ret

--- a/apiserver/paasng/paasng/platform/bkapp_model/views.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/views.py
@@ -34,11 +34,16 @@ from paasng.accessories.servicehub.manager import mixed_service_mgr
 from paasng.infras.accounts.permissions.application import application_perm_class
 from paasng.infras.iam.permissions.resources.application import AppAction
 from paasng.platform.applications.mixins import ApplicationCodeInPathMixin
-from paasng.platform.bkapp_model.entities import ProcEnvOverlay, Process
-from paasng.platform.bkapp_model.entities_syncer import sync_env_overlay_by_proc, sync_processes
+from paasng.platform.bkapp_model.entities import Process
+from paasng.platform.bkapp_model.entities_syncer import sync_processes
 from paasng.platform.bkapp_model.importer import import_manifest
 from paasng.platform.bkapp_model.manifest import get_manifest
-from paasng.platform.bkapp_model.models import DomainResolution, ModuleProcessSpec, SvcDiscConfig
+from paasng.platform.bkapp_model.models import (
+    DomainResolution,
+    ModuleProcessSpec,
+    ProcessSpecEnvOverlay,
+    SvcDiscConfig,
+)
 from paasng.platform.bkapp_model.serializers import (
     BkAppModelSLZ,
     DomainResolutionSLZ,
@@ -187,8 +192,8 @@ class ModuleProcessSpecViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
         for proc_spec in proc_specs:
             if env_overlay := proc_spec.get("env_overlay"):
                 for env_name, proc_env_overlay in env_overlay.items():
-                    sync_env_overlay_by_proc(
-                        module, proc_spec["name"], ProcEnvOverlay(**{"env_name": env_name, **proc_env_overlay})
+                    ProcessSpecEnvOverlay.objects.save_by_module(
+                        module, proc_spec["name"], env_name, **proc_env_overlay
                     )
 
         return self.retrieve(request, code, module_name)

--- a/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
@@ -26,13 +26,14 @@ from paas_wl.bk_app.monitoring.app_monitor.shim import upsert_app_monitor
 from paas_wl.bk_app.processes.constants import ProbeType
 from paasng.platform.applications.constants import ApplicationType
 from paasng.platform.bkapp_model.entities import EnvVar, EnvVarOverlay, ProbeSet, Process, SvcDiscConfig, v1alpha2
-from paasng.platform.bkapp_model.entities_syncer import sync_preset_env_vars, sync_svc_discovery
+from paasng.platform.bkapp_model.entities_syncer import sync_svc_discovery
 from paasng.platform.bkapp_model.importer import import_bkapp_spec_entity
 from paasng.platform.bkapp_model.manager import ModuleProcessSpecManager, sync_hooks
 from paasng.platform.declarative.constants import AppSpecVersion
 from paasng.platform.declarative.deployment.process_probe import delete_process_probes, upsert_process_probe
 from paasng.platform.declarative.deployment.resources import BluekingMonitor, DeploymentDesc
 from paasng.platform.declarative.models import DeploymentDescription
+from paasng.platform.engine.configurations import preset_envvars
 from paasng.platform.engine.models.deployment import Deployment, ProcessTmpl
 
 logger = logging.getLogger(__name__)
@@ -192,8 +193,7 @@ class DeploymentDeclarativeController:
             for process_type, process in processes.items():
                 self.update_probes(process_type=process_type, probes=process.probes)
 
-        # 导入预定义环境变量
-        sync_preset_env_vars(module, *get_preset_env_vars(desc.spec))
+        preset_envvars.batch_save(module, *get_preset_env_vars(desc.spec))
 
         if desc.bk_monitor:
             self.update_bkmonitor(desc.bk_monitor)

--- a/apiserver/paasng/paasng/platform/engine/configurations/preset_envvars.py
+++ b/apiserver/paasng/paasng/platform/engine/configurations/preset_envvars.py
@@ -1,0 +1,56 @@
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+
+"""Utilities of PresetEnvVariable model, such as batch sync, etc."""
+
+from typing import Dict, List, Tuple
+
+from paasng.platform.bkapp_model.entities import EnvVar, EnvVarOverlay
+from paasng.platform.engine.constants import ConfigVarEnvName
+from paasng.platform.engine.models.preset_envvars import PresetEnvVariable
+from paasng.platform.modules.models import Module
+
+
+def batch_save(module: Module, env_vars: List[EnvVar], overlay_env_vars: List[EnvVarOverlay]):
+    """Save environment variable lists to `PresetEnvVariable` model. The function do a
+    fully sync so existing data that is not in the input list will be removed.
+
+    :param module: app module
+    :param env_vars: The default variables
+    :param overlay_env_vars: The environment-specified variables
+    """
+    # Build the index of existing data first to remove data later.
+    # Data structure: {(env_name, key): pk}
+    existing_index: Dict[Tuple[str, str], int] = {}
+    for var_obj in PresetEnvVariable.objects.filter(module=module):
+        existing_index[(var_obj.environment_name, var_obj.key)] = var_obj.pk
+
+    # Upsert the input data
+    for var in env_vars:
+        env_name = ConfigVarEnvName.GLOBAL
+        PresetEnvVariable.objects.update_or_create(
+            module=module, environment_name=env_name.value, key=var.name, defaults={"value": var.value}
+        )
+        existing_index.pop((env_name.value, var.name), None)
+    for overlay_var in overlay_env_vars:
+        env_name = ConfigVarEnvName(overlay_var.env_name)
+        PresetEnvVariable.objects.update_or_create(
+            module=module, environment_name=env_name.value, key=overlay_var.name, defaults={"value": overlay_var.value}
+        )
+        existing_index.pop((env_name.value, overlay_var.name), None)
+
+    # Remove existing data that is not touched.
+    PresetEnvVariable.objects.filter(module=module, id__in=existing_index.values()).delete()

--- a/apiserver/paasng/paasng/utils/structure.py
+++ b/apiserver/paasng/paasng/utils/structure.py
@@ -35,5 +35,6 @@ def register(pydantic_model: Optional[Type[BaseModel]] = None, *, by_alias: bool
     return register_core
 
 
-# paasng.utils.models.make_json_field 需要 pydantic_model 注册到 cattr
+# 使用 paasng.utils.models.make_json_field 创建的 JSON 模型字段，如果用的是 pydantic 的模型，
+# 需要将该模型通过装饰器注册，以便 cattr 模块能正常处理其序列化和反序列化。
 prepare_json_field = register

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/entities_syncer/test_env_vars.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/entities_syncer/test_env_vars.py
@@ -18,10 +18,8 @@ import pytest
 from django_dynamic_fixture import G
 
 from paasng.platform.bkapp_model.entities import EnvVar, EnvVarOverlay
-from paasng.platform.bkapp_model.entities_syncer import sync_env_vars, sync_preset_env_vars
-from paasng.platform.engine.constants import ConfigVarEnvName
+from paasng.platform.bkapp_model.entities_syncer import sync_env_vars
 from paasng.platform.engine.models.config_var import ConfigVar
-from paasng.platform.engine.models.preset_envvars import PresetEnvVariable
 
 pytestmark = pytest.mark.django_db
 
@@ -38,23 +36,3 @@ class Test__sync_env_vars:
         assert ret.updated_num == 0
         assert ret.created_num == 3
         assert ret.deleted_num == 1
-
-
-class Test__sync_preset_env_vars:
-    def test_integrated(self, bk_module):
-        G(PresetEnvVariable, module=bk_module, environment_name=ConfigVarEnvName.GLOBAL, key="KEY_EXISTING")
-        global_env_vars = [EnvVar(name="KEY1", value="foo"), EnvVar(name="KEY2", value="foo")]
-        overlay_env_vars = [EnvVarOverlay(env_name="stag", name="KEY3", value="foo")]
-        ret = sync_preset_env_vars(bk_module, global_env_vars, overlay_env_vars)
-
-        assert PresetEnvVariable.objects.count() == 3
-        assert PresetEnvVariable.objects.filter(environment_name=ConfigVarEnvName.GLOBAL).count() == 2
-        assert ret.updated_num == 0
-        assert ret.created_num == 3
-        assert ret.deleted_num == 1
-
-    def test_delete(self, bk_module):
-        G(PresetEnvVariable, module=bk_module, environment_name=ConfigVarEnvName.GLOBAL, key="FOO", value="foo")
-        G(PresetEnvVariable, module=bk_module, environment_name=ConfigVarEnvName.PROD, key="BAR", value="bar")
-        ret = sync_preset_env_vars(bk_module, [], [])
-        assert ret.deleted_num == 2

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/test_models.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/test_models.py
@@ -1,0 +1,67 @@
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+
+import pytest
+from django_dynamic_fixture import G
+
+from paasng.platform.bkapp_model.constants import ResQuotaPlan
+from paasng.platform.bkapp_model.models import ModuleProcessSpec, ProcessSpecEnvOverlay
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def proc_web(bk_module) -> ModuleProcessSpec:
+    return G(ModuleProcessSpec, module=bk_module, name="web", command=["python"], args=["-m", "http.server"])
+
+
+class TestProcessSpecEnvOverlayManager:
+    def test_create(self, bk_module, proc_web):
+        ProcessSpecEnvOverlay.objects.save_by_module(
+            bk_module,
+            proc_web.name,
+            "prod",
+            target_replicas=2,
+            autoscaling=True,
+            scaling_config={"min_replicas": 1, "max_replicas": 10, "policy": "default"},
+        )
+
+        spec_overlay = ProcessSpecEnvOverlay.objects.get(proc_spec=proc_web, environment_name="prod")
+        assert spec_overlay.target_replicas == 2
+        assert spec_overlay.autoscaling is True
+        assert spec_overlay.scaling_config.max_replicas == 10
+
+    def test_update(self, bk_module, proc_web):
+        ProcessSpecEnvOverlay.objects.create(
+            proc_spec=proc_web,
+            environment_name="stag",
+            target_replicas=2,
+            plan_name=ResQuotaPlan.P_DEFAULT,
+            autoscaling=True,
+            scaling_config={"min_replicas": 1, "max_replicas": 1, "policy": "default"},
+        )
+
+        ProcessSpecEnvOverlay.objects.save_by_module(
+            bk_module,
+            proc_web.name,
+            "stag",
+            target_replicas=2,
+            autoscaling=False,
+        )
+
+        spec_overlay = ProcessSpecEnvOverlay.objects.get(proc_spec=proc_web, environment_name="stag")
+        assert spec_overlay.autoscaling is False
+        assert spec_overlay.scaling_config is None

--- a/apiserver/paasng/tests/paasng/platform/engine/configurations/test_preset_envvars.py
+++ b/apiserver/paasng/tests/paasng/platform/engine/configurations/test_preset_envvars.py
@@ -1,0 +1,61 @@
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+from typing import Dict
+
+import pytest
+from django_dynamic_fixture import G
+
+from paasng.platform.bkapp_model.entities import EnvVar, EnvVarOverlay
+from paasng.platform.engine.configurations import preset_envvars
+from paasng.platform.engine.constants import ConfigVarEnvName
+from paasng.platform.engine.models.preset_envvars import PresetEnvVariable
+
+pytestmark = pytest.mark.django_db
+
+
+class Test__batch_save:
+    def test_integrated(self, bk_module):
+        G(PresetEnvVariable, module=bk_module, environment_name=ConfigVarEnvName.GLOBAL, key="KEY_LEGACY")
+        preset_envvars.batch_save(
+            bk_module,
+            env_vars=[EnvVar(name="KEY1", value="val1"), EnvVar(name="KEY2", value="val2")],
+            overlay_env_vars=[EnvVarOverlay(env_name="stag", name="KEY3", value="val3")],
+        )
+
+        assert self.to_dict(PresetEnvVariable.objects.filter(module=bk_module)) == {
+            (ConfigVarEnvName.GLOBAL, "KEY1"): "val1",
+            (ConfigVarEnvName.GLOBAL, "KEY2"): "val2",
+            (ConfigVarEnvName.STAG, "KEY3"): "val3",
+        }, "The legacy global key should be removed."
+
+        # Save again, this time only provide an item of prod environment
+        preset_envvars.batch_save(
+            bk_module,
+            env_vars=[],
+            overlay_env_vars=[EnvVarOverlay(env_name="prod", name="KEY4", value="val4")],
+        )
+        assert self.to_dict(PresetEnvVariable.objects.filter(module=bk_module)) == {
+            (ConfigVarEnvName.PROD, "KEY4"): "val4",
+        }, "All existent keys should be removed."
+
+        # Save with empty input should remove all data
+        preset_envvars.batch_save(bk_module, [], [])
+        assert not PresetEnvVariable.objects.filter(module=bk_module).exists()
+
+    @staticmethod
+    def to_dict(qs) -> Dict:
+        """Turn PresetEnvVariable queryset to dict for easy comparison."""
+        return {(ConfigVarEnvName(var.environment_name), var.key): var.value for var in qs}


### PR DESCRIPTION
- refactor: move functions out of sync_entities and add docs
- fix: sync_preset_env_vars won't remove existent data when only some env is given