### PR TITLE
refactor: improve the process data sync logic & the declarative module

### DIFF
--- a/apiserver/paasng/paasng/platform/bkapp_model/entities/processes.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities/processes.py
@@ -36,7 +36,7 @@ class Process(BaseModel):
     :param command: 进程启动命令
     :param args: 进程启动参数
     :param proc_command: 单行脚本命令, 与 command/args 二选一, 优先于 command/args, 用于设置 Procfile 文件中进程 command
-    :param services: 暴露进程网路服务的 service 列表
+    :param services: 暴露进程网络服务的 service 列表
     :param target_port: 监听端口
     :param replicas: 进程副本数. `None` value means the replicas is not specified.
     :param res_quota_plan: 资源配额套餐名

--- a/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 class DeploymentDeclarativeController:
     """A controller which process deployment description, it was triggered by a
-    new deployment action. The controller handel a given description which was parsed
+    new deployment action. The controller handle a given description which was parsed
     from the source file and do following things:
 
     - Get and save the processes data

--- a/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/controller.py
@@ -88,35 +88,36 @@ class DeploymentDeclarativeController:
         self.deployment.update_fields(processes=desc.get_proc_tmpls())
 
     def _handle_desc_cnative_style(self, desc: DeploymentDesc, desc_obj: DeploymentDescription):
-        # == 云原生应用 或者 使用了 version 3 版本的应用描述文件
-        #
-        # TODO: 优化 import 方式, 例如直接接受 desc.spec
-        # Warning: app_desc 中声明的 hooks 会覆盖产品上已填写的 hooks
-        # ---
-        #
-        # NOTE: 对于云原生应用， import_bkapp_spec_entity() 的默认行为是将 spec 中的数据导入
-        # 到平台中，所有数据以它为准，是类似 PUT 请求的全量更新行为。然后这会导致一个问题：
-        #
-        # - 用户只在描述文件中定义了进程，未通过 envOverlay 定义区分环境的 replicas 数据
-        # - 用户通过产品页面，对进程进行了扩缩容，数据记录在 ProcessSpecEnvOverlay 中（体现为
-        #   模型中的 envOverlay）
-        # - 用户重新部署，import_bkapp_spec_entity() 将描述文件中的数据导入，其判断没有 envOverlay
-        #   数据，已有的 ProcessSpecEnvOverlay 数据被删除，用户设置的副本数丢失
-        #
-        # 为了解决这个问题，我们在 import_bkapp_spec_entity() 中增加了 reset_overlays_when_absent 参数，
-        # 比在这里调用时，将其设置为 False，避免已有的 envOverlay 数据被删除。
-        #
-        # 然而，这也算不上是万全之策。因为用户仍然可能会在描述文件中定义 envOverlay 数据，
-        # 或删除已有的 envOverlay 数据，这些操作仍然可能会导致预期之外的后果。更彻底的解决
-        # 方法，可能包括以下方面：
-        #
-        # - 在 ProcessSpecEnvOverlay 等数据模型中增加字段（或增加新模型），以区分由
-        #   用户手动设置的数据和由描述文件导入的数据，并依据一定优先级来处理
-        # - 模仿和参考 kubectl apply 的行为，开发新方法 apply_manifest()，对于通过
-        #   由配置文件定义的内容（比如 ProcessSpecEnvOverlay），打上特定的 manage-by
-        #   标签，这样，当配置文件中没有定义时，仅在旧数据原本是由配置文件定义时才删除，
-        #   否则跳过。
-        #
+        """
+        == 云原生应用 或者 使用了 version 3 版本的应用描述文件
+
+        TODO: 优化 import 方式, 例如直接接受 desc.spec
+        Warning: app_desc 中声明的 hooks 会覆盖产品上已填写的 hooks
+        ---
+
+        NOTE: 对于云原生应用， import_bkapp_spec_entity() 的默认行为是将 spec 中的数据导入
+        到平台中，所有数据以它为准，是类似 PUT 请求的全量更新行为。然后这会导致一个问题：
+
+        - 用户只在描述文件中定义了进程，未通过 envOverlay 定义区分环境的 replicas 数据
+        - 用户通过产品页面，对进程进行了扩缩容，数据记录在 ProcessSpecEnvOverlay 中（体现为
+          模型中的 envOverlay）
+        - 用户重新部署，import_bkapp_spec_entity() 将描述文件中的数据导入，其判断没有 envOverlay
+          数据，已有的 ProcessSpecEnvOverlay 数据被删除，用户设置的副本数丢失
+
+        为了解决这个问题，我们在 import_bkapp_spec_entity() 中增加了 reset_overlays_when_absent 参数，
+        比在这里调用时，将其设置为 False，避免已有的 envOverlay 数据被删除。
+
+        然而，这也算不上是万全之策。因为用户仍然可能会在描述文件中定义 envOverlay 数据，
+        或删除已有的 envOverlay 数据，这些操作仍然可能会导致预期之外的后果。更彻底的解决
+        方法，可能包括以下方面：
+
+        - 在 ProcessSpecEnvOverlay 等数据模型中增加字段（或增加新模型），以区分由
+          用户手动设置的数据和由描述文件导入的数据，并依据一定优先级来处理
+        - 模仿和参考 kubectl apply 的行为，开发新方法 apply_manifest()，对于通过
+          由配置文件定义的内容（比如 ProcessSpecEnvOverlay），打上特定的 manage-by
+          标签，这样，当配置文件中没有定义时，仅在旧数据原本是由配置文件定义时才删除，
+          否则跳过。
+        """
         import_bkapp_spec_entity(
             self.module,
             spec_entity=v1alpha2.BkAppSpec(**sanitize_bkapp_spec_to_dict(desc_obj.spec)),

--- a/apiserver/paasng/paasng/platform/declarative/deployment/resources.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/resources.py
@@ -110,7 +110,7 @@ class DeploymentDesc:
         """Use the processes defined in the Procfile if it's not identical with the
         process list in current spec object.
         """
-        if self.equal_with_procs(procfile_procs):
+        if self._equal_with_procs(procfile_procs):
             return
 
         # Replace the processes with the data defined by the Procfile
@@ -118,7 +118,7 @@ class DeploymentDesc:
         for proc in procfile_procs:
             self.spec.processes.append(Process(name=proc.name, proc_command=proc.command))
 
-    def equal_with_procs(self, procfile_procs: List[ProcfileProc]) -> bool:
+    def _equal_with_procs(self, procfile_procs: List[ProcfileProc]) -> bool:
         """Check if current process list is equal with given Procfile processes.
 
         Only "name" and "command" fields are compared because the ProcfileProc object
@@ -138,6 +138,9 @@ class DeploymentDesc:
                 "replicas": process.replicas,
                 "plan": process.res_quota_plan,
                 "probes": process.probes,
+                # FIXME: 是否需要补充 services 和 scaling_config 等字段，要弄明白增加
+                # 这些字段后会产生什么后果。以及 ProcessTmpl 到底代表什么，和 Process 的
+                # 区别如何。
             },
             ProcessTmpl,
         )

--- a/apiserver/paasng/paasng/platform/declarative/deployment/resources.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/resources.py
@@ -15,13 +15,15 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
+import cattr
 from attrs import define
 
 from paasng.platform.applications.constants import AppLanguage
 from paasng.platform.bkapp_model.entities import Process, v1alpha2
 from paasng.platform.declarative.constants import AppSpecVersion
+from paasng.platform.engine.models.deployment import ProcessTmpl
 
 
 @define
@@ -38,6 +40,18 @@ class BluekingMonitor:
     def __attrs_post_init__(self):
         if self.target_port is None:
             self.target_port = self.port
+
+
+@define
+class ProcfileProc:
+    """The process object defined by Procfile.
+
+    :param name: The process name, such as "web", "worker"
+    :param command: The command to run the process
+    """
+
+    name: str
+    command: str
 
 
 @define
@@ -59,7 +73,14 @@ class DeploymentDesc:
     spec_version: AppSpecVersion = AppSpecVersion.VER_2
 
     def get_procfile(self) -> Dict[str, str]:
+        """Get the processes in Procfile format. This function is used by patchers
+        such as `SourceCodePatcher` for generating "Procfile" file.
+        """
         return {proc_type: process.get_proc_command() for proc_type, process in self.get_processes().items()}
+
+    def get_proc_tmpls(self) -> Dict[str, ProcessTmpl]:
+        """Get the process objects as the `ProcessTmpl` type"""
+        return {name: self.to_proc_tmpl(p) for name, p in self.get_processes().items()}
 
     def get_processes(self) -> Dict[str, Process]:
         """Get the Process objects. These objects are used to synchronize with the
@@ -84,3 +105,39 @@ class DeploymentDesc:
             # TODO: Try read envOverlay to get the "replicas" and "plan" values
             result[process.name] = process
         return result
+
+    def use_procfile_procs_if_conflict(self, procfile_procs: List[ProcfileProc]):
+        """Use the processes defined in the Procfile if it's not identical with the
+        process list in current spec object.
+        """
+        if self.equal_with_procs(procfile_procs):
+            return
+
+        # Replace the processes with the data defined by the Procfile
+        self.spec.processes = []
+        for proc in procfile_procs:
+            self.spec.processes.append(Process(name=proc.name, proc_command=proc.command))
+
+    def equal_with_procs(self, procfile_procs: List[ProcfileProc]) -> bool:
+        """Check if current process list is equal with given Procfile processes.
+
+        Only "name" and "command" fields are compared because the template object
+        might be create through procfile which do not contain extra fields.
+        """
+        d1 = {p.name: p.get_proc_command() for p in self.get_processes().values()}
+        d2 = {p.name: p.command for p in procfile_procs}
+        return d1 == d2
+
+    @staticmethod
+    def to_proc_tmpl(process: Process) -> ProcessTmpl:
+        """Turn a Process object into a ProcessTmpl object."""
+        return cattr.structure(
+            {
+                "name": process.name,
+                "command": process.get_proc_command(),
+                "replicas": process.replicas,
+                "plan": process.res_quota_plan,
+                "probes": process.probes,
+            },
+            ProcessTmpl,
+        )

--- a/apiserver/paasng/paasng/platform/declarative/deployment/resources.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/resources.py
@@ -121,8 +121,8 @@ class DeploymentDesc:
     def equal_with_procs(self, procfile_procs: List[ProcfileProc]) -> bool:
         """Check if current process list is equal with given Procfile processes.
 
-        Only "name" and "command" fields are compared because the template object
-        might be create through procfile which do not contain extra fields.
+        Only "name" and "command" fields are compared because the ProcfileProc object
+        do not contain any other fields.
         """
         d1 = {p.name: p.get_proc_command() for p in self.get_processes().values()}
         d2 = {p.name: p.command for p in procfile_procs}

--- a/apiserver/paasng/paasng/platform/declarative/entities.py
+++ b/apiserver/paasng/paasng/platform/declarative/entities.py
@@ -1,0 +1,32 @@
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+from typing import Dict
+
+from attrs import define, field
+
+from paasng.platform.engine.models.deployment import ProcessTmpl
+
+
+@define
+class DeployHandleResult:
+    """部署阶段处理应用描述文件的结果类。
+
+    :param use_cnb: 是否使用了 v3 版本 CNB 模式，对 S-Mart 应用有意义
+    :param processes: 本次处理的进程列表, 命令为 Procfile 的单字符串格式
+    """
+
+    use_cnb: bool
+    processes: Dict[str, ProcessTmpl] = field(factory=dict)

--- a/apiserver/paasng/paasng/platform/declarative/entities.py
+++ b/apiserver/paasng/paasng/platform/declarative/entities.py
@@ -13,11 +13,7 @@
 #
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
-from typing import Dict
-
-from attrs import define, field
-
-from paasng.platform.engine.models.deployment import ProcessTmpl
+from attrs import define
 
 
 @define
@@ -25,8 +21,6 @@ class DeployHandleResult:
     """部署阶段处理应用描述文件的结果类。
 
     :param use_cnb: 是否使用了 v3 版本 CNB 模式，对 S-Mart 应用有意义
-    :param processes: 本次处理的进程列表, 命令为 Procfile 的单字符串格式
     """
 
     use_cnb: bool
-    processes: Dict[str, ProcessTmpl] = field(factory=dict)

--- a/apiserver/paasng/paasng/platform/declarative/exceptions.py
+++ b/apiserver/paasng/paasng/platform/declarative/exceptions.py
@@ -21,10 +21,6 @@ from blue_krill.web.drf_utils import stringify_validation_error
 from rest_framework.exceptions import ValidationError
 
 
-class AppDescriptionNotFoundError(Exception):
-    """Raised when app description is not found"""
-
-
 class DescriptionValidationError(Exception):
     """Raised when any given description was invalid
 

--- a/apiserver/paasng/paasng/platform/declarative/handlers.py
+++ b/apiserver/paasng/paasng/platform/declarative/handlers.py
@@ -206,6 +206,11 @@ class SMartDescriptionHandler:
         return controller.perform_action(self.app_desc)
 
 
+###
+# Deploy related functions
+###
+
+
 def get_deploy_desc_handler(
     desc_data: Optional[Dict] = None, procfile_data: Optional[Dict] = None
 ) -> "DeployDescHandler":

--- a/apiserver/paasng/paasng/platform/declarative/handlers.py
+++ b/apiserver/paasng/paasng/platform/declarative/handlers.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_desc_handler(json_data: Dict) -> "DescriptionHandler":
-    """Get the handler for handling description data, this handler handle the app
+    """Get the handler for handling description data, it handle the app
     level logics, see `get_deploy_desc_handler` for deployment level handler.
 
     :param json_data: The description data in dict format.
@@ -212,13 +212,13 @@ def get_deploy_desc_handler(
     """Get the handler for handling description data when performing new deployment.
 
     :param desc_data: The description data in dict format, optional
-    :param procfile_data: The "Procfile" data in dict format, format: {"type": "command"}
+    :param procfile_data: The "Procfile" data in dict format, format: {<proc_type>: <command>}
     """
     if not (desc_data or procfile_data):
         raise ValueError("json_data and procfile_data can't be both None")
 
     if not desc_data:
-        # Only procfile data is provided, use the handler to handel processes data only
+        # Only procfile data is provided, use the handler to handle processes data only
         assert procfile_data
         return ProcfileOnlyDeployDescHandler(procfile_data)
     return DefaultDeployDescHandler(desc_data, procfile_data, get_desc_getter_func(desc_data))
@@ -251,12 +251,11 @@ def get_desc_getter_func(desc_data: Dict) -> DescGetterFunc:
     spec_version = detect_spec_version(desc_data)
     # TODO: 删除此分支，VER_1 存量版本基本不再支持
     if spec_version == AppSpecVersion.VER_1:
-        desc_getter = deploy_desc_getter_v1
+        return deploy_desc_getter_v1
     elif spec_version == AppSpecVersion.VER_2:
-        desc_getter = deploy_desc_getter_v2
+        return deploy_desc_getter_v2
     else:
-        desc_getter = deploy_desc_getter_v3
-    return desc_getter
+        return deploy_desc_getter_v3
 
 
 class DefaultDeployDescHandler:

--- a/apiserver/paasng/paasng/platform/declarative/handlers.py
+++ b/apiserver/paasng/paasng/platform/declarative/handlers.py
@@ -17,11 +17,11 @@
 
 import copy
 import logging
-from typing import Dict, Literal, Optional, TextIO
+from typing import Callable, Dict, Literal, Optional, TextIO
 
 import yaml
 from django.utils.translation import gettext as _
-from typing_extensions import Protocol
+from typing_extensions import Protocol, TypeAlias
 
 from paasng.infras.accounts.models import User
 from paasng.platform.applications.models import Application
@@ -31,12 +31,21 @@ from paasng.platform.declarative.application.resources import ApplicationDesc, g
 from paasng.platform.declarative.application.validations import v2 as app_spec_v2
 from paasng.platform.declarative.application.validations import v3 as app_spec_v3
 from paasng.platform.declarative.constants import AppSpecVersion
-from paasng.platform.declarative.deployment.controller import DeploymentDeclarativeController, PerformResult
+from paasng.platform.declarative.deployment.controller import (
+    DeployHandleResult,
+    DeploymentDeclarativeController,
+    handle_procfile_procs,
+)
 from paasng.platform.declarative.deployment.resources import DeploymentDesc
 from paasng.platform.declarative.deployment.validations import v2 as deploy_spec_v2
 from paasng.platform.declarative.deployment.validations import v3 as deploy_spec_v3
 from paasng.platform.declarative.exceptions import DescriptionValidationError
-from paasng.platform.declarative.serializers import SMartV1DescriptionSLZ, UniConfigSLZ, validate_desc
+from paasng.platform.declarative.serializers import (
+    SMartV1DescriptionSLZ,
+    UniConfigSLZ,
+    validate_desc,
+    validate_procfile_procs,
+)
 from paasng.platform.engine.models.deployment import Deployment
 from paasng.platform.modules.constants import SourceOrigin
 
@@ -44,6 +53,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_desc_handler(json_data: Dict) -> "DescriptionHandler":
+    """Get the handler for handling description data, this handler handle the app
+    level logics, see `get_deploy_desc_handler` for deployment level handler.
+
+    :param json_data: The description data in dict format.
+    """
     spec_version = detect_spec_version(json_data)
     # TODO 删除 SMartDescriptionHandler 分支. VER_1 存量版本基本不再支持
     if spec_version == AppSpecVersion.VER_1:
@@ -65,19 +79,11 @@ class DescriptionHandler(Protocol):
     @property
     def app_desc(self) -> ApplicationDesc: ...
 
-    def get_deploy_desc(self, module_name: Optional[str]) -> DeploymentDesc: ...
-
     def handle_app(self, user: User, source_origin: Optional[SourceOrigin] = None) -> Application:
         """Handle a YAML config for application initialization
 
         :param user: User to perform actions as
         :param source_origin: 源码来源
-        """
-
-    def handle_deployment(self, deployment: Deployment) -> PerformResult:
-        """Handle a YAML config file for a deployment
-
-        :param deployment: The related deployment object
         """
 
 
@@ -89,7 +95,6 @@ class CNativeAppDescriptionHandler:
         return cls(yaml.safe_load(fp))
 
     def __init__(self, json_data: Dict):
-        """The app_desc.yml json data"""
         self.json_data = json_data
 
     @property
@@ -114,11 +119,6 @@ class CNativeAppDescriptionHandler:
         )
         return app_desc
 
-    def get_deploy_desc(self, module_name: Optional[str]) -> DeploymentDesc:
-        desc_data = _find_module_desc_data(self.json_data, module_name, "list")
-        desc = validate_desc(deploy_spec_v3.DeploymentDescSLZ, desc_data)
-        return desc
-
     def handle_app(self, user: User, source_origin: Optional[SourceOrigin] = None) -> Application:
         """Handle a YAML config for application initialization
 
@@ -126,14 +126,6 @@ class CNativeAppDescriptionHandler:
         """
         controller = AppDeclarativeController(user, source_origin)
         return controller.perform_action(self.app_desc)
-
-    def handle_deployment(self, deployment: Deployment) -> PerformResult:
-        """Handle a YAML config file for a deployment
-
-        :param deployment: The related deployment object
-        """
-        controller = DeploymentDeclarativeController(deployment)
-        return controller.perform_action(self.get_deploy_desc(deployment.app_environment.module.name))
 
 
 class AppDescriptionHandler:
@@ -144,7 +136,6 @@ class AppDescriptionHandler:
         return cls(yaml.safe_load(fp))
 
     def __init__(self, json_data: Dict):
-        """The app_desc.yml json data"""
         self.json_data = json_data
 
     @property
@@ -170,16 +161,6 @@ class AppDescriptionHandler:
         )
         return app_desc
 
-    def get_deploy_desc(self, module_name: Optional[str] = None) -> DeploymentDesc:
-        """Get the deployment description object by module name.
-
-        :param module_name: The name of module.
-        :raise DescriptionValidationError: If no info can be found using the given module.
-        """
-        desc_data = _find_module_desc_data(self.json_data, module_name, "dict")
-        desc = validate_desc(deploy_spec_v2.DeploymentDescSLZ, desc_data)
-        return desc
-
     def handle_app(self, user: User, source_origin: Optional[SourceOrigin] = None) -> Application:
         """Handle a YAML config for application initialization
 
@@ -193,16 +174,6 @@ class AppDescriptionHandler:
 
         controller = AppDeclarativeController(user, source_origin)
         return controller.perform_action(self.app_desc)
-
-    def handle_deployment(self, deployment: Deployment) -> PerformResult:
-        """Handle a YAML config file for a deployment
-
-        :param deployment: The related deployment object
-        """
-        validate_desc(UniConfigSLZ, self.json_data)
-
-        controller = DeploymentDeclarativeController(deployment)
-        return controller.perform_action(self.get_deploy_desc(deployment.app_environment.module.name))
 
 
 class SMartDescriptionHandler:
@@ -226,12 +197,6 @@ class SMartDescriptionHandler:
         app_desc, _ = validate_desc(SMartV1DescriptionSLZ, self.json_data, instance, partial=False)
         return app_desc
 
-    def get_deploy_desc(self, module_name: Optional[str] = None) -> DeploymentDesc:
-        instance = get_application(self.json_data, "app_code")
-        # S-mart application always perform a full update by using partial=False
-        _, deploy_desc = validate_desc(SMartV1DescriptionSLZ, self.json_data, instance, partial=False)
-        return deploy_desc
-
     def handle_app(self, user: User, source_origin: Optional[SourceOrigin] = None) -> Application:
         """Handle a app config
 
@@ -240,13 +205,145 @@ class SMartDescriptionHandler:
         controller = AppDeclarativeController(user)
         return controller.perform_action(self.app_desc)
 
-    def handle_deployment(self, deployment: Deployment) -> PerformResult:
-        """Handle a deployment config
 
-        :param deployment: The related deployment object
+def get_deploy_desc_handler(
+    desc_data: Optional[Dict] = None, procfile_data: Optional[Dict] = None
+) -> "DeployDescHandler":
+    """Get the handler for handling description data when performing new deployment.
+
+    :param desc_data: The description data in dict format, optional
+    :param procfile_data: The "Procfile" data in dict format, format: {"type": "command"}
+    """
+    if not (desc_data or procfile_data):
+        raise ValueError("json_data and procfile_data can't be both None")
+
+    if not desc_data:
+        # Only procfile data is provided, use the handler to handel processes data only
+        assert procfile_data
+        return ProcfileOnlyDeployDescHandler(procfile_data)
+    return DefaultDeployDescHandler(desc_data, procfile_data, get_desc_getter_func(desc_data))
+
+
+def get_deploy_desc_by_module(desc_data: Dict, module_name: str) -> DeploymentDesc:
+    """Get the deploy desc object by module name
+
+    :param desc_data: The description data in dict format, may contains multiple modules
+    :param module_name: The module name
+    """
+    return get_desc_getter_func(desc_data)(desc_data, module_name)
+
+
+class DeployDescHandler(Protocol):
+    def handle(self, deployment: Deployment, ignore_invalid_desc: bool = False) -> DeployHandleResult:
+        """Handle a deployment object.
+
+        :param deployment: The deployment object
+        :param ignore_invalid_desc: Whether to ignore error when the desc data is invalid, set this value to true to continue
+            process the procfile data.
         """
-        controller = DeploymentDeclarativeController(deployment)
-        return controller.perform_action(self.get_deploy_desc(None))
+        ...
+
+    def get_desc_obj(self, module_name: str) -> DeploymentDesc:
+        """Get the description object by module name
+
+        :raise TypeError: when it's impossible to get the desc object
+        """
+        ...
+
+
+# A simple function type that get the deploy description object from the json data.
+DescGetterFunc: TypeAlias = Callable[[Dict, str], DeploymentDesc]
+
+
+def get_desc_getter_func(desc_data: Dict) -> DescGetterFunc:
+    """Get the description getter function by current desc data."""
+    spec_version = detect_spec_version(desc_data)
+    # TODO: 删除此分支，VER_1 存量版本基本不再支持
+    if spec_version == AppSpecVersion.VER_1:
+        desc_getter = deploy_desc_getter_v1
+    elif spec_version == AppSpecVersion.VER_2:
+        desc_getter = deploy_desc_getter_v2
+    else:
+        desc_getter = deploy_desc_getter_v3
+    return desc_getter
+
+
+class DefaultDeployDescHandler:
+    """The default handler for handling deployment description data.
+
+    :param json_data: The description data in dict format
+    :param procfile_data: The Procfile data in dict format, can be none
+    :param desc_getter: The function to get the deployment desc object
+    """
+
+    def __init__(self, json_data: Dict, procfile_data: Optional[Dict], desc_getter: DescGetterFunc):
+        self.json_data = json_data
+        self.procfile_data = procfile_data
+        self.desc_getter = desc_getter
+
+    def get_desc_obj(self, module_name: str) -> DeploymentDesc:
+        return self.desc_getter(self.json_data, module_name)
+
+    def handle(self, deployment: Deployment, ignore_invalid_desc: bool = False) -> DeployHandleResult:
+        try:
+            desc = self.get_desc_obj(deployment.app_environment.module.name)
+        except DescriptionValidationError as e:
+            if not ignore_invalid_desc:
+                raise
+            else:
+                desc_getting_exc = e
+                desc = None
+
+        procfile_procs = validate_procfile_procs(self.procfile_data) if self.procfile_data else None
+        if desc is not None:
+            return DeploymentDeclarativeController(deployment).perform_action(desc, procfile_procs)
+        else:
+            # Error getting the desc data but the error has been ignored, continue to
+            # process the procfile data.
+            if not procfile_procs:
+                # Raise the original exception when the procfile data is also absent
+                raise desc_getting_exc
+
+            assert procfile_procs
+            return handle_procfile_procs(deployment, procfile_procs)
+
+
+class ProcfileOnlyDeployDescHandler:
+    """The handler for handling the procfile data only.
+
+    :param procfile_data: The Procfile data in dict format
+    """
+
+    def __init__(self, procfile_data: Dict):
+        self.procfile_data = procfile_data
+
+    def get_desc_obj(self, module_name: str) -> DeploymentDesc:
+        raise TypeError("Not supported because there is no desc data")
+
+    def handle(self, deployment: Deployment, ignore_invalid_desc: bool = False) -> DeployHandleResult:
+        procfile_procs = validate_procfile_procs(self.procfile_data)
+        return handle_procfile_procs(deployment, procfile_procs)
+
+
+def deploy_desc_getter_v1(json_data: Dict, module_name: str) -> DeploymentDesc:
+    """Get the deployment desc object, spec ver 1."""
+    instance = get_application(json_data, "app_code")
+    # S-mart application always perform a full update by using partial=False
+    _, deploy_desc = validate_desc(SMartV1DescriptionSLZ, json_data, instance, partial=False)
+    return deploy_desc
+
+
+def deploy_desc_getter_v2(json_data: Dict, module_name: str) -> DeploymentDesc:
+    """Get the deployment desc object, spec ver 2."""
+    validate_desc(UniConfigSLZ, json_data)
+    desc_data = _find_module_desc_data(json_data, module_name, "dict")
+    return validate_desc(deploy_spec_v2.DeploymentDescSLZ, desc_data)
+
+
+def deploy_desc_getter_v3(json_data: Dict, module_name: str) -> DeploymentDesc:
+    """Get the deployment desc object, spec ver 3."""
+    desc_data = _find_module_desc_data(json_data, module_name, "list")
+    return validate_desc(deploy_spec_v3.DeploymentDescSLZ, desc_data)
 
 
 def _find_module_desc_data(

--- a/apiserver/paasng/paasng/platform/declarative/handlers.py
+++ b/apiserver/paasng/paasng/platform/declarative/handlers.py
@@ -241,13 +241,6 @@ class DeployDescHandler(Protocol):
         """
         ...
 
-    def get_desc_obj(self, module_name: str) -> DeploymentDesc:
-        """Get the description object by module name
-
-        :raise TypeError: when it's impossible to get the desc object
-        """
-        ...
-
 
 # A simple function type that get the deploy description object from the json data.
 DescGetterFunc: TypeAlias = Callable[[Dict, str], DeploymentDesc]
@@ -279,11 +272,8 @@ class DefaultDeployDescHandler:
         self.procfile_data = procfile_data
         self.desc_getter = desc_getter
 
-    def get_desc_obj(self, module_name: str) -> DeploymentDesc:
-        return self.desc_getter(self.json_data, module_name)
-
     def handle(self, deployment: Deployment) -> DeployHandleResult:
-        desc = self.get_desc_obj(deployment.app_environment.module.name)
+        desc = self.desc_getter(self.json_data, deployment.app_environment.module.name)
         procfile_procs = validate_procfile_procs(self.procfile_data) if self.procfile_data else None
         return DeploymentDeclarativeController(deployment).perform_action(desc, procfile_procs)
 
@@ -296,9 +286,6 @@ class ProcfileOnlyDeployDescHandler:
 
     def __init__(self, procfile_data: Dict):
         self.procfile_data = procfile_data
-
-    def get_desc_obj(self, module_name: str) -> DeploymentDesc:
-        raise TypeError("Not supported because there is no desc data")
 
     def handle(self, deployment: Deployment) -> DeployHandleResult:
         procfile_procs = validate_procfile_procs(self.procfile_data)

--- a/apiserver/paasng/paasng/platform/declarative/serializers.py
+++ b/apiserver/paasng/paasng/platform/declarative/serializers.py
@@ -274,7 +274,7 @@ def validate_procfile_procs(data: Dict[str, str]) -> List[ProcfileProc]:
     if len(data) > settings.MAX_PROCESSES_PER_MODULE:
         raise DescriptionValidationError(
             f"The number of processes exceeded: maximum {settings.MAX_PROCESSES_PER_MODULE} processes per module, "
-            f"but got {len(data)}"
+            + f"but got {len(data)}"
         )
 
     for proc_type in data:

--- a/apiserver/paasng/paasng/platform/engine/configurations/source_file.py
+++ b/apiserver/paasng/paasng/platform/engine/configurations/source_file.py
@@ -94,10 +94,9 @@ class MetaDataFileReader:
         try:
             procfile = yaml.full_load(content)
         except Exception as e:
-            raise exceptions.GetProcfileError('file "Procfile"\'s format is not YAML') from e
-
+            raise exceptions.GetProcfileFormatError('file "Procfile"\'s format is not YAML') from e
         if not isinstance(procfile, dict):
-            raise exceptions.GetProcfileError('file "Procfile" must be dict type')
+            raise exceptions.GetProcfileFormatError('file "Procfile" must be dict type')
         return procfile
 
     def get_app_desc(self, version_info: VersionInfo) -> Dict:

--- a/apiserver/paasng/paasng/platform/engine/configurations/source_file.py
+++ b/apiserver/paasng/paasng/platform/engine/configurations/source_file.py
@@ -15,6 +15,7 @@
 # to the current version of the project delivered to anyone in the future.
 
 """Manage configurations related with source files"""
+
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional, Tuple
@@ -206,14 +207,13 @@ class PackageMetaDataReader(MetaDataFileReader):
 
     def get_procfile(self, version_info: VersionInfo) -> Dict[str, str]:
         """Read Procfile config from SourcePackage.meta_data(the field stored app_desc) or repository"""
-        from paasng.platform.declarative.handlers import get_desc_handler
+        from paasng.platform.declarative.handlers import get_deploy_desc_by_module
 
         _, version = self.extract_version_info(version_info)
         package_storage = self.module.packages.get(version=version)
         if package_storage.meta_info:
             try:
-                handler = get_desc_handler(package_storage.meta_info)
-                deploy_desc = handler.get_deploy_desc(self.module.name)
+                deploy_desc = get_deploy_desc_by_module(package_storage.meta_info, self.module.name)
                 return deploy_desc.get_procfile()
             except Exception as e:
                 raise exceptions.GetProcfileError('unable to read file "Procfile"') from e

--- a/apiserver/paasng/paasng/platform/engine/configurations/source_file.py
+++ b/apiserver/paasng/paasng/platform/engine/configurations/source_file.py
@@ -134,9 +134,9 @@ class MetaDataFileReader:
         try:
             app_description = yaml.full_load(content)
         except Exception as e:
-            raise exceptions.GetAppYamlError('file "app.yaml"\'s format is not YAML') from e
+            raise exceptions.GetAppYamlFormatError('file "app.yaml"\'s format is not YAML') from e
         if not isinstance(app_description, dict):
-            raise exceptions.GetAppYamlError('file "app.yaml" must be dict type')
+            raise exceptions.GetAppYamlFormatError('file "app.yaml" must be dict type')
         return app_description
 
     def get_dockerignore(self, version_info: VersionInfo) -> str:

--- a/apiserver/paasng/paasng/platform/engine/deploy/building.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/building.py
@@ -240,7 +240,7 @@ class ApplicationBuilder(BaseBuilder):
 
         is_cnative_app = self.module_environment.application.type == ApplicationType.CLOUD_NATIVE
         # DB 中存储的步骤名为中文，所以 procedure_force_phase 必须传中文，不能做国际化处理
-        with self.procedure_force_phase("解析应用描述文件", phase=preparation_phase):
+        with self.procedure_force_phase("解析应用进程信息", phase=preparation_phase):
             self.handle_app_description()
 
         bkapp_revision_id = None
@@ -331,7 +331,7 @@ class DockerBuilder(BaseBuilder):
 
         is_cnative_app = self.module_environment.application.type == ApplicationType.CLOUD_NATIVE
         # DB 中存储的步骤名为中文，所以 procedure_force_phase 必须传中文，不能做国际化处理
-        with self.procedure_force_phase("解析应用描述文件", phase=preparation_phase):
+        with self.procedure_force_phase("解析应用进程信息", phase=preparation_phase):
             self.handle_app_description()
 
         bkapp_revision_id = None

--- a/apiserver/paasng/paasng/platform/engine/deploy/building.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/building.py
@@ -241,8 +241,7 @@ class ApplicationBuilder(BaseBuilder):
         is_cnative_app = self.module_environment.application.type == ApplicationType.CLOUD_NATIVE
         # DB 中存储的步骤名为中文，所以 procedure_force_phase 必须传中文，不能做国际化处理
         with self.procedure_force_phase("解析应用描述文件", phase=preparation_phase):
-            handle_result = self.handle_app_description()
-            self.deployment.update_fields(processes=handle_result.processes)
+            self.handle_app_description()
 
         bkapp_revision_id = None
         if is_cnative_app:
@@ -333,8 +332,7 @@ class DockerBuilder(BaseBuilder):
         is_cnative_app = self.module_environment.application.type == ApplicationType.CLOUD_NATIVE
         # DB 中存储的步骤名为中文，所以 procedure_force_phase 必须传中文，不能做国际化处理
         with self.procedure_force_phase("解析应用描述文件", phase=preparation_phase):
-            handle_result = self.handle_app_description()
-            self.deployment.update_fields(processes=handle_result.processes)
+            self.handle_app_description()
 
         bkapp_revision_id = None
         if is_cnative_app:

--- a/apiserver/paasng/paasng/platform/engine/deploy/building.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/building.py
@@ -163,6 +163,7 @@ class BaseBuilder(DeployStep):
         except (DescriptionValidationError, ManifestImportError) as e:
             raise HandleAppDescriptionError(reason=_("应用描述文件解析异常: {}").format(e.message)) from e
         except Exception as e:
+            logger.exception("Error while handling app description file, deployment: %s.", self.deployment)
             raise HandleAppDescriptionError(reason=_("处理应用描述文件时出现异常, 请检查应用描述文件")) from e
 
     def create_bkapp_revision(self) -> int:

--- a/apiserver/paasng/paasng/platform/engine/deploy/building.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/building.py
@@ -144,13 +144,10 @@ class BaseBuilder(DeployStep):
                     package_path, source_destination_path
                 )
 
-    def handle_app_description(self, ignore_invalid_desc: bool = False) -> DeployHandleResult:
+    def handle_app_description(self) -> DeployHandleResult:
         """Handle the description files for deployment. It try to parse the app description
         file and store the related configurations, e.g. processes.
 
-        :param ignore_invalid_desc: whether to ignore the error when the desc data is
-            invalid, normal app need this flag to be true because they can still use
-            the Procfile.
         :raises HandleAppDescriptionError: When failed to handle the app description.
         """
         try:
@@ -160,7 +157,7 @@ class BaseBuilder(DeployStep):
                 self.deployment.version_info,
                 self.deployment.get_source_dir(),
             )
-            return handler.handle(self.deployment, ignore_invalid_desc=ignore_invalid_desc)
+            return handler.handle(self.deployment)
         except InitDeployDescHandlerError as e:
             raise HandleAppDescriptionError(reason=_("处理应用描述文件失败：{}".format(e)))
         except (DescriptionValidationError, ManifestImportError) as e:
@@ -243,7 +240,7 @@ class ApplicationBuilder(BaseBuilder):
         is_cnative_app = self.module_environment.application.type == ApplicationType.CLOUD_NATIVE
         # DB 中存储的步骤名为中文，所以 procedure_force_phase 必须传中文，不能做国际化处理
         with self.procedure_force_phase("解析应用描述文件", phase=preparation_phase):
-            handle_result = self.handle_app_description(ignore_invalid_desc=not is_cnative_app)
+            handle_result = self.handle_app_description()
             self.deployment.update_fields(processes=handle_result.processes)
 
         bkapp_revision_id = None
@@ -335,7 +332,7 @@ class DockerBuilder(BaseBuilder):
         is_cnative_app = self.module_environment.application.type == ApplicationType.CLOUD_NATIVE
         # DB 中存储的步骤名为中文，所以 procedure_force_phase 必须传中文，不能做国际化处理
         with self.procedure_force_phase("解析应用描述文件", phase=preparation_phase):
-            handle_result = self.handle_app_description(ignore_invalid_desc=not is_cnative_app)
+            handle_result = self.handle_app_description()
             self.deployment.update_fields(processes=handle_result.processes)
 
         bkapp_revision_id = None

--- a/apiserver/paasng/paasng/platform/engine/deploy/image_release.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/image_release.py
@@ -98,7 +98,7 @@ class ImageReleaseMgr(DeployStep):
                 use_cnb = False
                 if is_smart_app:
                     # S-Mart 应用使用 S-Mart 包的元信息记录启动进程
-                    handle_result = self.handle_smart_app_description()
+                    handle_result = self._handle_smart_app_description()
                     use_cnb = handle_result.use_cnb
                 else:
                     env_name = self.module_environment.environment
@@ -178,7 +178,7 @@ class ImageReleaseMgr(DeployStep):
 
                 AppImageCredential.objects.flush_from_refs(application, self.engine_app.to_wl_obj(), credential_refs)
 
-    def handle_smart_app_description(self) -> DeployHandleResult:
+    def _handle_smart_app_description(self) -> DeployHandleResult:
         """Handle the description files for S-Mart app."""
         try:
             handler = get_deploy_desc_handler_by_version(

--- a/apiserver/paasng/paasng/platform/engine/deploy/image_release.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/image_release.py
@@ -190,4 +190,5 @@ class ImageReleaseMgr(DeployStep):
         except InitDeployDescHandlerError as e:
             raise HandleAppDescriptionError(reason=_("处理应用描述文件失败：{}".format(e)))
         except Exception as e:
+            logger.exception("Error while handling s-mart app description file, deployment: %s.", self.deployment)
             raise HandleAppDescriptionError(reason=_("处理应用描述文件时出现异常, 请检查应用描述文件")) from e

--- a/apiserver/paasng/paasng/platform/engine/deploy/image_release.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/image_release.py
@@ -186,7 +186,7 @@ class ImageReleaseMgr(DeployStep):
                 self.deployment.operator,
                 self.deployment.version_info,
             )
-            return handler.handle(self.deployment, ignore_invalid_desc=True)
+            return handler.handle(self.deployment)
         except InitDeployDescHandlerError as e:
             raise HandleAppDescriptionError(reason=_("处理应用描述文件失败：{}".format(e)))
         except Exception as e:

--- a/apiserver/paasng/paasng/platform/engine/exceptions.py
+++ b/apiserver/paasng/paasng/platform/engine/exceptions.py
@@ -88,3 +88,7 @@ class HandleAppDescriptionError(Exception):
 
     def __str__(self):
         return self.reason
+
+
+class InitDeployDescHandlerError(Exception):
+    """Error when initialing the description handler for deployment."""

--- a/apiserver/paasng/paasng/platform/engine/models/deployment.py
+++ b/apiserver/paasng/paasng/platform/engine/models/deployment.py
@@ -292,6 +292,7 @@ class Deployment(OperationVersionBase):
         return hooks
 
     def get_processes(self) -> List[ProcessTmpl]:
+        """获取本次部署所使用的进程配置列表。"""
         if self.processes:
             return list(self.processes.values())
         # 兼容旧字段 procfile

--- a/apiserver/paasng/paasng/platform/engine/utils/patcher.py
+++ b/apiserver/paasng/paasng/platform/engine/utils/patcher.py
@@ -33,6 +33,7 @@ class SourceCodePatcherWithDBDriver:
     """基于数据库记录驱动的源码 Patcher
 
     - 目的：基于 CNB 的应用后续启动进程时，必须使用 Procfile 文件，因此自动生成一份
+    - 仅当 Procfile 不存在时才会写入文件
     - 副作用（存疑？）：当普通应用经由 app_desc.yaml 解析并获取应用进程信息失败时，后续仍
     会尝试从 Procfile 文件读取进程信息，变成了一种“托底”逻辑。详情见 ApplicationBuilder
     中调用 get_processes 的部分。

--- a/apiserver/paasng/paasng/platform/engine/utils/source.py
+++ b/apiserver/paasng/paasng/platform/engine/utils/source.py
@@ -39,7 +39,12 @@ from paasng.platform.modules.constants import SourceOrigin
 from paasng.platform.modules.models import Module
 from paasng.platform.modules.specs import ModuleSpecs
 from paasng.platform.sourcectl.controllers.package import PackageController
-from paasng.platform.sourcectl.exceptions import GetAppYamlError, GetDockerIgnoreError, GetProcfileError
+from paasng.platform.sourcectl.exceptions import (
+    GetAppYamlError,
+    GetDockerIgnoreError,
+    GetProcfileError,
+    GetProcfileFormatError,
+)
 from paasng.platform.sourcectl.models import VersionInfo
 from paasng.platform.sourcectl.repo_controller import get_repo_controller
 from paasng.platform.sourcectl.utils import DockerIgnore
@@ -159,6 +164,9 @@ def get_deploy_desc_handler_by_version(
     procfile_data, procfile_exc = None, None
     try:
         procfile_data = metadata_reader.get_procfile(version_info)
+    except GetProcfileFormatError as e:
+        # The format error in Procfile in not tolerable
+        raise InitDeployDescHandlerError(str(e))
     except GetProcfileError as e:
         procfile_exc = e
 

--- a/apiserver/paasng/paasng/platform/engine/utils/source.py
+++ b/apiserver/paasng/paasng/platform/engine/utils/source.py
@@ -41,6 +41,7 @@ from paasng.platform.modules.specs import ModuleSpecs
 from paasng.platform.sourcectl.controllers.package import PackageController
 from paasng.platform.sourcectl.exceptions import (
     GetAppYamlError,
+    GetAppYamlFormatError,
     GetDockerIgnoreError,
     GetProcfileError,
     GetProcfileFormatError,
@@ -158,6 +159,9 @@ def get_deploy_desc_handler_by_version(
     else:
         try:
             app_desc = metadata_reader.get_app_desc(version_info)
+        except GetAppYamlFormatError as e:
+            # The format error in app_desc is not tolerable
+            raise InitDeployDescHandlerError(str(e))
         except GetAppYamlError as e:
             app_desc_exc = e
 

--- a/apiserver/paasng/paasng/platform/smart_app/services/dispatch.py
+++ b/apiserver/paasng/paasng/platform/smart_app/services/dispatch.py
@@ -26,7 +26,7 @@ from moby_distribution import ImageJSON, ImageRef, LayerRef
 
 from paasng.infras.accounts.models import User
 from paasng.platform.applications.models import Application
-from paasng.platform.declarative.handlers import get_desc_handler
+from paasng.platform.declarative.handlers import get_deploy_desc_by_module
 from paasng.platform.modules.models import Module
 from paasng.platform.smart_app.conf import bksmart_settings
 from paasng.platform.smart_app.constants import SMartPackageBuilderVersionFlag
@@ -110,8 +110,7 @@ def dispatch_slug_image_to_registry(module: Module, workplace: Path, stat: SPSta
     """
     logger.debug("dispatching slug-image for module '%s', working at '%s'", module.name, workplace)
 
-    desc_handler = get_desc_handler(stat.meta_info)
-    deploy_desc = desc_handler.get_deploy_desc(module.name)
+    deploy_desc = get_deploy_desc_by_module(stat.meta_info, module.name)
 
     layer_path = workplace / stat.relative_path / deploy_desc.source_dir / "layer.tar.gz"
     procfile_path = workplace / stat.relative_path / deploy_desc.source_dir / f"{module.name}.Procfile.tar.gz"

--- a/apiserver/paasng/paasng/platform/sourcectl/exceptions.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/exceptions.py
@@ -16,6 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 
 """Exceptions for sourcectl package"""
+
 from typing import TYPE_CHECKING, Optional
 
 from django.utils.translation import gettext as _
@@ -88,7 +89,11 @@ class ExceptionWithMessage(Exception):
 
 
 class GetProcfileError(ExceptionWithMessage):
-    """When a valid procfile can not be found in application directory"""
+    """When no valid Procfile can not be found in application directory"""
+
+
+class GetProcfileFormatError(GetProcfileError):
+    """The Procfile exists but the content format is incorrect"""
 
 
 class GetAppYamlError(ExceptionWithMessage):

--- a/apiserver/paasng/paasng/platform/sourcectl/exceptions.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/exceptions.py
@@ -89,7 +89,7 @@ class ExceptionWithMessage(Exception):
 
 
 class GetProcfileError(ExceptionWithMessage):
-    """When no valid Procfile can not be found in application directory"""
+    """When no valid Procfile can be found in application directory"""
 
 
 class GetProcfileFormatError(GetProcfileError):
@@ -97,7 +97,11 @@ class GetProcfileFormatError(GetProcfileError):
 
 
 class GetAppYamlError(ExceptionWithMessage):
-    """When a valid app.yaml can not be found in application directory"""
+    """When no valid app.yaml can be found in application directory"""
+
+
+class GetAppYamlFormatError(GetAppYamlError):
+    """The app.yaml exists but the content format is incorrect"""
 
 
 class GetDockerIgnoreError(ExceptionWithMessage):

--- a/apiserver/paasng/tests/paasng/platform/declarative/deployment/v2/test_controller.py
+++ b/apiserver/paasng/tests/paasng/platform/declarative/deployment/v2/test_controller.py
@@ -74,14 +74,14 @@ class TestProcessesField:
         controller = DeploymentDeclarativeController(bk_deployment)
         result = controller.perform_action(desc=validate_desc(DeploymentDescSLZ, json_data))
 
-        assert result.loaded_processes["web"].replicas is None
+        assert result.processes["web"].replicas is None
 
     def test_proc_with_fixed_replicas(self, bk_deployment):
         json_data = {"language": "python", "processes": {"web": {"command": "start", "replicas": 3}}}
         controller = DeploymentDeclarativeController(bk_deployment)
         result = controller.perform_action(desc=validate_desc(DeploymentDescSLZ, json_data))
 
-        assert result.loaded_processes["web"].replicas == 3
+        assert result.processes["web"].replicas == 3
 
 
 class TestEnvVariablesField:

--- a/apiserver/paasng/tests/paasng/platform/declarative/handlers/test_v1.py
+++ b/apiserver/paasng/tests/paasng/platform/declarative/handlers/test_v1.py
@@ -28,7 +28,12 @@ from paasng.platform.applications.constants import AppLanguage
 from paasng.platform.applications.models import Application
 from paasng.platform.declarative.application.resources import ServiceSpec
 from paasng.platform.declarative.constants import AppDescPluginType
-from paasng.platform.declarative.handlers import SMartDescriptionHandler, get_desc_handler
+from paasng.platform.declarative.handlers import (
+    DefaultDeployDescHandler,
+    SMartDescriptionHandler,
+    deploy_desc_getter_v1,
+    get_desc_handler,
+)
 from paasng.platform.declarative.models import DeploymentDescription
 
 pytestmark = pytest.mark.django_db(databases=["default", "workloads"])
@@ -95,7 +100,7 @@ class TestSMartDescriptionHandler:
                 "container": {"memory": memory},
             }
         )
-        SMartDescriptionHandler(app_desc).handle_deployment(bk_deployment)
+        DefaultDeployDescHandler(app_desc, None, deploy_desc_getter_v1).handle(bk_deployment)
 
         desc_obj = DeploymentDescription.objects.get(deployment=bk_deployment)
         assert desc_obj.spec.processes[0].res_quota_plan == expected_plan_name

--- a/apiserver/paasng/tests/paasng/platform/declarative/handlers/v2/test_deployment.py
+++ b/apiserver/paasng/tests/paasng/platform/declarative/handlers/v2/test_deployment.py
@@ -205,11 +205,8 @@ class TestAppDescriptionHandler:
         handler = get_deploy_desc_handler(
             {"not": "valid yaml"}, procfile_data={"web": "gunicorn app", "worker": "celery"}
         )
-        ret = handler.handle(bk_deployment, ignore_invalid_desc=True)
-
-        assert query_proc_dict(bk_module) == {"web": ("gunicorn app", 1), "worker": ("celery", 1)}
-        assert ret.processes
-        assert len(ret.processes) == 2
+        with pytest.raises(DescriptionValidationError):
+            _ = handler.handle(bk_deployment)
 
     def test_with_modules_found(self, bk_deployment, bk_module):
         _yaml_content = dedent(

--- a/apiserver/paasng/tests/paasng/platform/declarative/handlers/v2/test_deployment.py
+++ b/apiserver/paasng/tests/paasng/platform/declarative/handlers/v2/test_deployment.py
@@ -18,6 +18,7 @@
 import base64
 import json
 from textwrap import dedent
+from typing import Dict, Tuple
 from unittest import mock
 
 import cattr
@@ -26,14 +27,9 @@ import yaml
 from django_dynamic_fixture import G
 
 from paasng.platform.applications.models import Application
-from paasng.platform.bkapp_model.models import get_svc_disc_as_env_variables
+from paasng.platform.bkapp_model.models import ModuleProcessSpec, get_svc_disc_as_env_variables
 from paasng.platform.declarative.exceptions import DescriptionValidationError
-from paasng.platform.declarative.handlers import (
-    AppDescriptionHandler,
-    CNativeAppDescriptionHandler,
-    SMartDescriptionHandler,
-    get_desc_handler,
-)
+from paasng.platform.declarative.handlers import get_deploy_desc_handler
 from paasng.platform.engine.configurations.config_var import get_preset_env_variables
 from paasng.platform.modules.models.module import Module
 
@@ -95,21 +91,22 @@ def yaml_v3_normal() -> str:
     )
 
 
-class Test__get_desc_handler:
+class Test__get_deploy_desc_handler:
     """Test cases for `get_desc_handler()` function"""
 
     @pytest.mark.parametrize(
-        ("yaml_fixture_name", "expected_type"),
+        ("yaml_fixture_name", "expected_name"),
         [
-            ("yaml_v1_normal", SMartDescriptionHandler),
-            ("yaml_v2_normal", AppDescriptionHandler),
-            ("yaml_v3_normal", CNativeAppDescriptionHandler),
+            ("yaml_v1_normal", "deploy_desc_getter_v1"),
+            ("yaml_v2_normal", "deploy_desc_getter_v2"),
+            ("yaml_v3_normal", "deploy_desc_getter_v3"),
         ],
     )
-    def test_v1(self, yaml_fixture_name, expected_type, request):
+    def test_desc_getter_name(self, yaml_fixture_name, expected_name, request):
         _yaml_content = request.getfixturevalue(yaml_fixture_name)
-        handler = get_desc_handler(yaml.safe_load(_yaml_content))
-        assert isinstance(handler, expected_type)
+        handler = get_deploy_desc_handler(yaml.safe_load(_yaml_content))
+        assert hasattr(handler, "desc_getter")
+        assert handler.desc_getter.__name__ == expected_name
 
 
 class TestAppDescriptionHandler:
@@ -127,7 +124,7 @@ class TestAppDescriptionHandler:
         with mock.patch(
             "paasng.platform.declarative.handlers.DeploymentDeclarativeController._update_bkmonitor"
         ) as update_bkmonitor:
-            get_desc_handler(yaml.safe_load(yaml_v2_normal)).handle_deployment(bk_deployment)
+            get_deploy_desc_handler(yaml.safe_load(yaml_v2_normal)).handle(bk_deployment)
 
             assert get_preset_env_variables(bk_deployment.app_environment) == {"FOO": "1"}
             assert get_svc_disc_as_env_variables(bk_deployment.app_environment) == {
@@ -156,6 +153,64 @@ class TestAppDescriptionHandler:
             assert update_bkmonitor.called
             assert cattr.unstructure(update_bkmonitor.call_args[0][0]) == {"port": 80, "target_port": 80}
 
+    def test_desc_and_procfile_same(self, bk_module, bk_deployment):
+        content = dedent(
+            """
+            spec_version: 2
+            module:
+                language: python
+                processes:
+                    web:
+                      command: python manage.py runserver
+                      replicas: 3
+            """
+        )
+        handler = get_deploy_desc_handler(yaml.safe_load(content), procfile_data={"web": "python manage.py runserver"})
+        ret = handler.handle(bk_deployment)
+
+        assert query_proc_dict(bk_module) == {"web": ("python manage.py runserver", 3)}
+        assert ret.processes
+        assert len(ret.processes) == 1
+
+    def test_desc_and_procfile_different(self, bk_module, bk_deployment):
+        content = dedent(
+            """
+            spec_version: 2
+            module:
+                language: python
+                processes:
+                    web:
+                      command: python manage.py runserver
+                      replicas: 3
+            """
+        )
+        handler = get_deploy_desc_handler(
+            yaml.safe_load(content), procfile_data={"web": "gunicorn app", "worker": "celery"}
+        )
+        ret = handler.handle(bk_deployment)
+
+        assert query_proc_dict(bk_module) == {"web": ("gunicorn app", 1), "worker": ("celery", 1)}
+        assert ret.processes
+        assert len(ret.processes) == 2
+
+    def test_procfile_only(self, bk_module, bk_deployment):
+        handler = get_deploy_desc_handler(None, procfile_data={"web": "gunicorn app", "worker": "celery"})
+        ret = handler.handle(bk_deployment)
+
+        assert query_proc_dict(bk_module) == {"web": ("gunicorn app", 1), "worker": ("celery", 1)}
+        assert ret.processes
+        assert len(ret.processes) == 2
+
+    def test_invalid_desc_and_valid_procfile(self, bk_module, bk_deployment):
+        handler = get_deploy_desc_handler(
+            {"not": "valid yaml"}, procfile_data={"web": "gunicorn app", "worker": "celery"}
+        )
+        ret = handler.handle(bk_deployment, ignore_invalid_desc=True)
+
+        assert query_proc_dict(bk_module) == {"web": ("gunicorn app", 1), "worker": ("celery", 1)}
+        assert ret.processes
+        assert len(ret.processes) == 2
+
     def test_with_modules_found(self, bk_deployment, bk_module):
         _yaml_content = dedent(
             f"""\
@@ -165,7 +220,7 @@ class TestAppDescriptionHandler:
                     language: python
         """
         )
-        get_desc_handler(yaml.safe_load(_yaml_content)).handle_deployment(bk_deployment)
+        get_deploy_desc_handler(yaml.safe_load(_yaml_content)).handle(bk_deployment)
 
     def test_with_modules_not_found(self, bk_deployment):
         _yaml_content = dedent(
@@ -177,7 +232,7 @@ class TestAppDescriptionHandler:
         """
         )
         with pytest.raises(DescriptionValidationError, match="未找到.*当前已配置"):
-            get_desc_handler(yaml.safe_load(_yaml_content)).handle_deployment(bk_deployment)
+            get_deploy_desc_handler(yaml.safe_load(_yaml_content)).handle(bk_deployment)
 
     def test_with_modules_not_found_fallback_to_module(self, bk_deployment):
         _yaml_content = dedent(
@@ -190,7 +245,7 @@ class TestAppDescriptionHandler:
                 language: python
         """
         )
-        get_desc_handler(yaml.safe_load(_yaml_content)).handle_deployment(bk_deployment)
+        get_deploy_desc_handler(yaml.safe_load(_yaml_content)).handle(bk_deployment)
 
     def test_with_module(self, bk_deployment):
         _yaml_content = dedent(
@@ -200,7 +255,7 @@ class TestAppDescriptionHandler:
                 language: python
         """
         )
-        get_desc_handler(yaml.safe_load(_yaml_content)).handle_deployment(bk_deployment)
+        get_deploy_desc_handler(yaml.safe_load(_yaml_content)).handle(bk_deployment)
 
     def test_with_module_and_modules_missing(self, bk_deployment):
         _yaml_content = dedent(
@@ -210,4 +265,12 @@ class TestAppDescriptionHandler:
         """
         )
         with pytest.raises(DescriptionValidationError, match="配置内容不能为空"):
-            get_desc_handler(yaml.safe_load(_yaml_content)).handle_deployment(bk_deployment)
+            get_deploy_desc_handler(yaml.safe_load(_yaml_content)).handle(bk_deployment)
+
+
+def query_proc_dict(module: Module) -> Dict[str, Tuple[str, int]]:
+    """A helper function that queries module's all process specs for comparison."""
+    proc_dict = {}
+    for p in ModuleProcessSpec.objects.filter(module=module):
+        proc_dict[p.name] = (p.proc_command, p.target_replicas)
+    return proc_dict

--- a/apiserver/paasng/tests/paasng/platform/declarative/handlers/v2/test_deployment.py
+++ b/apiserver/paasng/tests/paasng/platform/declarative/handlers/v2/test_deployment.py
@@ -125,7 +125,7 @@ class TestAppDescriptionHandler:
         """Handle a normal YAML content."""
 
         with mock.patch(
-            "paasng.platform.declarative.handlers.DeploymentDeclarativeController.update_bkmonitor"
+            "paasng.platform.declarative.handlers.DeploymentDeclarativeController._update_bkmonitor"
         ) as update_bkmonitor:
             get_desc_handler(yaml.safe_load(yaml_v2_normal)).handle_deployment(bk_deployment)
 

--- a/apiserver/paasng/tests/paasng/platform/declarative/handlers/v3/test_deployment.py
+++ b/apiserver/paasng/tests/paasng/platform/declarative/handlers/v3/test_deployment.py
@@ -75,7 +75,7 @@ def yaml_v3_example() -> str:
 class TestCnativeAppDescriptionHandler:
     def test_handle_deployment_normal(self, bk_deployment, yaml_v3_example):
         with mock.patch(
-            "paasng.platform.declarative.handlers.DeploymentDeclarativeController.update_bkmonitor"
+            "paasng.platform.declarative.handlers.DeploymentDeclarativeController._update_bkmonitor"
         ) as update_bkmonitor:
             handler = get_desc_handler(yaml.safe_load(yaml_v3_example))
 

--- a/apiserver/paasng/tests/paasng/platform/declarative/handlers/v3/test_deployment.py
+++ b/apiserver/paasng/tests/paasng/platform/declarative/handlers/v3/test_deployment.py
@@ -18,6 +18,7 @@
 import base64
 import json
 from textwrap import dedent
+from typing import Dict, Tuple
 from unittest import mock
 
 import pytest
@@ -27,9 +28,10 @@ from paas_wl.bk_app.cnative.specs.constants import PROC_SERVICES_ENABLED_ANNOTAT
 from paasng.platform.bkapp_model.entities import ProcService
 from paasng.platform.bkapp_model.models import ModuleProcessSpec, get_svc_disc_as_env_variables
 from paasng.platform.declarative.exceptions import DescriptionValidationError
-from paasng.platform.declarative.handlers import get_desc_handler
+from paasng.platform.declarative.handlers import get_deploy_desc_handler
 from paasng.platform.declarative.models import DeploymentDescription
 from paasng.platform.engine.configurations.config_var import get_preset_env_variables
+from paasng.platform.modules.models.module import Module
 
 pytestmark = pytest.mark.django_db(databases=["default", "workloads"])
 
@@ -73,16 +75,13 @@ def yaml_v3_example() -> str:
 
 
 class TestCnativeAppDescriptionHandler:
-    def test_handle_deployment_normal(self, bk_deployment, yaml_v3_example):
+    def test_handle_normal(self, bk_module, bk_deployment, yaml_v3_example):
         with mock.patch(
             "paasng.platform.declarative.handlers.DeploymentDeclarativeController._update_bkmonitor"
         ) as update_bkmonitor:
-            handler = get_desc_handler(yaml.safe_load(yaml_v3_example))
+            handler = get_deploy_desc_handler(yaml.safe_load(yaml_v3_example))
 
-            handler.handle_deployment(bk_deployment)
-
-            deploy_desc = handler.get_deploy_desc(bk_deployment.app_environment.module.name)
-            assert deploy_desc.get_procfile() == {"web": "python manage.py runserver"}
+            handler.handle(bk_deployment)
 
             assert bk_deployment.hooks[0].command == []
             assert bk_deployment.hooks[0].args == ["python", "manage.py", "migrate"]
@@ -115,6 +114,8 @@ class TestCnativeAppDescriptionHandler:
                 ).decode()
             }
 
+            assert query_proc_dict(bk_module) == {"web": ("python manage.py runserver", 1)}
+
             spec = ModuleProcessSpec.objects.get(module=bk_deployment.app_environment.module, name="web")
             assert spec.services == [
                 ProcService(
@@ -128,6 +129,17 @@ class TestCnativeAppDescriptionHandler:
             ]
 
             assert not update_bkmonitor.called
+
+    def test_desc_and_procfile_different(self, bk_module, bk_deployment, yaml_v3_example):
+        with mock.patch("paasng.platform.declarative.handlers.DeploymentDeclarativeController._update_bkmonitor"):
+            handler = get_deploy_desc_handler(
+                yaml.safe_load(yaml_v3_example), procfile_data={"worker": "celery worker"}
+            )
+
+            handler.handle(bk_deployment)
+
+            # Should use the process data in procfile when conflicts
+            assert query_proc_dict(bk_module) == {"worker": ("celery worker", 1)}
 
     def test_with_modules_found(self, bk_deployment, bk_module):
         _yaml_content = dedent(
@@ -143,7 +155,7 @@ class TestCnativeAppDescriptionHandler:
                       procCommand: python manage.py runserver
         """
         )
-        get_desc_handler(yaml.safe_load(_yaml_content)).handle_deployment(bk_deployment)
+        get_deploy_desc_handler(yaml.safe_load(_yaml_content)).handle(bk_deployment)
 
     def test_with_modules_not_found(self, bk_deployment):
         _yaml_content = dedent(
@@ -160,7 +172,15 @@ class TestCnativeAppDescriptionHandler:
         """
         )
         with pytest.raises(DescriptionValidationError, match="未找到.*当前已配置"):
-            get_desc_handler(yaml.safe_load(_yaml_content)).handle_deployment(bk_deployment)
+            get_deploy_desc_handler(yaml.safe_load(_yaml_content)).handle(bk_deployment)
 
     # Other tests that cover different cases when modules/module field uses different values
     # share similar logic with TestAppDescriptionHandler, no need to duplicate in here.
+
+
+def query_proc_dict(module: Module) -> Dict[str, Tuple[str, int]]:
+    """A helper function to query module's all process specs for comparison."""
+    proc_dict = {}
+    for p in ModuleProcessSpec.objects.filter(module=module):
+        proc_dict[p.name] = (p.proc_command, p.target_replicas)
+    return proc_dict

--- a/apiserver/paasng/tests/paasng/platform/engine/deploy/test_building.py
+++ b/apiserver/paasng/tests/paasng/platform/engine/deploy/test_building.py
@@ -64,11 +64,11 @@ class TestNormalApp:
             assert "[Procfile] Invalid Procfile format" in deployment.err_detail
 
             assert mocked_stream().write_title.called
-            assert mocked_stream().write_title.call_args[0][0] == "正在解析应用描述文件"
+            assert mocked_stream().write_title.call_args[0][0] == "正在解析应用进程信息"
             assert mocked_stream().write_message.called
             assert (
                 mocked_stream().write_message.call_args[0][0]
-                == "步骤 [解析应用描述文件] 出错了，原因：处理应用描述文件失败：[app_desc] unknown; [Procfile] Invalid Procfile format。"
+                == "步骤 [解析应用进程信息] 出错了，原因：处理应用描述文件失败：[app_desc] unknown; [Procfile] Invalid Procfile format。"
             )
 
     def test_failed_when_upload_source(self, builder_class, bk_deployment_full):

--- a/apiserver/paasng/tests/paasng/platform/engine/deploy/test_building.py
+++ b/apiserver/paasng/tests/paasng/platform/engine/deploy/test_building.py
@@ -23,6 +23,7 @@ from blue_krill.async_utils.poll_task import CallbackResult, CallbackStatus
 
 from paas_wl.bk_app.cnative.specs.models import AppModelResource, create_app_resource
 from paas_wl.core.resource import generate_bkapp_name
+from paasng.platform.declarative.handlers import get_deploy_desc_handler
 from paasng.platform.engine.constants import JobStatus
 from paasng.platform.engine.deploy.building import ApplicationBuilder, BuildProcessResultHandler, DockerBuilder
 from paasng.platform.engine.handlers import attach_all_phases
@@ -44,7 +45,7 @@ class TestNormalApp:
         with mock.patch(
             "paasng.platform.engine.configurations.source_file.MetaDataFileReader.get_app_desc"
         ) as mocked_get_app_yaml:
-            mocked_get_app_yaml.side_effect = GetAppYamlError("")
+            mocked_get_app_yaml.side_effect = GetAppYamlError("unknown")
             yield
 
     def test_failed_when_parsing_processes(self, builder_class, bk_deployment_full):
@@ -60,14 +61,14 @@ class TestNormalApp:
 
             deployment = Deployment.objects.get(pk=bk_deployment_full.id)
             assert deployment.status == JobStatus.FAILED.value
-            assert deployment.err_detail == "Procfile error: Invalid Procfile format"
+            assert "[Procfile] Invalid Procfile format" in deployment.err_detail
 
             assert mocked_stream().write_title.called
-            assert mocked_stream().write_title.call_args[0][0] == "正在解析应用进程信息"
+            assert mocked_stream().write_title.call_args[0][0] == "正在解析应用描述文件"
             assert mocked_stream().write_message.called
             assert (
                 mocked_stream().write_message.call_args[0][0]
-                == "步骤 [解析应用进程信息] 出错了，原因：Procfile error: Invalid Procfile format。"
+                == "步骤 [解析应用描述文件] 出错了，原因：处理应用描述文件失败：app_desc: unknown, Procfile: Invalid Procfile format。"
             )
 
     def test_failed_when_upload_source(self, builder_class, bk_deployment_full):
@@ -156,9 +157,11 @@ class TestCloudNative:
         )
 
     def test_start_build(self, builder_class, bk_cnative_app, bk_module_full, bk_deployment_full, model_resource):
+        # Replace the deploy desc handler to skip the metadata reading action
+        desc_handler = get_deploy_desc_handler(None, {"web": "gunicorn"})
         with mock.patch(
-            "paasng.platform.engine.utils.source.get_metadata_reader",
-        ), mock.patch.object(builder_class, "handle_app_description"), mock.patch(
+            "paasng.platform.engine.deploy.building.get_deploy_desc_handler_by_version", return_value=desc_handler
+        ), mock.patch(
             "paasng.platform.engine.deploy.building.{}.compress_and_upload".format(builder_class.__name__)
         ), mock.patch("paasng.platform.engine.deploy.building.BuildProcessPoller") as mocked_poller, mock.patch(
             "paasng.platform.engine.utils.output.RedisChannelStream"

--- a/apiserver/paasng/tests/paasng/platform/engine/deploy/test_building.py
+++ b/apiserver/paasng/tests/paasng/platform/engine/deploy/test_building.py
@@ -68,7 +68,7 @@ class TestNormalApp:
             assert mocked_stream().write_message.called
             assert (
                 mocked_stream().write_message.call_args[0][0]
-                == "步骤 [解析应用描述文件] 出错了，原因：处理应用描述文件失败：app_desc: unknown, Procfile: Invalid Procfile format。"
+                == "步骤 [解析应用描述文件] 出错了，原因：处理应用描述文件失败：[app_desc] unknown; [Procfile] Invalid Procfile format。"
             )
 
     def test_failed_when_upload_source(self, builder_class, bk_deployment_full):

--- a/apiserver/paasng/tests/paasng/platform/engine/utils/test_source.py
+++ b/apiserver/paasng/tests/paasng/platform/engine/utils/test_source.py
@@ -22,27 +22,20 @@ from unittest import mock
 import cattr
 import pytest
 import yaml
-from django.conf import settings
 from django.test.utils import override_settings
 from django_dynamic_fixture import G
 
-from paasng.platform.declarative.constants import CELERY_BEAT_PROCESS, CELERY_PROCESS, WEB_PROCESS
+from paasng.platform.declarative.constants import WEB_PROCESS
 from paasng.platform.declarative.deployment.controller import DeploymentDescription
-from paasng.platform.declarative.handlers import get_desc_handler
-from paasng.platform.engine.exceptions import DeployShouldAbortError
 from paasng.platform.engine.models import Deployment
 from paasng.platform.engine.utils.output import ConsoleStream
 from paasng.platform.engine.utils.source import (
     TypeProcesses,
     check_source_package,
     download_source_to_dir,
-    get_app_description_handler,
-    get_processes,
     get_source_package_path,
 )
 from paasng.platform.modules.constants import SourceOrigin
-from paasng.platform.sourcectl.exceptions import DoesNotExistsOnServer
-from paasng.platform.sourcectl.models import SourcePackage
 from paasng.platform.sourcectl.utils import generate_temp_dir, generate_temp_file
 
 pytestmark = pytest.mark.django_db(databases=["default", "workloads"])
@@ -53,227 +46,6 @@ def cast_to_processes(obj: Dict[str, Dict[str, Any]]) -> TypeProcesses:
 
 
 EXPECTED_WEB_PROCESS = WEB_PROCESS
-
-
-@pytest.mark.usefixtures("_init_tmpls")
-class TestGetProcesses:
-    """Test get_procfile()"""
-
-    @pytest.mark.parametrize(
-        ("file_content", "error_pattern"),
-        [
-            (ValueError("trivial value error"), "Can not read Procfile file from repository"),
-            ("invalid#$type: gunicorn\n", "pattern"),
-            ("{}: gunicorn\n".format("p" * 13), "longer than"),
-            ("WEB: gunicorn wsgi -w 4\nworker: celery", "pattern"),
-        ],
-    )
-    def test_invalid_procfile_cases(self, file_content, error_pattern, bk_module_full, bk_deployment_full):
-        def fake_read_file(key, version):
-            if "Procfile" in key:
-                if isinstance(file_content, Exception):
-                    raise file_content
-                return file_content
-            raise DoesNotExistsOnServer
-
-        with mock.patch("paasng.platform.sourcectl.type_specs.SvnRepoController.read_file") as mocked_read_file:
-            mocked_read_file.side_effect = fake_read_file
-            with pytest.raises(DeployShouldAbortError) as exc_info:
-                get_processes(deployment=bk_deployment_full)
-
-            assert error_pattern in str(exc_info)
-
-    def test_valid_procfile_cases(self, bk_module_full, bk_deployment_full):
-        def fake_read_file(key, version):
-            if "Procfile" in key:
-                return "web: gunicorn wsgi -w 4\nworker: celery"
-            raise DoesNotExistsOnServer
-
-        with mock.patch("paasng.platform.sourcectl.type_specs.SvnRepoController.read_file") as mocked_read_file:
-            mocked_read_file.side_effect = fake_read_file
-            processes = get_processes(bk_deployment_full)
-            assert processes == cast_to_processes(
-                {
-                    "web": {"name": "web", "command": "gunicorn wsgi -w 4"},
-                    "worker": {"name": "worker", "command": "celery"},
-                }
-            )
-
-    @pytest.mark.parametrize(
-        ("extra_info", "expected"),
-        [
-            (
-                {},
-                cast_to_processes({"web": {"name": "web", "command": EXPECTED_WEB_PROCESS, "replicas": 1}}),
-            ),
-            (
-                {"is_use_celery": True},
-                cast_to_processes(
-                    {
-                        "web": {"name": "web", "command": EXPECTED_WEB_PROCESS, "replicas": 1},
-                        "celery": {"name": "celery", "command": CELERY_PROCESS, "replicas": 1},
-                    }
-                ),
-            ),
-            (
-                {"is_use_celery": True, "is_use_celery_beat": True},
-                cast_to_processes(
-                    {
-                        "web": {"name": "web", "command": EXPECTED_WEB_PROCESS, "replicas": 1},
-                        "celery": {"name": "celery", "command": CELERY_PROCESS, "replicas": 1},
-                        "beat": {"name": "beat", "command": CELERY_BEAT_PROCESS, "replicas": 1},
-                    }
-                ),
-            ),
-        ],
-    )
-    def test_v1_app_desc_cases(self, extra_info, expected, bk_app_full, bk_module_full, bk_deployment_full):
-        app_desc = {
-            "app_code": bk_app_full.code,
-            "app_name": bk_app_full.name,
-            "author": "blueking",
-            "introduction": "blueking app",
-            "is_use_celery": False,
-            "version": "0.0.1",
-            "env": [],
-            **extra_info,
-        }
-        perform_result = get_desc_handler(app_desc).handle_deployment(bk_deployment_full)
-        processes = get_processes(deployment=bk_deployment_full, proc_data_from_desc=perform_result.loaded_processes)
-        assert processes == expected
-
-    @pytest.mark.parametrize(
-        ("processes_desc", "expected"),
-        [
-            (
-                {"web": {"command": "start web"}},
-                cast_to_processes({"web": {"name": "web", "command": "start web", "replicas": None}}),
-            ),
-            (
-                {"web": {"command": "start web", "replicas": 1}},
-                cast_to_processes({"web": {"name": "web", "command": "start web", "replicas": 1}}),
-            ),
-            (
-                {
-                    "web": {"command": "start web", "replicas": 5, "plan": "4C2G5R"},
-                    "celery": {"command": "start celery", "replicas": 5},
-                },
-                cast_to_processes(
-                    {
-                        "web": {"name": "web", "command": "start web", "replicas": 5, "plan": "4C2G"},
-                        "celery": {"name": "celery", "command": "start celery", "replicas": 5},
-                    }
-                ),
-            ),
-        ],
-    )
-    def test_v2_app_desc_cases(self, processes_desc, expected, bk_app_full, bk_module_full, bk_deployment_full):
-        app_desc = {
-            "spec_version": 2,
-            "region": settings.DEFAULT_REGION_NAME,
-            "bk_app_code": bk_app_full.code,
-            "bk_app_name": bk_app_full.name,
-            "market": {"introduction": "应用简介", "display_options": {"open_mode": "desktop"}},
-            "module": {"is_default": True, "processes": processes_desc, "language": "python"},
-        }
-        perform_result = get_desc_handler(app_desc).handle_deployment(bk_deployment_full)
-        processes = get_processes(deployment=bk_deployment_full, proc_data_from_desc=perform_result.loaded_processes)
-        assert processes == expected
-
-    def test_metadata_in_package(self, bk_app_full, bk_module_full, bk_deployment_full):
-        """s-mart case: 当处理 app_desc 后, 从源码包读取进程包含进程启动命令、方案、副本数等信息"""
-        bk_module_full.source_origin = SourceOrigin.S_MART
-        bk_module_full.save()
-
-        G(
-            SourcePackage,
-            module=bk_module_full,
-            version=bk_deployment_full.version_info.revision,
-            meta_info={
-                "spec_version": 2,
-                "region": settings.DEFAULT_REGION_NAME,
-                "bk_app_code": bk_app_full.code,
-                "bk_app_name": bk_app_full.name,
-                "market": {"introduction": "应用简介", "display_options": {"open_mode": "desktop"}},
-                "module": {
-                    "is_default": True,
-                    "processes": {"web": {"command": "start web", "plan": "default", "replicas": 5}},
-                    "language": "python",
-                },
-            },
-        )
-
-        handler = get_app_description_handler(
-            module=bk_module_full, operator=bk_module_full.owner, version_info=bk_deployment_full.version_info
-        )
-        assert handler is not None
-        perform_result = handler.handle_deployment(bk_deployment_full)
-
-        processes = get_processes(deployment=bk_deployment_full, proc_data_from_desc=perform_result.loaded_processes)
-        assert processes == cast_to_processes(
-            {"web": {"name": "web", "command": "start web", "plan": "default", "replicas": 5}}
-        )
-
-    def test_get_from_metadata_in_package(self, bk_app_full, bk_module_full, bk_deployment_full):
-        """lesscode case: 当未处理 app_desc 时, 从源码包读取进程仅包含进程启动命令信息"""
-        bk_module_full.source_origin = SourceOrigin.S_MART
-        bk_module_full.save()
-
-        G(
-            SourcePackage,
-            module=bk_module_full,
-            version=bk_deployment_full.version_info.revision,
-            meta_info={
-                "spec_version": 2,
-                "region": settings.DEFAULT_REGION_NAME,
-                "bk_app_code": bk_app_full.code,
-                "bk_app_name": bk_app_full.name,
-                "market": {"introduction": "应用简介", "display_options": {"open_mode": "desktop"}},
-                "module": {
-                    "is_default": True,
-                    "processes": {"web": {"command": "start web", "plan": "default"}},
-                    "language": "python",
-                },
-            },
-        )
-
-        processes = get_processes(deployment=bk_deployment_full)
-        assert processes == cast_to_processes({"web": {"name": "web", "command": "start web"}})
-
-    def test_both_app_description_and_procfile(self, bk_app_full, bk_module_full, bk_deployment_full):
-        """应用描述文件和 Procfile 同时定义, 以 Procfile 为准"""
-        app_desc = {
-            "spec_version": 2,
-            "region": settings.DEFAULT_REGION_NAME,
-            "bk_app_code": bk_app_full.code,
-            "bk_app_name": bk_app_full.name,
-            "market": {"introduction": "应用简介", "display_options": {"open_mode": "desktop"}},
-            "module": {
-                "is_default": True,
-                "processes": {"web": {"command": "gunicorn wsgi -w 4"}},
-                "language": "python",
-            },
-        }
-        perform_result = get_desc_handler(app_desc).handle_deployment(bk_deployment_full)
-
-        def fake_read_file(key, version):
-            if "Procfile" in key:
-                return "web: gunicorn wsgi -w 4\nworker: celery"
-            raise DoesNotExistsOnServer
-
-        with mock.patch("paasng.platform.sourcectl.type_specs.SvnRepoController.read_file") as mocked_read_file:
-            mocked_read_file.side_effect = fake_read_file
-
-            processes = get_processes(
-                deployment=bk_deployment_full, proc_data_from_desc=perform_result.loaded_processes
-            )
-
-        assert processes == cast_to_processes(
-            {
-                "web": {"name": "web", "command": "gunicorn wsgi -w 4"},
-                "worker": {"name": "worker", "command": "celery"},
-            }
-        )
 
 
 class TestGetSourcePackagePath:

--- a/apiserver/paasng/tests/paasng/platform/smart_app/test_patcher.py
+++ b/apiserver/paasng/tests/paasng/platform/smart_app/test_patcher.py
@@ -23,7 +23,6 @@ import yaml
 from blue_krill.contextlib import nullcontext as does_not_raise
 
 from paasng.platform.declarative import constants
-from paasng.platform.declarative.handlers import get_desc_handler
 from paasng.platform.modules.constants import SourceOrigin
 from paasng.platform.smart_app.services.detector import SourcePackageStatReader
 from paasng.platform.smart_app.services.patcher import SourceCodePatcher
@@ -67,7 +66,7 @@ class TestSourcePackagePatcher:
         patcher = SourceCodePatcher(
             module=bk_module_full,
             source_dir=LocalFSPath(tmp_path),
-            desc_handler=get_desc_handler(stat.meta_info),
+            desc_data=stat.meta_info,
             relative_path=stat.relative_path,
         )
         with mock.patch.object(patcher, "get_user_source_dir", return_value=user_source_dir):


### PR DESCRIPTION
主要改动点：

- 优化部署流程与进程数据数据：将使用 declarative 解析“应用描述文件”变成必须步骤，同时把 Procfile 一并纳入解析流程中，以此简化当前部署流程中的多次“获取与对比”进程逻辑（`get_processes()`、对比与 sync 等），使进程数据在部署阶段一次性完成解析和数据持久化；
- 重构 declarative 模块：把 `handle_deployment()` 逻辑从现有 AppDescriptionHandler 中拆除，变为独立抽象；提升 `DeploymentDeclarativeController` 可读性并让它可以同时处理 procfile 数据；

已测试：

- 所有单测用例；
- 实际部署这些情况的应用：仅提供 app_desc、仅提供 procfile、二者都不提供、二者都提供并且进程数据冲突、app_desc 数据有误但 procfile 数据正常；

未测试存疑：

- ImageReleaseMgr 中的 S-Mart 应用分支逻辑
- 旧代码 `building.py` 中获取 desc_handler 后判断 `or not isinstance(handler, (AppDescriptionHandler, CNativeAppDescriptionHandler))`，用途存疑
    - 相关代码：`"Currently only runtime configs such as environment variables declared in app_desc.yaml are applied."`