### PR TITLE
fix: 修复日志相关 Sentry 异常

### DIFF
--- a/apiserver/paasng/paasng/accessories/log/constants.py
+++ b/apiserver/paasng/paasng/accessories/log/constants.py
@@ -22,6 +22,10 @@ DEFAULT_LOG_CONFIG_PLACEHOLDER = "-"
 # 默认查询日志的分片大小
 DEFAULT_LOG_BATCH_SIZE = 200
 
+# ES 查询的最大窗口，可在 ES 中配置，但不建议调大，容易导致 ES oom
+# 日志平台最多也只返回 10,000 条数据，且不可修改
+MAX_RESULT_WINDOW = 10000
+
 
 class LogTimeChoices(str, StructuredEnum):
     """日志搜索-日期范围可选值"""

--- a/apiserver/paasng/paasng/accessories/log/serializers.py
+++ b/apiserver/paasng/paasng/accessories/log/serializers.py
@@ -116,11 +116,11 @@ class LogFieldFilterSLZ(serializers.Serializer):
 
 class LogQueryParamsSLZ(serializers.Serializer):
     """查询日志的 query 参数，包含：
-    - 结构化日志：需要分页
-    - 访问日志：需要分页
-    - 标准输出日志：不需要分页
-    - 日志事件直方图：不需要分页
-    - 日志字段统计：不需要分页
+    - 结构化日志
+    - 访问日志
+    - 标准输出日志
+    - 日志事件直方图
+    - 日志字段统计
     """
 
     time_range = serializers.ChoiceField(choices=LogTimeChoices.get_choices(), required=True)

--- a/apiserver/paasng/paasng/accessories/log/views/logs.py
+++ b/apiserver/paasng/paasng/accessories/log/views/logs.py
@@ -35,7 +35,7 @@ from rest_framework.viewsets import ViewSet
 
 from paasng.accessories.log import serializers
 from paasng.accessories.log.client import instantiate_log_client
-from paasng.accessories.log.constants import DEFAULT_LOG_BATCH_SIZE, LogType
+from paasng.accessories.log.constants import DEFAULT_LOG_BATCH_SIZE, MAX_RESULT_WINDOW, LogType
 from paasng.accessories.log.dsl import SearchRequestSchema
 from paasng.accessories.log.exceptions import NoIndexError
 from paasng.accessories.log.filters import EnvFilter, ModuleFilter
@@ -219,6 +219,7 @@ class LogAPIView(LogBaseAPIView):
                 timeout=settings.DEFAULT_ES_SEARCH_TIMEOUT,
             )
         except RequestError:
+            logger.exception("failed to get logs")
             raise error_codes.QUERY_REQUEST_ERROR
         except Exception:
             logger.exception("failed to get logs")
@@ -229,6 +230,8 @@ class LogAPIView(LogBaseAPIView):
                 "logs": clean_logs(list(response), log_config.search_params),
                 "total": total,
                 "dsl": json.dumps(search.to_dict()),
+                # 前端使用该配置控制页面上展示的日志分页的最大页数
+                "max_result_window": MAX_RESULT_WINDOW,
             },
             Logs[self.line_model],  # type: ignore
         )

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/exceptions.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/exceptions.py
@@ -54,6 +54,8 @@ class ErrorCodes:
     QUERY_REPO_OVERVIEW_DATA_ERROR = ErrorCode(_("查询代码仓库概览数据异常"))
     # 日志查询异常
     QUERY_ES_ERROR = ErrorCode(_("日志系统异常, 请稍后重试"))
+    QUERY_LOG_FAILED = ErrorCode(_("查询日志失败"))
+    QUERY_REQUEST_ERROR = ErrorCode(_("查询日志失败，请检查查询条件"))
 
     # 可见范围修改失败
     VISIBLE_RANGE_UPDATE_FAIELD = ErrorCode(_("可见范围修改失败"))

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/__init__.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/__init__.py
@@ -25,6 +25,7 @@ from paasng.accessories.log.client import LogClientProtocol as BkSaaSLogClientPr
 from paasng.accessories.log.client import instantiate_log_client as instantiate_bksaas_log_client
 from paasng.accessories.log.constants import LogType
 from paasng.accessories.log.models import ProcessLogQueryConfig
+from paasng.accessories.log.shim import setup_env_log_model
 from paasng.bk_plugins.pluginscenter.definitions import ElasticSearchParams
 from paasng.bk_plugins.pluginscenter.log.client import (
     FieldBucketData,
@@ -250,6 +251,8 @@ def _instantiate_log_client(
         return log_client, search_params
     # 由于 bk-saas 接入了日志平台, 每个应用独立的日志查询配置, 因此需要访问 PaaS 的数据库获取配置信息
     env = Application.objects.get(code=instance.id).get_app_envs("prod")
+    # 初始化 env log 模型, 保证数据库对象存在且是 settings 中的最新配置
+    setup_env_log_model(env)
     if log_type == LogType.INGRESS:
         log_config = ProcessLogQueryConfig.objects.select_process_irrelevant(env).ingress
         search_params = log_config.search_params

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/__init__.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/__init__.py
@@ -250,7 +250,8 @@ def _instantiate_log_client(
             search_params = cast(ElasticSearchParams, pd.log_config.ingress)
         return log_client, search_params
     # 由于 bk-saas 接入了日志平台, 每个应用独立的日志查询配置, 因此需要访问 PaaS 的数据库获取配置信息
-    env = Application.objects.get(code=instance.id).get_app_envs("prod")
+    # 插件开发中心只部署主模块的生产环境
+    env = Application.objects.get(code=instance.id).envs.get(environment="prod", module__is_default=True)
     # 初始化 env log 模型, 保证数据库对象存在且是 settings 中的最新配置
     setup_env_log_model(env)
     if log_type == LogType.INGRESS:

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/client.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/client.py
@@ -14,7 +14,7 @@
 #
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
-
+import logging
 from functools import reduce
 from operator import add
 from typing import Dict, List, Protocol, Tuple
@@ -38,6 +38,8 @@ from paasng.bk_plugins.pluginscenter.thirdparty.utils import make_client
 from paasng.utils.es_log.misc import count_filters_options
 from paasng.utils.es_log.models import FieldFilter
 from paasng.utils.es_log.search import SmartSearch
+
+logger = logging.getLogger(__name__)
 
 
 class LogClientProtocol(Protocol):
@@ -115,7 +117,11 @@ class BKLogClient:
             data["bkdata_authentication_method"] = self.config.bkdataAuthenticationMethod
         if self.config.bkdataDataToken:
             data["bkdata_data_token"] = self.config.bkdataDataToken
-        return self.client.call(data=data, timeout=timeout)
+        resp = self.client.call(data=data, timeout=timeout)
+        if not resp.get("result"):
+            logger.error(f"query bk log error: {resp.get('message')}")
+            raise error_codes.QUERY_REQUEST_ERROR
+        return resp
 
 
 class ESLogClient:

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/client.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/client.py
@@ -34,6 +34,7 @@ from paasng.bk_plugins.pluginscenter.definitions import (
 )
 from paasng.bk_plugins.pluginscenter.exceptions import error_codes
 from paasng.bk_plugins.pluginscenter.log.constants import DEFAULT_LOG_BATCH_SIZE
+from paasng.bk_plugins.pluginscenter.log.exceptions import BkLogApiError
 from paasng.bk_plugins.pluginscenter.thirdparty.utils import make_client
 from paasng.utils.es_log.misc import count_filters_options
 from paasng.utils.es_log.models import FieldFilter
@@ -119,8 +120,8 @@ class BKLogClient:
             data["bkdata_data_token"] = self.config.bkdataDataToken
         resp = self.client.call(data=data, timeout=timeout)
         if not resp.get("result"):
-            logger.error(f"query bk log error: {resp.get('message')}")
-            raise error_codes.QUERY_REQUEST_ERROR
+            logger.error(f"query bk log error: {resp['message']}")
+            raise BkLogApiError(resp["message"])
         return resp
 
 

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/exceptions.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/log/exceptions.py
@@ -16,30 +16,6 @@
 # to the current version of the project delivered to anyone in the future.
 
 
-class LogQueryError(Exception):
-    def __init__(self, message):
-        super().__init__()
-        self.message = message
-
-
-class UnknownEngineAppNameError(Exception):
-    def __init__(self, message):
-        super().__init__()
-        self.message = message
-
-
-class LogLineInfoBrokenError(Exception):
-    """日志行关键信息缺失异常"""
-
-    def __init__(self, lacking_key: str):
-        self.message = f"log line lacking key info: {lacking_key}"
-        super().__init__(self.message)
-
-
-class NoIndexError(Exception):
-    """无可用 index"""
-
-
 class BkLogGatewayServiceError(Exception):
     """This error indicates that there's something wrong when operating bk_log's
     API Gateway resource. It's a wrapper class of API SDK's original exceptions

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/views.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/views.py
@@ -50,6 +50,7 @@ from paasng.bk_plugins.pluginscenter.itsm_adaptor.utils import (
     submit_create_approval_ticket,
     submit_visible_range_ticket,
 )
+from paasng.bk_plugins.pluginscenter.log.exceptions import BkLogApiError
 from paasng.bk_plugins.pluginscenter.models import (
     OperationRecord,
     PluginBasicInfoDefinition,
@@ -1004,8 +1005,8 @@ class PluginLogViewSet(PluginInstanceMixin, GenericViewSet):
                 limit=query_params["limit"],
                 offset=query_params["offset"],
             )
-        except RequestError as e:
-            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，故仅打 error 日志
+        except (RequestError, BkLogApiError) as e:
+            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，仅打 error 日志即可
             logger.error("request error when querying stdout log: %s", e)  # noqa: TRY400
             raise error_codes.QUERY_REQUEST_ERROR
         except Exception:
@@ -1042,8 +1043,8 @@ class PluginLogViewSet(PluginInstanceMixin, GenericViewSet):
                 limit=query_params["limit"],
                 offset=query_params["offset"],
             )
-        except RequestError as e:
-            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，故仅打 error 日志
+        except (RequestError, BkLogApiError) as e:
+            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，仅打 error 日志即可
             logger.error("request error when querying structure log: %s", e)  # noqa: TRY400
             raise error_codes.QUERY_REQUEST_ERROR
         except Exception:
@@ -1078,8 +1079,8 @@ class PluginLogViewSet(PluginInstanceMixin, GenericViewSet):
                 limit=query_params["limit"],
                 offset=query_params["offset"],
             )
-        except RequestError as e:
-            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，故仅打 error 日志
+        except (RequestError, BkLogApiError) as e:
+            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，仅打 error 日志即可
             logger.error("request error when querying ingress log: %s", e)  # noqa: TRY400
             raise error_codes.QUERY_REQUEST_ERROR
         except Exception:
@@ -1115,8 +1116,8 @@ class PluginLogViewSet(PluginInstanceMixin, GenericViewSet):
                 time_range=query_params["smart_time_range"],
                 query_string=data["query"]["query_string"],
             )
-        except RequestError as e:
-            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，故仅打 error 日志
+        except (RequestError, BkLogApiError) as e:
+            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，仅打 error 日志即可
             logger.error("failed to aggregate time-based histogram: %s", e)  # noqa: TRY400
             raise error_codes.QUERY_REQUEST_ERROR
         except Exception:
@@ -1154,8 +1155,8 @@ class PluginLogViewSet(PluginInstanceMixin, GenericViewSet):
                 terms=data["query"]["terms"],
                 exclude=data["query"]["exclude"],
             )
-        except RequestError as e:
-            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，故仅打 error 日志
+        except (RequestError, BkLogApiError) as e:
+            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，仅打 error 日志即可
             logger.error("request error when aggregating log fields: %s", e)  # noqa: TRY400
             raise error_codes.QUERY_REQUEST_ERROR
         except Exception:

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/views.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/views.py
@@ -26,6 +26,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 from drf_yasg.utils import swagger_auto_schema
+from elasticsearch.exceptions import RequestError
 from rest_framework import mixins, status
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.pagination import LimitOffsetPagination
@@ -993,15 +994,23 @@ class PluginLogViewSet(PluginInstanceMixin, GenericViewSet):
         slz.is_valid(raise_exception=True)
         query_params = slz.validated_data
 
-        logs = log_api.query_standard_output_logs(
-            pd=plugin.pd,
-            instance=plugin,
-            operator=request.user.username,
-            time_range=query_params["smart_time_range"],
-            query_string=data["query"]["query_string"],
-            limit=query_params["limit"],
-            offset=query_params["offset"],
-        )
+        try:
+            logs = log_api.query_standard_output_logs(
+                pd=plugin.pd,
+                instance=plugin,
+                operator=request.user.username,
+                time_range=query_params["smart_time_range"],
+                query_string=data["query"]["query_string"],
+                limit=query_params["limit"],
+                offset=query_params["offset"],
+            )
+        except RequestError as e:
+            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，故仅打 error 日志
+            logger.error("request error when querying stdout log: %s", e)  # noqa: TRY400
+            raise error_codes.QUERY_REQUEST_ERROR
+        except Exception:
+            logger.exception("Failed to query stdout log")
+            raise error_codes.QUERY_LOG_FAILED.f(_("查询标准输出日志失败，请稍后再试。"))
         return Response(data=serializers.StandardOutputLogsSLZ(logs).data)
 
     @swagger_auto_schema(
@@ -1021,17 +1030,25 @@ class PluginLogViewSet(PluginInstanceMixin, GenericViewSet):
         slz.is_valid(raise_exception=True)
         query_params = slz.validated_data
 
-        logs = log_api.query_structure_logs(
-            pd=plugin.pd,
-            instance=plugin,
-            operator=request.user.username,
-            time_range=query_params["smart_time_range"],
-            query_string=data["query"]["query_string"],
-            terms=data["query"]["terms"],
-            exclude=data["query"]["exclude"],
-            limit=query_params["limit"],
-            offset=query_params["offset"],
-        )
+        try:
+            logs = log_api.query_structure_logs(
+                pd=plugin.pd,
+                instance=plugin,
+                operator=request.user.username,
+                time_range=query_params["smart_time_range"],
+                query_string=data["query"]["query_string"],
+                terms=data["query"]["terms"],
+                exclude=data["query"]["exclude"],
+                limit=query_params["limit"],
+                offset=query_params["offset"],
+            )
+        except RequestError as e:
+            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，故仅打 error 日志
+            logger.error("request error when querying structure log: %s", e)  # noqa: TRY400
+            raise error_codes.QUERY_REQUEST_ERROR
+        except Exception:
+            logger.exception("Failed to query structure log")
+            raise error_codes.QUERY_LOG_FAILED.f(_("查询结构化日志失败，请稍后再试。"))
         return Response(data=serializers.StructureLogsSLZ(logs).data)
 
     @swagger_auto_schema(
@@ -1051,15 +1068,23 @@ class PluginLogViewSet(PluginInstanceMixin, GenericViewSet):
         slz.is_valid(raise_exception=True)
         query_params = slz.validated_data
 
-        logs = log_api.query_ingress_logs(
-            pd=plugin.pd,
-            instance=plugin,
-            operator=request.user.username,
-            time_range=query_params["smart_time_range"],
-            query_string=data["query"]["query_string"],
-            limit=query_params["limit"],
-            offset=query_params["offset"],
-        )
+        try:
+            logs = log_api.query_ingress_logs(
+                pd=plugin.pd,
+                instance=plugin,
+                operator=request.user.username,
+                time_range=query_params["smart_time_range"],
+                query_string=data["query"]["query_string"],
+                limit=query_params["limit"],
+                offset=query_params["offset"],
+            )
+        except RequestError as e:
+            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，故仅打 error 日志
+            logger.error("request error when querying ingress log: %s", e)  # noqa: TRY400
+            raise error_codes.QUERY_REQUEST_ERROR
+        except Exception:
+            logger.exception("Failed to query ingress log")
+            raise error_codes.QUERY_LOG_FAILED.f(_("查询访问日志失败，请稍后再试。"))
         return Response(data=serializers.IngressLogSLZ(logs).data)
 
     @swagger_auto_schema(
@@ -1081,14 +1106,22 @@ class PluginLogViewSet(PluginInstanceMixin, GenericViewSet):
         slz.is_valid(raise_exception=True)
         query_params = slz.validated_data
 
-        date_histogram = log_api.aggregate_date_histogram(
-            pd=plugin.pd,
-            instance=plugin,
-            log_type=log_type,
-            operator=request.user.username,
-            time_range=query_params["smart_time_range"],
-            query_string=data["query"]["query_string"],
-        )
+        try:
+            date_histogram = log_api.aggregate_date_histogram(
+                pd=plugin.pd,
+                instance=plugin,
+                log_type=log_type,
+                operator=request.user.username,
+                time_range=query_params["smart_time_range"],
+                query_string=data["query"]["query_string"],
+            )
+        except RequestError as e:
+            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，故仅打 error 日志
+            logger.error("failed to aggregate time-based histogram: %s", e)  # noqa: TRY400
+            raise error_codes.QUERY_REQUEST_ERROR
+        except Exception:
+            logger.exception("failed to aggregate time-based histogram")
+            raise error_codes.QUERY_LOG_FAILED.f(_("聚合时间直方图失败，请稍后再试。"))
         return Response(data=serializers.DateHistogramSLZ(date_histogram).data)
 
     @swagger_auto_schema(
@@ -1099,7 +1132,7 @@ class PluginLogViewSet(PluginInstanceMixin, GenericViewSet):
     def aggregate_fields_filters(
         self, request, pd_id, plugin_id, log_type: Literal["standard_output", "structure", "ingress"]
     ):
-        """查询日志基于时间分布的直方图"""
+        """统计日志的字段分布"""
         plugin = self.get_plugin_instance()
 
         slz = serializers.PluginLogQueryBodySLZ(data=request.data)
@@ -1110,16 +1143,24 @@ class PluginLogViewSet(PluginInstanceMixin, GenericViewSet):
         slz.is_valid(raise_exception=True)
         query_params = slz.validated_data
 
-        fields_filters = log_api.aggregate_fields_filters(
-            pd=plugin.pd,
-            instance=plugin,
-            log_type=log_type,
-            operator=request.user.username,
-            time_range=query_params["smart_time_range"],
-            query_string=data["query"]["query_string"],
-            terms=data["query"]["terms"],
-            exclude=data["query"]["exclude"],
-        )
+        try:
+            fields_filters = log_api.aggregate_fields_filters(
+                pd=plugin.pd,
+                instance=plugin,
+                log_type=log_type,
+                operator=request.user.username,
+                time_range=query_params["smart_time_range"],
+                query_string=data["query"]["query_string"],
+                terms=data["query"]["terms"],
+                exclude=data["query"]["exclude"],
+            )
+        except RequestError as e:
+            # 用户输入数据不符合 ES 语法等报错，不需要记录到 Sentry，故仅打 error 日志
+            logger.error("request error when aggregating log fields: %s", e)  # noqa: TRY400
+            raise error_codes.QUERY_REQUEST_ERROR
+        except Exception:
+            logger.exception("Failed to aggregate log fields")
+            raise error_codes.QUERY_LOG_FAILED.f(_("统计日志的字段失败，请稍后再试。"))
         return Response(data=serializers.LogFieldFilterSLZ(fields_filters, many=True).data)
 
 


### PR DESCRIPTION
- 限制日志查询的最大窗口，避免查询 10,000 条以上的日志报错
- 修复插件查询日志时，未初始化配置导致异常问题
- 用户输入语法错误，API 返回错误码，记录错误日志即可，不抛 500 异常
- 日志平台 API 返回 result=false，记录错误日志，返回错误码，避免后续抛出 500 异常
- 修复插件查询日志时未指定主模块导致异常问题

以下是符合预期的异常，不用处理
- 查询标准输出日志时，scroll id 失效等导致 ES 查询异常
- 调用 bklog API 504 、连接超时等