### PR TITLE
fix: pymysql 1.1.1+ no longer need patch

### DIFF
--- a/apiserver/paasng/paasng/settings/__init__.py
+++ b/apiserver/paasng/paasng/settings/__init__.py
@@ -109,8 +109,6 @@ class PatchFeatures:
 DatabaseFeatures.minimum_database_version = PatchFeatures.minimum_database_version  # noqa
 
 pymysql.install_as_MySQLdb()
-# Patch version info to force pass Django client check
-setattr(pymysql, "version_info", (1, 4, 6, "final", 0))
 
 # 蓝鲸数据库内容加密私钥
 # 使用 `from cryptography.fernet import Fernet; Fernet.generate_key()` 生成随机秘钥


### PR DESCRIPTION
https://github.com/PyMySQL/PyMySQL/blob/a1ac8239c8bf79e7f1a17347b10d6e184221f9c1/pymysql/__init__.py#L57

pymysql 1.1.1+ 中已经内置兼容逻辑，无需再次 patch