### PR TITLE
feat: 云 API 权限批量申请 API

### DIFF
--- a/apiserver/paasng/paasng/accessories/cloudapi/constants.py
+++ b/apiserver/paasng/paasng/accessories/cloudapi/constants.py
@@ -46,6 +46,7 @@ class PermissionActionEnum(StructuredEnum):
 
 
 class PermissionApplyExpireDaysEnum(StructuredEnum):
+    PERMANENT = EnumField(0, label="永久")
     SIX_MONTH = EnumField(180, label="6个月")
     TWELVE_MONTH = EnumField(360, label="12个月")
 

--- a/apiserver/paasng/paasng/accessories/cloudapi/serializers.py
+++ b/apiserver/paasng/paasng/accessories/cloudapi/serializers.py
@@ -61,6 +61,27 @@ class APIGWPermissionApplySLZ(serializers.Serializer):
     gateway_name = serializers.CharField(help_text="网关名称，用于记录操作记录")
 
 
+class GatewayResourceIDsSLZ(serializers.Serializer):
+    gateway_id = serializers.IntegerField(required=True, help_text="网关 ID")
+    resource_ids = serializers.ListField(
+        max_length=100,
+        child=serializers.IntegerField(),
+        allow_empty=True,
+        required=False,
+        help_text="如果不传则为网关维度申请",
+    )
+
+
+class APIGWPermissionBatchApplySLZ(serializers.Serializer):
+    """批量申请网关/ API 权限"""
+
+    reason = serializers.CharField(max_length=512, allow_blank=True, required=False, default="")
+    expire_days = serializers.ChoiceField(
+        choices=constants.PermissionApplyExpireDaysEnum.get_django_choices(),
+    )
+    gateway_resource_ids = serializers.ListField(child=GatewayResourceIDsSLZ(), max_length=100)
+
+
 class APIGWPermissionRenewSLZ(serializers.Serializer):
     resource_ids = serializers.ListField(
         child=serializers.IntegerField(),

--- a/apiserver/paasng/paasng/accessories/cloudapi/urls.py
+++ b/apiserver/paasng/paasng/accessories/cloudapi/urls.py
@@ -37,6 +37,11 @@ urlpatterns = [
         name="api.cloudapi.v1.apply_resource_permissions",
     ),
     path(
+        "api/cloudapi/apps/<slug:app_code>/apis/permissions/apply/",
+        views.CloudAPIViewSet.as_view({"post": "batch_apply"}),
+        name="api.cloudapi.v1.batch_apply_resource_permissions",
+    ),
+    path(
         "api/cloudapi/apps/<slug:app_code>/apis/permissions/renew/",
         views.CloudAPIViewSet.as_view({"post": "renew"}),
         name="api.cloudapi.v1.renew_resource_permissions",

--- a/apiserver/paasng/paasng/accessories/cloudapi/views.py
+++ b/apiserver/paasng/paasng/accessories/cloudapi/views.py
@@ -74,6 +74,19 @@ class CloudAPIViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
         return self._post(request, apigw_url, operation_type, app)
 
     @swagger_auto_schema(
+        request_body=serializers.APIGWPermissionBatchApplySLZ,
+        tags=["CloudAPI"],
+    )
+    def batch_apply(self, request, *args, **kwargs):
+        slz = serializers.APIGWPermissionBatchApplySLZ(data=request.data)
+        slz.is_valid(raise_exception=True)
+
+        app = self.get_application()
+        operation_type = OperationEnum.APPLY
+        apigw_url = self._trans_request_path_to_apigw_url(request.path, app.code)
+        return self._post(request, apigw_url, operation_type, app)
+
+    @swagger_auto_schema(
         request_body=serializers.APIGWPermissionRenewSLZ,
         tags=["CloudAPI"],
     )

--- a/apiserver/paasng/tests/paasng/accessories/cloudapi/test_views.py
+++ b/apiserver/paasng/tests/paasng/accessories/cloudapi/test_views.py
@@ -112,6 +112,20 @@ class TestCloudAPIViewSet:
                 "/api/v1/apis/",
                 False,
             ),
+            # 批量申请 API
+            (
+                "/api/cloudapi/apps/test/apis/permissions/apply/",
+                "test",
+                "/api/v1/apis/permissions/apply/",
+                False,
+            ),
+            # 按单个网关申请 API
+            (
+                "/api/cloudapi/apps/test/apis/1/permissions/apply/",
+                "test",
+                "/api/v1/apis/1/permissions/apply/",
+                False,
+            ),
             (
                 "/api/apps/test/apis/",
                 "test",


### PR DESCRIPTION
1. 续期使用原来的 API 和参数，API 网关侧支持已过期 API 直接续期（之前必须重新走申请逻辑）- 已验证
2. 新增批量 API 申请 API，可一次性申请多个网关下的多个 API（之前一次只能申请一个网关下的 API）- 已验证

3. 网关先发社区版最后再更新上云版本，先在社区版本验证了网关的功能