### PR TITLE
fix: handle None values in env_overlay fields to prevent unexpected behavior

### DIFF
--- a/apiserver/paasng/paasng/platform/bkapp_model/importer.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/importer.py
@@ -89,11 +89,12 @@ def import_bkapp_spec_entity(module: Module, spec_entity: v1alpha2_entity.BkAppS
     if not isinstance(spec_entity.env_overlay, NotSetType):
         eo = spec_entity.env_overlay
         if eo:
-            overlay_replicas = eo.replicas or []
-            overlay_res_quotas = eo.res_quotas or []
-            overlay_env_vars = eo.env_variables or []
-            overlay_autoscaling = eo.autoscaling or []
-            overlay_mounts = eo.mounts or []
+            # Turn `None` value into empty list
+            overlay_replicas = [] if eo.replicas is None else eo.replicas
+            overlay_res_quotas = [] if eo.res_quotas is None else eo.res_quotas
+            overlay_env_vars = [] if eo.env_variables is None else eo.env_variables
+            overlay_autoscaling = [] if eo.autoscaling is None else eo.autoscaling
+            overlay_mounts = [] if eo.mounts is None else eo.mounts
 
     # Run sync functions
     sync_processes(module, processes=spec_entity.processes, manager=manager)

--- a/apiserver/paasng/paasng/platform/declarative/deployment/validations/v2.py
+++ b/apiserver/paasng/paasng/platform/declarative/deployment/validations/v2.py
@@ -113,6 +113,14 @@ class DeploymentDescSLZ(serializers.Serializer):
                     {"env_name": env_var["environment_name"], "name": env_var["key"], "value": env_var["value"]}
                 )
 
+        # The only possible member of the `env_overlay` field is `env_variables`, if
+        # there are no env vars then the field should be set to NOTSET.
+        env_overlay: NotSetType | dict
+        if not env_vars:
+            env_overlay = NOTSET
+        else:
+            env_overlay = {"env_variables": env_vars}
+
         # svc_discovery -> SvcDiscConfig
         _svc_discovery_value = attrs.get("svc_discovery")
         svc_discovery: NotSetType | dict[str, list[dict]]
@@ -129,9 +137,7 @@ class DeploymentDescSLZ(serializers.Serializer):
             processes=processes,
             hooks=hooks,
             configuration={"env": global_vars},
-            env_overlay={
-                "env_variables": env_vars,
-            },
+            env_overlay=env_overlay,
             svc_discovery=svc_discovery,
         )
         return cattr.structure(

--- a/apiserver/paasng/tests/paasng/platform/bkapp_model/test_importer.py
+++ b/apiserver/paasng/tests/paasng/platform/bkapp_model/test_importer.py
@@ -271,6 +271,22 @@ class TestReplicasOverlay:
         proc_spec = ModuleProcessSpec.objects.get(module=bk_module, name="web")
         assert proc_spec.get_target_replicas("stag") == 3, "The overlay data should remain as it is"
 
+    def test_not_reset_when_manager_different_and_overlay_subfield_notset(
+        self, bk_module, manifest_no_replicas, base_manifest_with_overlay
+    ):
+        """When the envOverlay field is set and the replicas subfield is not set,
+        the replicas should not be reset also.
+        """
+        import_manifest_app_desc(bk_module, base_manifest_with_overlay)
+        # Set the envOverlay field with some subfield other than "replicas" to make the
+        # validated `envOverlay` object not be `NOTSET`.
+        m = copy.deepcopy(manifest_no_replicas)
+        m["spec"]["envOverlay"] = {"envVariables": [{"envName": "stag", "name": "KEY", "value": "foo"}]}
+        import_manifest(bk_module, m, manager=fieldmgr.FieldMgrName.WEB_FORM)
+
+        proc_spec = ModuleProcessSpec.objects.get(module=bk_module, name="web")
+        assert proc_spec.get_target_replicas("stag") == 3, "The overlay data should remain as it is"
+
     def test_proc_replicas_reset_overlay_managed_by_other(self, bk_module, base_manifest, base_manifest_with_overlay):
         """When the replicas field is set on the process object, the overlay should
         always be reset even if no overlay data is provided.


### PR DESCRIPTION
fix: handle None values in env_overlay fields to prevent unexpected behavior