### PR TITLE
fix: remove try_to_preserve_meta_info

### DIFF
--- a/apiserver/paasng/paasng/platform/engine/utils/source.py
+++ b/apiserver/paasng/paasng/platform/engine/utils/source.py
@@ -281,12 +281,7 @@ def tag_module_from_source_files(module, source_files_path):
 
 
 def upload_source_code(
-    module: Module,
-    version_info: VersionInfo,
-    relative_source_dir: Path,
-    operator: str,
-    region: str,
-    try_to_preserve_meta_info: bool = True,
+    module: Module, version_info: VersionInfo, relative_source_dir: Path, operator: str, region: str
 ) -> str:
     """上传应用模块源码到 blob 存储, 并且返回源码的下载链接, 参考方法 "BaseBuilder.compress_and_upload"
 
@@ -297,7 +292,7 @@ def upload_source_code(
         source_dir = working_dir.absolute() / relative_source_dir
         # 下载源码到临时目录
         if spec.source_origin_specs.source_origin == SourceOrigin.AUTHORIZED_VCS:
-            get_repo_controller(module, operator=operator).export(working_dir, version_info, try_to_preserve_meta_info)
+            get_repo_controller(module, operator=operator).export(working_dir, version_info)
         else:
             raise NotImplementedError
 

--- a/apiserver/paasng/paasng/platform/sourcectl/controllers/bare_git.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/controllers/bare_git.py
@@ -88,11 +88,10 @@ class BareGitRepoController:
             raise
         return True
 
-    def export(self, local_path, version_info: VersionInfo, try_to_preserve_meta_info: bool = False):
+    def export(self, local_path, version_info: VersionInfo):
         """直接将代码库 clone 下来，由通用逻辑进行打包"""
         self.client.clone(self.repo_url, local_path, depth=1, branch=version_info.version_name)
-        if not try_to_preserve_meta_info:
-            self.client.clean_meta_info(local_path)
+        self.client.clean_meta_info(local_path)
 
     def list_alternative_versions(self) -> List[AlternativeVersion]:
         """尝试直接从远端获取可选的分支信息"""

--- a/apiserver/paasng/paasng/platform/sourcectl/controllers/bk_svn.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/controllers/bk_svn.py
@@ -59,7 +59,7 @@ class SvnRepoController:
         else:
             return True
 
-    def export(self, local_path, version_info: VersionInfo, try_to_preserve_meta_info: bool = False):
+    def export(self, local_path, version_info: VersionInfo):
         target_branch, revision = self.extract_version_info(version_info)
         self.svn_client.export(target_branch, local_path=local_path, revision=revision)
 

--- a/apiserver/paasng/paasng/platform/sourcectl/controllers/gitee.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/controllers/gitee.py
@@ -85,12 +85,11 @@ class GiteeRepoController(BaseGitRepoController):
         else:
             return True
 
-    def export(self, local_path, version_info: VersionInfo, try_to_preserve_meta_info: bool = False):
+    def export(self, local_path, version_info: VersionInfo):
         """Gitee API 不支持下载压缩包，改成直接将代码库 clone 下来，由通用逻辑进行打包"""
         git_client = GitClient()
         git_client.clone(self._build_repo_url_with_auth(), local_path, branch=version_info.version_name, depth=1)
-        if not try_to_preserve_meta_info:
-            git_client.clean_meta_info(local_path)
+        git_client.clean_meta_info(local_path)
 
     def list_alternative_versions(self) -> List[AlternativeVersion]:
         """列举仓库所有可用 branch 或 tag"""

--- a/apiserver/paasng/paasng/platform/sourcectl/controllers/github.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/controllers/github.py
@@ -85,7 +85,7 @@ class GitHubRepoController(BaseGitRepoController):
         else:
             return True
 
-    def export(self, local_path: PathLike, version_info: VersionInfo, try_to_preserve_meta_info: bool = False):
+    def export(self, local_path: PathLike, version_info: VersionInfo):
         """下载 zip 包并解压到指定路径"""
         target_branch, revision = self.extract_version_info(version_info)
         with generate_temp_file(suffix=".zip") as zip_file:

--- a/apiserver/paasng/paasng/platform/sourcectl/controllers/gitlab.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/controllers/gitlab.py
@@ -106,7 +106,7 @@ class GitlabRepoController(BaseGitRepoController):
             return True
 
     @error_converter
-    def export(self, local_path: str, version_info: VersionInfo, try_to_preserve_meta_info: bool = False):
+    def export(self, local_path: str, version_info: VersionInfo):
         tag_or_branch, revision = self.extract_version_info(version_info)
         with generate_temp_file(suffix=".tar.gz") as tar_file:
             self.api_client.repo_archive(self.project, tar_file, ref=revision or tag_or_branch)

--- a/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
@@ -69,13 +69,11 @@ class RepoController(Protocol):
         :return: 是否有权限
         """
 
-    def export(self, local_path: PathLike, version_info: VersionInfo, try_to_preserve_meta_info: bool = False):
+    def export(self, local_path: PathLike, version_info: VersionInfo):
         """导出指定版本的整个项目内容到本地路径
 
         :param local_path: 本地路径
         :param version_info: 指定版本信息
-        :param try_to_preserve_meta_info: 是否尝试保留源码元信息(.git 文件夹)，RepoController 实现比较多样，例如 gitee 是无法做到保留元信息，
-        因此该参数为 try_to_preserve_meta_info 意为尝试保留，能否保留需要看具体实现是否支持。暂时主要用途在沙箱开发环境的代码编辑器
         """
 
     def build_url(self, version_info: VersionInfo) -> str:


### PR DESCRIPTION
`try_to_preserve_meta_info` 是之前为在沙箱中保留 `.git` 而引入的

现在沙箱支持新的方式实现了代码提交，因此该参数不再需要保留，可以直接移除