### PR TITLE
feat: enable bcs and lesscode by settings config

### DIFF
--- a/apiserver/paasng/paas_wl/bk_app/processes/processes.py
+++ b/apiserver/paasng/paas_wl/bk_app/processes/processes.py
@@ -40,7 +40,7 @@ from paas_wl.bk_app.processes.models import ProcessProbeManager, ProcessSpecMana
 from paas_wl.bk_app.processes.readers import process_kmodel
 from paas_wl.bk_app.processes.serializers import ProcessSpecSLZ
 from paas_wl.infras.cluster.utils import get_cluster_by_app
-from paas_wl.infras.resources.base.bcs.client import make_bcs_client
+from paas_wl.infras.resources.base.bcs.client import bcs_client_cls
 from paas_wl.infras.resources.base.kres import KPod
 from paas_wl.infras.resources.utils.basic import get_client_by_app
 from paasng.platform.applications.models import Application, ModuleEnvironment
@@ -268,7 +268,7 @@ class ProcessManager:
             container_name = process_kmodel.get_by_type(self.wl_app, type=process_type).main_container_name
 
         cluster = get_cluster_by_app(self.wl_app)
-        return make_bcs_client().create_web_console_sessions(
+        return bcs_client_cls().create_web_console_sessions(
             json={
                 "namespace": self.wl_app.namespace,
                 "pod_name": process_instance_name,

--- a/apiserver/paasng/paas_wl/bk_app/processes/processes.py
+++ b/apiserver/paasng/paas_wl/bk_app/processes/processes.py
@@ -40,7 +40,7 @@ from paas_wl.bk_app.processes.models import ProcessProbeManager, ProcessSpecMana
 from paas_wl.bk_app.processes.readers import process_kmodel
 from paas_wl.bk_app.processes.serializers import ProcessSpecSLZ
 from paas_wl.infras.cluster.utils import get_cluster_by_app
-from paas_wl.infras.resources.base.bcs_client import BCSClient
+from paas_wl.infras.resources.base.bcs.client import make_bcs_client
 from paas_wl.infras.resources.base.kres import KPod
 from paas_wl.infras.resources.utils.basic import get_client_by_app
 from paasng.platform.applications.models import Application, ModuleEnvironment
@@ -268,7 +268,7 @@ class ProcessManager:
             container_name = process_kmodel.get_by_type(self.wl_app, type=process_type).main_container_name
 
         cluster = get_cluster_by_app(self.wl_app)
-        return BCSClient().api.create_web_console_sessions(
+        return make_bcs_client().create_web_console_sessions(
             json={
                 "namespace": self.wl_app.namespace,
                 "pod_name": process_instance_name,

--- a/apiserver/paasng/paas_wl/infras/resources/base/bcs/__init__.py
+++ b/apiserver/paasng/paas_wl/infras/resources/base/bcs/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.

--- a/apiserver/paasng/paas_wl/infras/resources/base/bcs/apigw.py
+++ b/apiserver/paasng/paas_wl/infras/resources/base/bcs/apigw.py
@@ -15,38 +15,13 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
-import json
-from typing import Any, Dict
-
 from bkapi_client_core.apigateway import APIGatewayClient, Operation, OperationGroup, bind_property
-from django.conf import settings
-
-
-class AuthOperation(Operation):
-    """头部带有认证信息的 Operation"""
-
-    def _get_context(self, **kwargs) -> Dict[str, Any]:
-        """将认证信息添加到 headers"""
-        context = super()._get_context(**kwargs)
-
-        headers = context.get("headers") or {}
-        headers.update(
-            {
-                "X-Bkapi-Authorization": json.dumps(
-                    {"bk_app_code": settings.BK_APP_CODE, "bk_app_secret": settings.BK_APP_SECRET}
-                ),
-                "Content-Type": "application/json",
-            }
-        )
-
-        context["headers"] = headers
-        return context
 
 
 class Group(OperationGroup):
     # 创建 websocket session
     create_web_console_sessions = bind_property(
-        AuthOperation,
+        Operation,
         name="create_web_console_sessions",
         method="POST",
         path="/{version}/webconsole/api/portal/projects/{project_id_or_code}/"
@@ -54,11 +29,8 @@ class Group(OperationGroup):
     )
 
 
-class BCSClient(APIGatewayClient):
+class Client(APIGatewayClient):
     """bcs-services 提供的网关 client"""
 
     _api_name = "bcs-api-gateway"
     api = bind_property(Group, name="api")
-
-    def __init__(self):
-        super().__init__(stage=settings.APIGW_ENVIRONMENT, endpoint=settings.BK_API_URL_TMPL)

--- a/apiserver/paasng/paas_wl/infras/resources/base/bcs/client.py
+++ b/apiserver/paasng/paas_wl/infras/resources/base/bcs/client.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+from django.conf import settings
+
+from paas_wl.infras.resources.base.bcs.apigw import Client
+from paas_wl.infras.resources.base.bcs.apigw import Group as BcsGroup
+
+
+class DummyBcsClient:
+    """Dummy BCS Clientwhen BCS is disabled."""
+
+    def create_web_console_sessions(*args, **kwargs): ...
+
+
+class BcsClient:
+    """bcs 通过 APIGW 提供的 API"""
+
+    def __init__(self):
+        client = Client(stage=settings.APIGW_ENVIRONMENT, endpoint=settings.BK_API_URL_TMPL)
+        client.update_bkapi_authorization(
+            bk_app_code=settings.BK_APP_CODE,
+            bk_app_secret=settings.BK_APP_SECRET,
+        )
+        client.update_headers(self._prepare_headers())
+        self.client: BcsGroup = client.api
+
+    def _prepare_headers(self) -> dict:
+        # 添加公共的 header
+        return {"Content-Type": "application/json"}
+
+    def create_web_console_sessions(self, *args, **kwargs):
+        return self.client.create_web_console_sessions(*args, **kwargs)
+
+
+def make_bcs_client():
+    if settings.ENABLE_BCS:
+        return BcsClient
+    else:
+        return DummyBcsClient

--- a/apiserver/paasng/paas_wl/infras/resources/base/bcs/client.py
+++ b/apiserver/paasng/paas_wl/infras/resources/base/bcs/client.py
@@ -46,8 +46,11 @@ class BcsClient:
         return self.client.create_web_console_sessions(*args, **kwargs)
 
 
-def make_bcs_client():
+def get_bcs_client():
     if settings.ENABLE_BCS:
         return BcsClient
     else:
         return DummyBcsClient
+
+
+bcs_client_cls = get_bcs_client()

--- a/apiserver/paasng/paasng/core/region/models.py
+++ b/apiserver/paasng/paasng/core/region/models.py
@@ -141,7 +141,6 @@ class Region:
     allow_user_modify_custom_domain: Optional[bool] = True
     module_mobile_config: Optional[RegionMobileConfig] = None
     provide_env_vars_platform: Optional[bool] = True
-    allow_deploy_app_by_lesscode: Optional[bool] = False
 
     def __post_init__(self):
         self._service_categories = []

--- a/apiserver/paasng/paasng/core/region/states.py
+++ b/apiserver/paasng/paasng/core/region/states.py
@@ -61,7 +61,6 @@ def load_regions_from_settings():
             enabled_feature_flags=set(cfg.pop("enabled_feature_flags", [])),
             allow_user_modify_custom_domain=cfg.pop("allow_user_modify_custom_domain", None),
             provide_env_vars_platform=cfg.pop("provide_env_vars_platform", None),
-            allow_deploy_app_by_lesscode=cfg.pop("allow_deploy_app_by_lesscode", None),
         )
         register_region(region)
 

--- a/apiserver/paasng/paasng/infras/accounts/serializers.py
+++ b/apiserver/paasng/paasng/infras/accounts/serializers.py
@@ -94,7 +94,6 @@ class AllRegionSpecsSLZ:
                         "display_name": region.display_name,
                         "languages": languages,
                         "description": region.basic_info.description,
-                        "allow_deploy_app_by_lesscode": region.allow_deploy_app_by_lesscode,
                     }
                 }
             )

--- a/apiserver/paasng/paasng/misc/plat_config/views.py
+++ b/apiserver/paasng/paasng/misc/plat_config/views.py
@@ -63,5 +63,9 @@ class FrontendFeatureViewSet(ViewSet):
             "BK_CI_PIPELINE_BUILD": bool(settings.BK_CI_PAAS_PROJECT_ID and settings.BK_CI_BUILD_PIPELINE_ID),
             # 创建与使用“蓝鲸插件”类型应用
             "BK_PLUGIN_TYPED_APPLICATION": settings.IS_ALLOW_CREATE_BK_PLUGIN_APP,
+            # 访问控制台功能，由是否启用 BCS 控制
+            "WEB_CONSOLE": settings.ENABLE_BCS,
+            # 是否能创建 LessCode 应用
+            "BK_LESSCODE_APP": settings.ENABLE_BK_LESSCODE,
         }
         return Response(data={**features_reuses_backend_settings, **fronted_features})

--- a/apiserver/paasng/paasng/platform/bk_lesscode/client.py
+++ b/apiserver/paasng/paasng/platform/bk_lesscode/client.py
@@ -106,7 +106,7 @@ class LessCodeClient:
 
 
 def make_bk_lesscode_client(login_cookie: str, client: Optional[LessCodeGroup] = None):
-    if settings.ENABLE_BK_LESSCODE_APIGW:
+    if settings.ENABLE_BK_LESSCODE:
         return LessCodeClient(login_cookie, client)
     else:
         return DummyLessCodeClient()

--- a/apiserver/paasng/paasng/settings/__init__.py
+++ b/apiserver/paasng/paasng/settings/__init__.py
@@ -947,8 +947,6 @@ DEFAULT_REGION_TEMPLATE = {
     "enabled_feature_flags": [],
     # 应用是否需要写入蓝鲸体系其他系统访问地址的环境变量
     "provide_env_vars_platform": True,
-    # 是否允许部署“蓝鲸运维开发平台提供源码包”
-    "allow_deploy_app_by_lesscode": True,
 }
 
 REGION_CONFIGS = settings.get("REGION_CONFIGS", {"regions": [copy.deepcopy(DEFAULT_REGION_TEMPLATE)]})
@@ -1321,12 +1319,12 @@ APP_DOCKER_REGISTRY_PASSWORD = settings.get("APP_DOCKER_PASSWORD", "blueking")
 # ------------------
 # bk-lesscode 相关配置
 # ------------------
+# 是否允许创建 LessCode 应用
+ENABLE_BK_LESSCODE = settings.get("ENABLE_BK_LESSCODE", True)
 # bk_lesscode 注册在 APIGW 上的环境
 BK_LESSCODE_APIGW_STAGE = settings.get("BK_LESSCODE_APIGW_STAGE", "prod")
 # bk_lesscode 平台访问地址
 BK_LESSCODE_URL = settings.get("BK_LESSCODE_URL", "")
-# bk_lesscode API 是否已经注册在 APIGW 网关上
-ENABLE_BK_LESSCODE_APIGW = settings.get("ENABLE_BK_LESSCODE_APIGW", False)
 BK_LESSCODE_TIPS = settings.get("BK_LESSCODE_TIPS", "")
 
 # -----------------
@@ -1410,6 +1408,12 @@ BK_AUDIT_SETTINGS = {
     "ot_endpoint": BK_AUDIT_ENDPOINT,
     "bk_data_token": BK_AUDIT_DATA_TOKEN,
 }
+
+# ---------------------------------------------
+# 蓝鲸容器服务配置
+# ---------------------------------------------
+# 是否部署了 BCS，影响访问控制台等功能
+ENABLE_BCS = settings.get("ENABLE_BCS", True)
 
 # ---------------------------------------------
 # （internal）内部配置，仅开发项目与特殊环境下使用

--- a/apiserver/paasng/tests/api/test_applications.py
+++ b/apiserver/paasng/tests/api/test_applications.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 import pytest
 from django.conf import settings
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django_dynamic_fixture import G
@@ -279,23 +280,24 @@ class TestApplicationCreateWithEngine:
         source_control_type,
         is_success,
     ):
-        random_suffix = generate_random_string(length=6)
-        response = api_client.post(
-            "/api/bkapps/applications/v2/",
-            data={
-                "region": settings.DEFAULT_REGION_NAME,
-                "code": f"uta-{random_suffix}",
-                "name": f"uta-{random_suffix}",
-                "engine_params": {
-                    "source_origin": source_origin,
-                    "source_repo_url": source_repo_url,
-                    "source_init_template": settings.DUMMY_TEMPLATE_NAME,
-                    "source_control_type": source_control_type,
+        with override_settings(ENABLE_BK_LESSCODE=False):
+            random_suffix = generate_random_string(length=6)
+            response = api_client.post(
+                "/api/bkapps/applications/v2/",
+                data={
+                    "region": settings.DEFAULT_REGION_NAME,
+                    "code": f"uta-{random_suffix}",
+                    "name": f"uta-{random_suffix}",
+                    "engine_params": {
+                        "source_origin": source_origin,
+                        "source_repo_url": source_repo_url,
+                        "source_init_template": settings.DUMMY_TEMPLATE_NAME,
+                        "source_control_type": source_control_type,
+                    },
                 },
-            },
-        )
-        desired_status_code = 201 if is_success else 400
-        assert response.status_code == desired_status_code
+            )
+            desired_status_code = 201 if is_success else 400
+            assert response.status_code == desired_status_code
 
 
 class TestApplicationCreateWithoutEngine:

--- a/apiserver/paasng/tests/api/test_modules.py
+++ b/apiserver/paasng/tests/api/test_modules.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 import pytest
 from django.conf import settings
+from django.test.utils import override_settings
 
 from paas_wl.workloads.networking.ingress.models import Domain
 from paasng.accessories.publish.market.constant import ProductSourceUrlType
@@ -93,7 +94,9 @@ class TestModuleCreation:
         bk_user,
         mock_wl_services_in_creation,
     ):
-        with mock.patch.object(IntegratedSvnAppRepoConnector, "sync_templated_sources") as mocked_sync:
+        with mock.patch.object(
+            IntegratedSvnAppRepoConnector, "sync_templated_sources"
+        ) as mocked_sync, override_settings(ENABLE_BK_LESSCODE=False):
             # Mock return value of syncing template
             mocked_sync.return_value = SourceSyncResult(dest_type="mock")
 

--- a/apiserver/paasng/tests/paasng/platform/test_lesscode.py
+++ b/apiserver/paasng/tests/paasng/platform/test_lesscode.py
@@ -29,7 +29,7 @@ from tests.utils.helpers import generate_random_string
 
 @pytest.fixture(autouse=True)
 def _override_default_region():
-    with override_settings(ENABLE_BK_LESSCODE_APIGW=True):
+    with override_settings(ENABLE_BK_LESSCODE=True):
         yield
 
 

--- a/webfe/package_vue/src/views/dev-center/app/create-module/index.vue
+++ b/webfe/package_vue/src/views/dev-center/app/create-module/index.vue
@@ -142,7 +142,7 @@
                     {{ $t('蓝鲸开发框架') }}
                   </li>
                   <li
-                    v-if="allRegionsSpecs[region] && allRegionsSpecs[region].allow_deploy_app_by_lesscode"
+                    v-if="curUserFeature.BK_LESSCODE_APP"
                     :class="['tab-item template', { 'active': localSourceOrigin === 2 }]"
                     @click="handleCodeTypeChange(2)"
                   >


### PR DESCRIPTION
1. 未启用 bcs 时，不调用 bcs API
2. 优化 bcs api 调用代码
2. 是否启用 lesscode 不再放到 region 配置中
3. 需要合入到 release-1.5 分支
4. helm chart 需要新增配置: ENABLE_BCS、ENABLE_BK_LESSCODE