### PR TITLE
fix: replace kube-rbac-proxy image

### DIFF
--- a/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
+        image: bitnami/kube-rbac-proxy:0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -18,10 +18,8 @@ require (
 	github.com/samber/lo v1.47.0
 	github.com/tidwall/sjson v1.2.5
 	go.uber.org/zap v1.19.1
-	golang.org/x/net v0.30.0
 	golang.org/x/time v0.7.0
 	gopkg.in/inf.v0 v0.9.1
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
@@ -72,6 +70,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
+	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/term v0.25.0 // indirect
@@ -79,6 +78,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect


### PR DESCRIPTION
关联 Issue：https://github.com/TencentBlueKing/blueking-paas/issues/1768

注：Helm Charts 无需更新，因为脚本中有做替换：https://github.com/TencentBlueKing/blueking-paas/blob/777aa6c187a2c3515f117b74b0d3eb93742138ac/operator/scripts/update_helm_chart.py#L653