### PR TITLE
refactor: let sync_processes respect the management status of "replicas" and "autoscaling" fields

### DIFF
--- a/apiserver/paasng/paas_wl/bk_app/processes/views.py
+++ b/apiserver/paasng/paas_wl/bk_app/processes/views.py
@@ -71,6 +71,7 @@ from paasng.misc.audit.service import add_app_audit_record
 from paasng.platform.applications.constants import ApplicationType
 from paasng.platform.applications.mixins import ApplicationCodeInPathMixin
 from paasng.platform.applications.models import ModuleEnvironment
+from paasng.platform.bkapp_model import fieldmgr
 from paasng.platform.bkapp_model.utils import get_image_info
 from paasng.platform.engine.constants import RuntimeType
 from paasng.platform.engine.deploy.version import get_env_deployed_version_info
@@ -162,6 +163,13 @@ class ProcessesViewSet(GenericViewSet, ApplicationCodeInPathMixin):
             raise error_codes.PROCESS_OPERATE_FAILED.f(str(e), replace=True)
         except AutoscalingUnsupported as e:
             raise error_codes.PROCESS_OPERATE_FAILED.f(str(e), replace=True)
+
+        # Set the field manager when it's a scale operation
+        if operate_type == ProcessUpdateType.SCALE:
+            m = module_env.module
+            # Set both the replicas and autoscaling fields at the same time
+            fieldmgr.FieldManager(m, fieldmgr.f_proc_replicas(process_type)).set(fieldmgr.FieldMgrName.WEB_FORM)
+            fieldmgr.FieldManager(m, fieldmgr.f_proc_autoscaling(process_type)).set(fieldmgr.FieldMgrName.WEB_FORM)
 
     def restart(self, request, code, module_name, environment, process_name):
         """滚动重启进程"""

--- a/apiserver/paasng/paasng/platform/bkapp_model/entities/processes.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities/processes.py
@@ -18,17 +18,18 @@
 import shlex
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from paasng.platform.bkapp_model.constants import ResQuotaPlan
 from paasng.utils.procfile import generate_bash_command_with_tokens
+from paasng.utils.structure import NOTSET, AllowNotsetModel, NotSetType
 
 from .probes import ProbeSet
 from .proc_service import ProcService
 from .scaling_config import AutoscalingConfig
 
 
-class Process(BaseModel):
+class Process(AllowNotsetModel):
     """
     模块进程
 
@@ -53,9 +54,9 @@ class Process(BaseModel):
     services: Optional[List[ProcService]] = None
     target_port: Optional[int] = None
 
-    replicas: Optional[int] = None
+    replicas: int | NotSetType | None = NOTSET
     res_quota_plan: Optional[ResQuotaPlan] = None
-    autoscaling: Optional[AutoscalingConfig] = None
+    autoscaling: AutoscalingConfig | NotSetType | None = NOTSET
 
     probes: Optional[ProbeSet] = None
 

--- a/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/processes.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/processes.py
@@ -15,21 +15,27 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
 
+from paasng.platform.bkapp_model import fieldmgr
 from paasng.platform.bkapp_model.constants import ResQuotaPlan
 from paasng.platform.bkapp_model.entities import Process
+from paasng.platform.bkapp_model.entities.scaling_config import AutoscalingConfig
 from paasng.platform.bkapp_model.models import ModuleProcessSpec
 from paasng.platform.modules.models import Module
+from paasng.utils.structure import NOTSET, NotSetType
 
 from .result import CommonSyncResult
 
 
-def sync_processes(module: Module, processes: List[Process], use_proc_command: bool = False) -> CommonSyncResult:
+def sync_processes(
+    module: Module, processes: List[Process], manager: fieldmgr.FieldMgrName, use_proc_command: bool = False
+) -> CommonSyncResult:
     """sync processes data to ModuleProcessSpec(db model)
 
     :param module: app module
     :param processes: processes list
+    :param manager: the manager performing the sync action.
     :param use_proc_command: only update the "proc_command" field, ignore "command"
         and "args", when the processes data is provided by legacy desc file, this
         argument should be set to True.
@@ -43,6 +49,10 @@ def sync_processes(module: Module, processes: List[Process], use_proc_command: b
     for proc_spec in ModuleProcessSpec.objects.filter(module=module):
         existing_index[proc_spec.name] = proc_spec.pk
 
+    managed_values = ManagedFieldValues(module, processes, manager, set(existing_index.keys()))
+    target_replicas_map = managed_values.get_target_replicas()
+    autoscaling_map = managed_values.get_autoscaling()
+
     # Update or create data
     for process in processes:
         defaults: Dict[str, Any] = {
@@ -54,17 +64,11 @@ def sync_processes(module: Module, processes: List[Process], use_proc_command: b
         }
         if not use_proc_command:
             defaults.update({"command": process.command, "args": process.args})
-
-        # When the replicas value is None, only update the data if the process appears
-        # for the first time in the module.
-        if process.replicas is None:
-            if not ModuleProcessSpec.objects.filter(module=module, name=process.name).exists():
-                defaults["target_replicas"] = 1
-        else:
-            defaults["target_replicas"] = process.replicas
-
-        if process.autoscaling:
-            defaults.update({"autoscaling": True, "scaling_config": process.autoscaling})
+        if process.name in target_replicas_map:
+            defaults.update({"target_replicas": target_replicas_map[process.name]})
+        if process.name in autoscaling_map:
+            as_config = autoscaling_map[process.name]
+            defaults.update({"autoscaling": bool(as_config), "scaling_config": as_config})
 
         _, created = ModuleProcessSpec.objects.update_or_create(module=module, name=process.name, defaults=defaults)
 
@@ -74,4 +78,74 @@ def sync_processes(module: Module, processes: List[Process], use_proc_command: b
 
     # Remove existing data that is not touched.
     ret.deleted_num, _ = ModuleProcessSpec.objects.filter(module=module, id__in=existing_index.values()).delete()
+
+    # Set field managers
+    managed_values.set_field_mgr_target_replicas(target_replicas_map.keys())
+    managed_values.set_field_mgr_autoscaling(autoscaling_map.keys())
     return ret
+
+
+class ManagedFieldValues:
+    """This class helps get the values of the fields that might be managed by other managers."""
+
+    default_replicas = 1
+
+    def __init__(
+        self, module: Module, processes: List[Process], manager: fieldmgr.FieldMgrName, existing_procs: set[str]
+    ):
+        self.module = module
+        self.processes = processes
+        self.manager = manager
+        self.existing_procs = existing_procs
+
+    def get_target_replicas(self) -> dict[str, int]:
+        """Get the target replicas for each process.
+
+        :return: A dict of process name to replicas.
+        """
+        results: dict[str, int] = {}
+        for process in self.processes:
+            name = process.name
+            replicas_mgr = fieldmgr.FieldManager(self.module, fieldmgr.f_proc_replicas(name))
+            if (
+                not replicas_mgr.is_managed_by(self.manager)
+                and process.replicas == NOTSET
+                and name in self.existing_procs
+            ):
+                continue
+            results[name] = (
+                process.replicas
+                if not isinstance(process.replicas, NotSetType) and process.replicas is not None
+                else self.default_replicas
+            )
+        return results
+
+    def set_field_mgr_target_replicas(self, names: Iterable[str]):
+        """Set the field manager for the target replicas field."""
+        for name in names:
+            replicas_mgr = fieldmgr.FieldManager(self.module, fieldmgr.f_proc_replicas(name))
+            replicas_mgr.set(self.manager)
+
+    def get_autoscaling(self) -> dict[str, AutoscalingConfig | None]:
+        """Get the autoscaling config for each process.
+
+        :return: A dict of process name to autoscaling config.
+        """
+        results: dict[str, AutoscalingConfig | None] = {}
+        for process in self.processes:
+            name = process.name
+            autoscaling_mgr = fieldmgr.FieldManager(self.module, fieldmgr.f_proc_autoscaling(name))
+            if isinstance(process.autoscaling, NotSetType) and not autoscaling_mgr.is_managed_by(self.manager):
+                continue
+
+            if isinstance(process.autoscaling, NotSetType):
+                results[name] = None
+            else:
+                results[name] = process.autoscaling
+        return results
+
+    def set_field_mgr_autoscaling(self, names: Iterable[str]):
+        """Set the field manager for the autoscaling field."""
+        for name in names:
+            replicas_mgr = fieldmgr.FieldManager(self.module, fieldmgr.f_proc_autoscaling(name))
+            replicas_mgr.set(self.manager)

--- a/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/processes.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/processes.py
@@ -86,7 +86,10 @@ def sync_processes(
 
 
 class ManagedFieldValues:
-    """This class helps get the values of the fields that might be managed by other managers."""
+    """This class helps to get the values of the fields that respects the field management
+    status, for example, if the "replicas" field is managed by managers other than "APP_DESC"
+    and the input is NOTSET, current class will skip the process when producing values.
+    """
 
     default_replicas = 1
 

--- a/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/processes.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/entities_syncer/processes.py
@@ -122,9 +122,9 @@ class ManagedFieldValues:
 
     def set_field_mgr_target_replicas(self, names: Iterable[str]):
         """Set the field manager for the target replicas field."""
-        for name in names:
-            replicas_mgr = fieldmgr.FieldManager(self.module, fieldmgr.f_proc_replicas(name))
-            replicas_mgr.set(self.manager)
+        fieldmgr.MultiFieldsManager(self.module).set_many(
+            [fieldmgr.f_proc_replicas(name) for name in names], self.manager
+        )
 
     def get_autoscaling(self) -> dict[str, AutoscalingConfig | None]:
         """Get the autoscaling config for each process.
@@ -146,6 +146,6 @@ class ManagedFieldValues:
 
     def set_field_mgr_autoscaling(self, names: Iterable[str]):
         """Set the field manager for the autoscaling field."""
-        for name in names:
-            replicas_mgr = fieldmgr.FieldManager(self.module, fieldmgr.f_proc_autoscaling(name))
-            replicas_mgr.set(self.manager)
+        fieldmgr.MultiFieldsManager(self.module).set_many(
+            [fieldmgr.f_proc_autoscaling(name) for name in names], self.manager
+        )

--- a/apiserver/paasng/paasng/platform/bkapp_model/fieldmgr/__init__.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/fieldmgr/__init__.py
@@ -32,10 +32,11 @@ from .fields import (
     f_proc_autoscaling,
     f_proc_replicas,
 )
-from .managers import FieldManager
+from .managers import FieldManager, MultiFieldsManager
 
 __all__ = [
     "FieldMgrName",
+    "MultiFieldsManager",
     "F_DOMAIN_RESOLUTION",
     "F_HOOKS",
     "F_SVC_DISCOVERY",

--- a/apiserver/paasng/paasng/platform/bkapp_model/fieldmgr/__init__.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/fieldmgr/__init__.py
@@ -29,6 +29,8 @@ from .fields import (
     f_overlay_mounts,
     f_overlay_replicas,
     f_overlay_res_quotas,
+    f_proc_autoscaling,
+    f_proc_replicas,
 )
 from .managers import FieldManager
 
@@ -42,4 +44,6 @@ __all__ = [
     "f_overlay_mounts",
     "f_overlay_replicas",
     "f_overlay_res_quotas",
+    "f_proc_autoscaling",
+    "f_proc_replicas",
 ]

--- a/apiserver/paasng/paasng/platform/bkapp_model/fieldmgr/fields.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/fieldmgr/fields.py
@@ -29,6 +29,14 @@ F_DOMAIN_RESOLUTION: Field = "spec.domainResolution"
 F_HOOKS: Field = "spec.hooks"
 
 
+def f_proc_replicas(process: str) -> Field:
+    return f"spec.processes.replicas[{process}]"
+
+
+def f_proc_autoscaling(process: str) -> Field:
+    return f"spec.processes.autoscaling[{process}]"
+
+
 def f_overlay_replicas(process: str, env_name: str) -> Field:
     return f"spec.envOverlay.replicas[{process}:{env_name}]"
 

--- a/apiserver/paasng/paasng/platform/bkapp_model/importer.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/importer.py
@@ -96,7 +96,7 @@ def import_bkapp_spec_entity(module: Module, spec_entity: v1alpha2_entity.BkAppS
             overlay_mounts = eo.mounts or []
 
     # Run sync functions
-    sync_processes(module, processes=spec_entity.processes)
+    sync_processes(module, processes=spec_entity.processes, manager=manager)
     if build := spec_entity.build:
         sync_build(module, build)
 
@@ -152,7 +152,7 @@ def import_bkapp_spec_entity_non_cnative(
             overlay_env_vars = eo.env_variables or []
 
     # Run sync functions
-    sync_processes(module, processes=spec_entity.processes, use_proc_command=True)
+    sync_processes(module, processes=spec_entity.processes, manager=manager, use_proc_command=True)
     sync_hooks(module, spec_entity.hooks, manager, use_proc_command=True)
 
     # sync_env_vars doesn't need to use manager parameter because the data will

--- a/apiserver/paasng/paasng/platform/bkapp_model/serializers/v1alpha2.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/serializers/v1alpha2.py
@@ -210,7 +210,7 @@ class ProcessInputSLZ(serializers.Serializer):
     """Validate the `processes` field."""
 
     name = serializers.RegexField(regex=PROC_TYPE_PATTERN, max_length=PROC_TYPE_MAX_LENGTH)
-    replicas = serializers.IntegerField(min_value=0, allow_null=True, default=None)
+    replicas = serializers.IntegerField(min_value=0, allow_null=True, default=NOTSET)
     resQuotaPlan = serializers.ChoiceField(
         choices=ResQuotaPlan.get_choices(), allow_null=True, default=None, source="res_quota_plan"
     )
@@ -225,7 +225,7 @@ class ProcessInputSLZ(serializers.Serializer):
     command = serializers.ListField(child=serializers.CharField(), allow_null=True, default=None)
     args = serializers.ListField(child=serializers.CharField(), allow_null=True, default=None)
     procCommand = serializers.CharField(allow_null=True, required=False, source="proc_command")
-    autoscaling = AutoscalingSpecInputSLZ(allow_null=True, default=None)
+    autoscaling = AutoscalingSpecInputSLZ(allow_null=True, default=NOTSET)
     probes = ProbeSetInputSLZ(allow_null=True, default=None)
     services = serializers.ListField(child=ProcServiceInputSLZ(), allow_null=True, default=None)
 

--- a/apiserver/paasng/paasng/platform/bkapp_model/views.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/views.py
@@ -39,6 +39,7 @@ from paasng.platform.applications.mixins import ApplicationCodeInPathMixin
 from paasng.platform.bkapp_model import fieldmgr
 from paasng.platform.bkapp_model.entities import Monitoring, Process
 from paasng.platform.bkapp_model.entities_syncer import sync_processes
+from paasng.platform.bkapp_model.fieldmgr.constants import FieldMgrName
 from paasng.platform.bkapp_model.importer import import_manifest
 from paasng.platform.bkapp_model.manifest import get_manifest
 from paasng.platform.bkapp_model.models import (
@@ -203,7 +204,7 @@ class ModuleProcessSpecViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
             for proc_spec in proc_specs
         ]
 
-        sync_processes(module, processes)
+        sync_processes(module, processes, manager=FieldMgrName.WEB_FORM)
 
         # 更新环境覆盖&更新可观测功能配置
         metrics = []

--- a/apiserver/paasng/paasng/platform/declarative/deployment/resources.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/resources.py
@@ -24,6 +24,7 @@ from paasng.platform.applications.constants import AppLanguage
 from paasng.platform.bkapp_model.entities import Process, v1alpha2
 from paasng.platform.declarative.constants import AppSpecVersion
 from paasng.platform.engine.models.deployment import ProcessTmpl
+from paasng.utils.structure import NotSetType
 
 
 @define
@@ -131,11 +132,16 @@ class DeploymentDesc:
     @staticmethod
     def to_proc_tmpl(process: Process) -> ProcessTmpl:
         """Turn a Process object into a ProcessTmpl object."""
+        # Turn "notset" value to None
+        if isinstance(process.replicas, NotSetType):
+            replicas = None
+        else:
+            replicas = process.replicas
         return cattr.structure(
             {
                 "name": process.name,
                 "command": process.get_proc_command(),
-                "replicas": process.replicas,
+                "replicas": replicas,
                 "plan": process.res_quota_plan,
                 "probes": process.probes,
                 # FIXME: 是否需要补充 services 和 scaling_config 等字段，要弄明白增加

--- a/apiserver/paasng/paasng/platform/declarative/deployment/validations/v2.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/validations/v2.py
@@ -53,7 +53,7 @@ class EnvVariableSLZ(serializers.Serializer):
 
 class ProcessSLZ(serializers.Serializer):
     command = serializers.CharField(help_text="进程启动指令")
-    replicas = serializers.IntegerField(default=None, help_text="进程副本数", allow_null=True)
+    replicas = serializers.IntegerField(default=NOTSET, help_text="进程副本数", allow_null=True)
     plan = serializers.CharField(help_text="资源方案名称", required=False, allow_blank=True, allow_null=True)
     probes = ProbeSetSLZ(default=None, help_text="探针集合", required=False)
 

--- a/apiserver/paasng/paasng/platform/modules/manager.py
+++ b/apiserver/paasng/paasng/platform/modules/manager.py
@@ -43,6 +43,7 @@ from paasng.platform.applications.constants import ApplicationType
 from paasng.platform.applications.models import ModuleEnvironment
 from paasng.platform.bkapp_model.entities import Monitoring, Process
 from paasng.platform.bkapp_model.entities_syncer import sync_processes
+from paasng.platform.bkapp_model.fieldmgr.constants import FieldMgrName
 from paasng.platform.bkapp_model.models import ObservabilityConfig, ProcessSpecEnvOverlay
 from paasng.platform.engine.constants import RuntimeType
 from paasng.platform.engine.models import EngineApp
@@ -290,7 +291,7 @@ class ModuleInitializer:
             for proc_spec in bkapp_spec["processes"]
         ]
 
-        sync_processes(self.module, processes)
+        sync_processes(self.module, processes, manager=FieldMgrName.WEB_FORM)
 
         # 更新环境覆盖&更新可观测功能配置
         metrics = []

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/entities_syncer/test_processes.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/entities_syncer/test_processes.py
@@ -27,6 +27,7 @@ from paasng.platform.bkapp_model.entities import (
     TCPSocketAction,
 )
 from paasng.platform.bkapp_model.entities_syncer import sync_processes
+from paasng.platform.bkapp_model.fieldmgr.constants import FieldMgrName
 from paasng.platform.bkapp_model.models import ModuleProcessSpec
 
 pytestmark = pytest.mark.django_db
@@ -68,6 +69,7 @@ class Test__sync_processes:
                     autoscaling=AutoscalingConfig(min_replicas=2, max_replicas=10, policy="default"),
                 ),
             ],
+            FieldMgrName.APP_DESC,
         )
         assert ret.updated_num == 1
         assert ret.created_num == 1

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/fieldmgr/test_managers.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/fieldmgr/test_managers.py
@@ -16,8 +16,8 @@
 import pytest
 
 from paasng.platform.bkapp_model.fieldmgr.constants import FieldMgrName
-from paasng.platform.bkapp_model.fieldmgr.fields import F_SVC_DISCOVERY
-from paasng.platform.bkapp_model.fieldmgr.managers import FieldManager
+from paasng.platform.bkapp_model.fieldmgr.fields import F_DOMAIN_RESOLUTION, F_SVC_DISCOVERY
+from paasng.platform.bkapp_model.fieldmgr.managers import FieldManager, MultiFieldsManager
 
 pytestmark = pytest.mark.django_db(databases=["default"])
 
@@ -38,3 +38,12 @@ class TestFieldManager:
 
         m2.reset()
         assert m2.get() is None
+
+
+class TestMultiFieldsManager:
+    def test_integrated(self, bk_module):
+        m = MultiFieldsManager(bk_module)
+        m.set_many([F_SVC_DISCOVERY, F_DOMAIN_RESOLUTION], FieldMgrName.WEB_FORM)
+
+        assert FieldManager(bk_module, F_SVC_DISCOVERY).is_managed_by(FieldMgrName.WEB_FORM)
+        assert FieldManager(bk_module, F_DOMAIN_RESOLUTION).is_managed_by(FieldMgrName.WEB_FORM)


### PR DESCRIPTION
- refactor: let sync_processes respect the management status of "replicas" and "autoscaling" fields