### PR TITLE
WIP：add X-Bk-Tenant-Id to all APIGW API request headers

### DIFF
--- a/apiserver/paasng/paasng/accessories/cloudapi/components/bk_apigateway_inner.py
+++ b/apiserver/paasng/paasng/accessories/cloudapi/components/bk_apigateway_inner.py
@@ -32,13 +32,13 @@ class BkApigatewayInnerComponent(BaseComponent):
     host = BK_APIGATEWAY_INNER_API_URL
     system_name = "bk-apigateway-inner"
 
-    def get(self, path: str, bk_username: str = "", **kwargs):
-        return self._call_api(http_get, path, headers=self._prepare_headers(bk_username), **kwargs)
+    def get(self, path: str, tenant_id: str, bk_username: str = "", **kwargs):
+        return self._call_api(http_get, path, headers=self._prepare_headers(bk_username, tenant_id), **kwargs)
 
-    def post(self, path: str, bk_username: str = "", **kwargs):
-        return self._call_api(http_post, path, headers=self._prepare_headers(bk_username), **kwargs)
+    def post(self, path: str, tenant_id: str, bk_username: str = "", **kwargs):
+        return self._call_api(http_post, path, headers=self._prepare_headers(bk_username, tenant_id), **kwargs)
 
-    def _prepare_headers(self, bk_username: str):
+    def _prepare_headers(self, bk_username: str, tenant_id: str):
         headers = {
             "x-bkapi-authorization": json.dumps(
                 {
@@ -46,7 +46,8 @@ class BkApigatewayInnerComponent(BaseComponent):
                     "bk_app_secret": settings.BK_APP_SECRET,
                     "bk_username": bk_username,
                 }
-            )
+            ),
+            "X-Bk-Tenant-Id": tenant_id,
         }
 
         language = get_language()

--- a/apiserver/paasng/paasng/accessories/cloudapi/views.py
+++ b/apiserver/paasng/paasng/accessories/cloudapi/views.py
@@ -33,6 +33,7 @@ from paasng.misc.audit.constants import DataType, OperationEnum, OperationTarget
 from paasng.misc.audit.service import DataDetail, add_app_audit_record
 from paasng.platform.applications.mixins import ApplicationCodeInPathMixin
 from paasng.platform.applications.models import Application
+from paasng.platform.applications.tenant import get_tenant_id_for_app
 from paasng.utils.dictx import get_items
 from paasng.utils.error_codes import error_codes
 
@@ -217,8 +218,10 @@ class CloudAPIViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
                 "user_auth_type": get_user_auth_type(app.region),
             }
         )
-
-        result = bk_apigateway_inner_component.get(apigw_url, params=params, bk_username=request.user.username)
+        tenant_id = get_tenant_id_for_app(app.code)
+        result = bk_apigateway_inner_component.get(
+            apigw_url, params=params, tenant_id=tenant_id, bk_username=request.user.username
+        )
         return Response(result)
 
     def _post(
@@ -245,8 +248,10 @@ class CloudAPIViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
                 "user_auth_type": get_user_auth_type(app.region),
             }
         )
-
-        result = bk_apigateway_inner_component.post(apigw_url, json=data, bk_username=request.user.username)
+        tenant_id = get_tenant_id_for_app(app.code)
+        result = bk_apigateway_inner_component.post(
+            apigw_url, json=data, tenant_id=tenant_id, bk_username=request.user.username
+        )
 
         try:
             # 云 API 申请记录 ID，用于操作详情的展示

--- a/apiserver/paasng/paasng/accessories/log/client.py
+++ b/apiserver/paasng/paasng/accessories/log/client.py
@@ -72,9 +72,9 @@ class LogClientProtocol(Protocol):
 class BKLogClient:
     """BKLogClient is an implement of LogClientProtocol, the log search backend is bk log search"""
 
-    def __init__(self, config: BKLogConfig, bk_username: str):
+    def __init__(self, config: BKLogConfig, tenant_id: str, bk_username: str):
         self.config = config
-        self._esclient = make_bk_log_esquery_client()
+        self._esclient = make_bk_log_esquery_client(tenant_id)
 
     def execute_search(self, index: str, search: SmartSearch, timeout: int) -> Tuple[Response, int]:
         """search log from index with body and params, implement with bk-log"""
@@ -314,11 +314,11 @@ class ESLogClient:
         ]
 
 
-def instantiate_log_client(log_config: ElasticSearchConfig, bk_username: str) -> LogClientProtocol:
+def instantiate_log_client(log_config: ElasticSearchConfig, tenant_id: str, bk_username: str) -> LogClientProtocol:
     """实例化 log client 实例"""
     if log_config.backend_type == "bkLog":
         assert log_config.bk_log_config
-        return BKLogClient(log_config.bk_log_config, bk_username=bk_username)
+        return BKLogClient(log_config.bk_log_config, tenant_id=tenant_id, bk_username=bk_username)
     elif log_config.backend_type == "es":
         assert log_config.elastic_search_host
         return ESLogClient(log_config.elastic_search_host)

--- a/apiserver/paasng/paasng/accessories/log/shim/bklog_custom_collector_config.py
+++ b/apiserver/paasng/paasng/accessories/log/shim/bklog_custom_collector_config.py
@@ -23,6 +23,7 @@ from paasng.accessories.log.models import CustomCollectorConfig as CustomCollect
 from paasng.infras.bk_log.client import make_bk_log_management_client
 from paasng.infras.bk_log.definitions import CustomCollectorConfig
 from paasng.infras.bkmonitorv3.shim import get_or_create_bk_monitor_space
+from paasng.platform.applications.tenant import get_tenant_id_for_app
 from paasng.platform.modules.models import Module
 
 
@@ -37,7 +38,8 @@ def get_or_create_custom_collector_config(
     :return: CustomCollectorConfigModel
     """
     monitor_space, _ = get_or_create_bk_monitor_space(module.application)
-    client = make_bk_log_management_client()
+    tenant_id = get_tenant_id_for_app(module.application.code)
+    client = make_bk_log_management_client(tenant_id)
     collector_config_in_bk_log = client.get_custom_collector_config_by_name_en(
         biz_or_space_id=monitor_space.iam_resource_id, collector_config_name_en=collector_config.name_en
     )
@@ -80,7 +82,8 @@ def update_or_create_custom_collector_config(
     :return: CustomCollectorConfigModel
     """
     monitor_space, _ = get_or_create_bk_monitor_space(module.application)
-    client = make_bk_log_management_client()
+    tenant_id = get_tenant_id_for_app(module.application.code)
+    client = make_bk_log_management_client(tenant_id)
     if not collector_config.id and not skip_query_bk_log:
         collector_config_in_bk_log = client.get_custom_collector_config_by_name_en(
             biz_or_space_id=monitor_space.iam_resource_id, collector_config_name_en=collector_config.name_en

--- a/apiserver/paasng/paasng/accessories/log/views/logs.py
+++ b/apiserver/paasng/paasng/accessories/log/views/logs.py
@@ -43,6 +43,7 @@ from paasng.accessories.log.models import ElasticSearchParams, ProcessLogQueryCo
 from paasng.accessories.log.responses import IngressLogLine, StandardOutputLogLine, StructureLogLine
 from paasng.accessories.log.shim import setup_env_log_model
 from paasng.accessories.log.utils import clean_logs, parse_request_to_es_dsl
+from paasng.core.tenant.user import get_tenant
 from paasng.infras.accounts.permissions.application import application_perm_class
 from paasng.infras.accounts.permissions.constants import SiteAction
 from paasng.infras.accounts.permissions.global_site import site_perm_required
@@ -94,7 +95,10 @@ class LogBaseAPIView(ViewSet, ApplicationCodeInPathMixin):
         #     environment=request.GET.get('environment', 'all'), stream=request.GET.get('stream', 'all')
         # ).inc()
         log_config = self._get_log_query_config()
-        return instantiate_log_client(log_config=log_config, bk_username=self.request.user.username), log_config
+        tenant_id = get_tenant(self.request.user).id
+        return instantiate_log_client(
+            log_config=log_config, tenant_id=tenant_id, bk_username=self.request.user.username
+        ), log_config
 
     def parse_time_range(self) -> SmartTimeRange:
         """parse time range from request.query_params"""
@@ -440,16 +444,13 @@ class ModuleLogAPIMixin(_MixinBase):
         return search.limit_offset(limit=limit, offset=offset)
 
 
-class ModuleStdoutLogAPIView(ModuleLogAPIMixin, StdoutLogAPIView):
-    ...
+class ModuleStdoutLogAPIView(ModuleLogAPIMixin, StdoutLogAPIView): ...
 
 
-class ModuleStructuredLogAPIView(ModuleLogAPIMixin, StructuredLogAPIView):
-    ...
+class ModuleStructuredLogAPIView(ModuleLogAPIMixin, StructuredLogAPIView): ...
 
 
-class ModuleIngressLogAPIView(ModuleLogAPIMixin, IngressLogAPIView):
-    ...
+class ModuleIngressLogAPIView(ModuleLogAPIMixin, IngressLogAPIView): ...
 
 
 class SysStructuredLogAPIView(StructuredLogAPIView):

--- a/apiserver/paasng/paasng/bk_plugins/bk_plugins/logging.py
+++ b/apiserver/paasng/paasng/bk_plugins/bk_plugins/logging.py
@@ -137,7 +137,9 @@ class PluginLoggingClient:
         # ).inc()
         module = self.application.get_module(module_name=self._module_name)
         log_config = ProcessLogQueryConfig.objects.select_process_irrelevant(module.get_envs("prod")).json
-        return instantiate_log_client(log_config=log_config, bk_username="blueking"), log_config
+        return instantiate_log_client(
+            log_config=log_config, tenant_id=self.application.tenant_id, bk_username="blueking"
+        ), log_config
 
     def make_search(self, mappings: dict, trace_id: str) -> SmartSearch:
         """构造日志查询语句

--- a/apiserver/paasng/paasng/infras/bk_ci/client.py
+++ b/apiserver/paasng/paasng/infras/bk_ci/client.py
@@ -46,8 +46,9 @@ class BaseBkCIClient:
     :param stage: 网关环境, 蓝盾只提供了正式环境(prod)的 API
     """
 
-    def __init__(self, bk_username: str, stage: str = "prod"):
+    def __init__(self, tenant_id: str, bk_username: str, stage: str = "prod"):
         self.bk_username = bk_username
+        self.tenant_id = tenant_id
 
         client = Client(endpoint=settings.BK_API_URL_TMPL, stage=stage)
         client.update_bkapi_authorization(
@@ -59,7 +60,10 @@ class BaseBkCIClient:
 
     def _prepare_headers(self) -> dict:
         # 应用态 API 需要添加 X-DEVOPS-UID，用户态 API 不需要
-        return {"X-DEVOPS-UID": self.bk_username}
+        return {
+            "X-DEVOPS-UID": self.bk_username,
+            "X-Bk-Tenant-Id": self.tenant_id,
+        }
 
 
 class BkCIPipelineClient(BaseBkCIClient):

--- a/apiserver/paasng/paasng/infras/bk_log/client.py
+++ b/apiserver/paasng/paasng/infras/bk_log/client.py
@@ -40,8 +40,7 @@ class _APIGWOperationStub(Protocol):
         proxies: Optional[Dict[str, Any]] = None,
         verify: Optional[bool] = None,
         **kwargs,
-    ) -> Dict:
-        ...
+    ) -> Dict: ...
 
 
 class BKLogQueryAPIProtocol(Protocol):
@@ -201,7 +200,7 @@ class BkLogManagementClient:
             raise BkLogApiError(resp["message"])
 
 
-def make_bk_log_management_client() -> BkLogManagementClient:
+def make_bk_log_management_client(tenant_id: str) -> BkLogManagementClient:
     if settings.ENABLE_BK_LOG_APIGW:
         apigw_client = APIGWClient(endpoint=settings.BK_API_URL_TMPL, stage=settings.BK_LOG_APIGW_SERVICE_STAGE)
         apigw_client.update_bkapi_authorization(
@@ -210,6 +209,11 @@ def make_bk_log_management_client() -> BkLogManagementClient:
             bk_app_secret=settings.BK_APP_SECRET,
             bk_username="admin",
         )
+        apigw_client.update_headers(
+            {
+                "X-Bk-Tenant-Id": tenant_id,
+            }
+        )
         return BkLogManagementClient(apigw_client.api)
 
     # ESB 开启了免用户认证，但是又限制了用户名不能为空，所以需要给一个随机字符串
@@ -217,7 +221,7 @@ def make_bk_log_management_client() -> BkLogManagementClient:
     return BkLogManagementClient(esb_client.api)
 
 
-def make_bk_log_esquery_client() -> BKLogQueryAPIProtocol:
+def make_bk_log_esquery_client(tenant_id: str) -> BKLogQueryAPIProtocol:
     if settings.ENABLE_BK_LOG_APIGW:
         apigw_client = APIGWClient(endpoint=settings.BK_API_URL_TMPL, stage=settings.BK_LOG_APIGW_SERVICE_STAGE)
         apigw_client.update_bkapi_authorization(
@@ -225,6 +229,11 @@ def make_bk_log_esquery_client() -> BKLogQueryAPIProtocol:
             bk_app_code=settings.BK_APP_CODE,
             bk_app_secret=settings.BK_APP_SECRET,
             bk_username="admin",
+        )
+        apigw_client.update_headers(
+            {
+                "X-Bk-Tenant-Id": tenant_id,
+            }
         )
         return apigw_client.api
 

--- a/apiserver/paasng/paasng/infras/bkmonitorv3/client.py
+++ b/apiserver/paasng/paasng/infras/bkmonitorv3/client.py
@@ -279,7 +279,7 @@ class BkMonitorClient:
             raise BkMonitorApiError(resp["message"])
 
 
-def _make_bk_minotor_backend() -> BkMonitorBackend:
+def _make_bk_minotor_backend(tenant_id) -> BkMonitorBackend:
     if settings.ENABLE_BK_MONITOR_APIGW:
         apigw_client = Client(
             endpoint=settings.BK_API_URL_TMPL,
@@ -289,6 +289,11 @@ def _make_bk_minotor_backend() -> BkMonitorBackend:
             bk_app_code=settings.BK_APP_CODE,
             bk_app_secret=settings.BK_APP_SECRET,
         )
+        apigw_client.update_headers(
+            {
+                "X-Bk-Tenant-Id": tenant_id,
+            }
+        )
         return apigw_client.api
 
     # ESB 开启了免用户认证，但限制用户名不能为空，因此给默认用户名
@@ -296,9 +301,9 @@ def _make_bk_minotor_backend() -> BkMonitorBackend:
     return esb_client.monitor_v3
 
 
-def make_bk_monitor_client() -> BkMonitorClient:
-    return BkMonitorClient(_make_bk_minotor_backend())
+def make_bk_monitor_client(tenant_id) -> BkMonitorClient:
+    return BkMonitorClient(_make_bk_minotor_backend(tenant_id))
 
 
-def make_bk_monitor_space_manager() -> BKMonitorSpaceManager:
-    return BKMonitorSpaceManager(_make_bk_minotor_backend())
+def make_bk_monitor_space_manager(tenant_id) -> BKMonitorSpaceManager:
+    return BKMonitorSpaceManager(_make_bk_minotor_backend(tenant_id))

--- a/apiserver/paasng/paasng/infras/bkmonitorv3/shim.py
+++ b/apiserver/paasng/paasng/infras/bkmonitorv3/shim.py
@@ -23,6 +23,7 @@ from paasng.infras.bkmonitorv3.definitions import gen_bk_monitor_space
 from paasng.infras.bkmonitorv3.models import BKMonitorSpace
 from paasng.infras.iam.tasks import add_monitoring_space_permission
 from paasng.platform.applications.models import Application
+from paasng.platform.applications.tenant import get_tenant_id_for_app
 
 
 def create_bk_monitor_space(application: Application) -> BKMonitorSpace:
@@ -31,7 +32,8 @@ def create_bk_monitor_space(application: Application) -> BKMonitorSpace:
     :param application:
     :return: BKMonitorSpace
     """
-    mgr = make_bk_monitor_space_manager()
+    tenant_id = get_tenant_id_for_app(application.code)
+    mgr = make_bk_monitor_space_manager(tenant_id)
     try:
         # 兼容多个 paas 环境对接同一个蓝鲸监控服务的情况, 先尝试获取同名的 space, 如果存在则不调用蓝鲸监控的创建接口
         space = mgr.get_space_detail(gen_bk_monitor_space(application))
@@ -75,7 +77,8 @@ def update_or_create_bk_monitor_space(application: Application) -> Tuple[BKMonit
     except BKMonitorSpace.DoesNotExist:
         return create_bk_monitor_space(application), True
 
-    mgr = make_bk_monitor_space_manager()
+    tenant_id = get_tenant_id_for_app(application.code)
+    mgr = make_bk_monitor_space_manager(tenant_id)
     space = mgr.update_space(gen_bk_monitor_space(application))
     db_space.id = space.id
     db_space.space_type_id = space.space_type_id

--- a/apiserver/paasng/paasng/infras/iam/client.py
+++ b/apiserver/paasng/paasng/infras/iam/client.py
@@ -44,8 +44,9 @@ logger = logging.getLogger(__name__)
 class BKIAMClient:
     """bk-iam 通过 APIGW 提供的 API"""
 
-    def __init__(self):
+    def __init__(self, tenant_id: str):
         self._client = Client(endpoint=settings.BK_API_URL_TMPL, stage=settings.BK_IAM_APIGW_SERVICE_STAGE)
+        self.tenant_id = tenant_id
         self._client.update_headers(self._prepare_headers())
         self.client: BKIAMGroup = self._client.api
 
@@ -56,7 +57,8 @@ class BKIAMClient:
                     "bk_app_code": settings.BK_APP_CODE,
                     "bk_app_secret": settings.BK_APP_SECRET,
                 }
-            )
+            ),
+            "X-Bk-Tenant-Id": self.tenant_id,
         }
         return headers
 

--- a/apiserver/paasng/paasng/infras/iam/open_apis/providers/application.py
+++ b/apiserver/paasng/paasng/infras/iam/open_apis/providers/application.py
@@ -25,6 +25,7 @@ from iam.resource.utils import Page
 from paasng.infras.iam.client import BKIAMClient
 from paasng.infras.iam.members.models import ApplicationGradeManager
 from paasng.platform.applications.models import Application
+from paasng.platform.applications.tenant import get_tenant_id_for_app
 
 
 class ApplicationProvider(ResourceProvider):
@@ -91,8 +92,7 @@ class ApplicationProvider(ResourceProvider):
         :param app_codes: 蓝鲸应用 ID 列表
         :returns: 审批人信息，格式：{app_code: single_app_approvers}
         """
-        cli = BKIAMClient()
         return {
-            m.app_code: cli.fetch_grade_manager_members(m.grade_manager_id)
+            m.app_code: BKIAMClient(get_tenant_id_for_app(m.app_code)).fetch_grade_manager_members(m.grade_manager_id)
             for m in ApplicationGradeManager.objects.filter(app_code__in=app_codes)
         }

--- a/apiserver/paasng/paasng/misc/monitoring/metrics/clients/bkmonitor.py
+++ b/apiserver/paasng/paasng/misc/monitoring/metrics/clients/bkmonitor.py
@@ -32,8 +32,9 @@ logger = logging.getLogger(__name__)
 class BkMonitorMetricClient:
     query_tmpl_config = BKMONITOR_PROMQL_TMPL
 
-    def __init__(self, bk_biz_id: str):
+    def __init__(self, bk_biz_id: str, tenant_id: str):
         self.bk_biz_id = bk_biz_id
+        self.tenant_id = tenant_id
 
     def general_query(
         self, queries: List[MetricQuery], container_name: str
@@ -82,7 +83,7 @@ class BkMonitorMetricClient:
         """请求蓝鲸监控时序数据 API，若成功则返回 Series 数据(list)，否则抛出异常"""
 
         try:
-            client = make_bk_monitor_client()
+            client = make_bk_monitor_client(self.tenant_id)
             series = client.promql_query(self.bk_biz_id, promql, start, end, step)
         except BkMonitorGatewayServiceError as e:
             logger.warning("fetch metrics failed, promql: %s, start: %s, end: %s, step: %s", promql, start, end, step)

--- a/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/client.py
+++ b/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/client.py
@@ -30,6 +30,7 @@ from paasng.infras.bkmonitorv3.client import make_bk_monitor_client
 from paasng.infras.bkmonitorv3.shim import get_or_create_bk_monitor_space
 from paasng.misc.monitoring.monitor.alert_rules.config import RuleConfig
 from paasng.platform.applications.models import Application
+from paasng.platform.applications.tenant import get_tenant_id_for_app
 
 from .exceptions import AsCodeAPIError
 
@@ -130,7 +131,8 @@ class AsCodeClient:
         """
         space, _ = get_or_create_bk_monitor_space(Application.objects.get(code=self.app_code))
         try:
-            make_bk_monitor_client().as_code_import_config(
+            tenant_id = get_tenant_id_for_app(self.app_code)
+            make_bk_monitor_client(tenant_id).as_code_import_config(
                 configs,
                 int(space.iam_resource_id),
                 config_group or self.app_code,

--- a/apiserver/paasng/paasng/misc/monitoring/monitor/dashboards/manager.py
+++ b/apiserver/paasng/paasng/misc/monitoring/monitor/dashboards/manager.py
@@ -24,6 +24,7 @@ from paasng.infras.bkmonitorv3.client import make_bk_monitor_client
 from paasng.infras.bkmonitorv3.shim import get_or_create_bk_monitor_space
 from paasng.misc.monitoring.monitor.models import AppDashboard, AppDashboardTemplate
 from paasng.platform.applications.models import Application
+from paasng.platform.applications.tenant import get_tenant_id_for_app
 from paasng.platform.modules.models import Module
 
 logger = logging.getLogger(__name__)
@@ -43,7 +44,8 @@ class BkDashboardManager:
     def __init__(self, application: Application):
         self.application = application
         self.app_code = self.application.code
-        self.client = make_bk_monitor_client()
+        tenant_id = get_tenant_id_for_app(self.app_code)
+        self.client = make_bk_monitor_client(tenant_id)
 
     def init_builtin_dashboard(self):
         """初始化内置仪表盘"""

--- a/apiserver/paasng/paasng/platform/applications/helpers.py
+++ b/apiserver/paasng/paasng/platform/applications/helpers.py
@@ -21,6 +21,7 @@ from paasng.infras.iam.client import BKIAMClient
 from paasng.infras.iam.constants import NEVER_EXPIRE_DAYS
 from paasng.infras.iam.members.models import ApplicationGradeManager, ApplicationUserGroup
 from paasng.platform.applications.models import Application
+from paasng.platform.applications.tenant import get_tenant_id_for_app
 from paasng.utils.basic import get_username_by_bkpaas_user_id
 
 logger = logging.getLogger(__name__)
@@ -31,18 +32,19 @@ def register_builtin_user_groups_and_grade_manager(application: Application):
     默认为每个新建的蓝鲸应用创建三个用户组（管理者，开发者，运营者），以及该应用对应的分级管理员
     将 创建者 添加到 管理者用户组 以获取应用的管理权限，并添加为 分级管理员成员 以获取审批其他用户加入各个用户组的权限
     """
-    cli = BKIAMClient()
+    tenant_id = get_tenant_id_for_app(application.app_code)
+    iam_client = BKIAMClient(tenant_id)
     creator = get_username_by_bkpaas_user_id(application.creator)
 
     # 1. 创建分级管理员，并记录分级管理员 ID
-    grade_manager_id = cli.create_grade_managers(application.code, application.name, creator)
+    grade_manager_id = iam_client.create_grade_managers(application.code, application.name, creator)
     ApplicationGradeManager.objects.create(app_code=application.code, grade_manager_id=grade_manager_id)
 
     # 2. 将创建者，添加为分级管理员的成员
-    cli.add_grade_manager_members(grade_manager_id, [creator])
+    iam_client.add_grade_manager_members(grade_manager_id, [creator])
 
     # 3. 创建默认的 管理者，开发者，运营者用户组
-    user_groups = cli.create_builtin_user_groups(grade_manager_id, application.code)
+    user_groups = iam_client.create_builtin_user_groups(grade_manager_id, application.code)
     ApplicationUserGroup.objects.bulk_create(
         [
             ApplicationUserGroup(app_code=application.code, role=group["role"], user_group_id=group["id"])
@@ -51,7 +53,7 @@ def register_builtin_user_groups_and_grade_manager(application: Application):
     )
 
     # 4. 为默认的三个用户组授权
-    cli.grant_user_group_policies(application.code, application.name, user_groups)
+    iam_client.grant_user_group_policies(application.code, application.name, user_groups)
 
     # 5. 将创建者添加到管理者用户组，返回数据中第一个即为管理者用户组信息
-    cli.add_user_group_members(user_groups[0]["id"], [creator], NEVER_EXPIRE_DAYS)
+    iam_client.add_user_group_members(user_groups[0]["id"], [creator], NEVER_EXPIRE_DAYS)

--- a/apiserver/paasng/paasng/platform/applications/models.py
+++ b/apiserver/paasng/paasng/platform/applications/models.py
@@ -33,7 +33,6 @@ from paasng.core.core.storages.redisdb import get_default_redis
 from paasng.core.region.models import get_region
 from paasng.core.tenant.constants import AppTenantMode
 from paasng.core.tenant.user import DEFAULT_TENANT_ID
-from paasng.infras.iam.helpers import fetch_role_members
 from paasng.infras.iam.permissions.resources.application import ApplicationPermission
 from paasng.platform.applications.constants import AppFeatureFlag, ApplicationRole, ApplicationType
 from paasng.platform.modules.constants import SourceOrigin
@@ -433,10 +432,14 @@ class Application(OwnerTimestampedModel):
 
     def get_administrators(self):
         """获取具有管理权限的人员名单"""
+        from paasng.infras.iam.helpers import fetch_role_members
+
         return fetch_role_members(self.code, ApplicationRole.ADMINISTRATOR)
 
     def get_devopses(self) -> List[str]:
         """获取具有运营权限的人员名单"""
+        from paasng.infras.iam.helpers import fetch_role_members
+
         devopses = fetch_role_members(self.code, ApplicationRole.OPERATOR) + fetch_role_members(
             self.code, ApplicationRole.ADMINISTRATOR
         )
@@ -444,6 +447,8 @@ class Application(OwnerTimestampedModel):
 
     def get_developers(self) -> List[str]:
         """获取具有开发权限的人员名单"""
+        from paasng.infras.iam.helpers import fetch_role_members
+
         developers = fetch_role_members(self.code, ApplicationRole.DEVELOPER) + fetch_role_members(
             self.code, ApplicationRole.ADMINISTRATOR
         )

--- a/apiserver/paasng/paasng/platform/applications/tenant.py
+++ b/apiserver/paasng/paasng/platform/applications/tenant.py
@@ -14,6 +14,7 @@
 #
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
+import logging
 
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import ValidationError
@@ -21,6 +22,9 @@ from rest_framework.exceptions import ValidationError
 from paasng.core.tenant.constants import AppTenantMode
 from paasng.core.tenant.user import Tenant, get_tenant
 from paasng.infras.accounts.models import User
+from paasng.platform.applications.models import Application
+
+logger = logging.getLogger(__name__)
 
 
 def validate_app_tenant_params(user: User, raw_app_tenant_mode: str | None) -> tuple[AppTenantMode, str, Tenant]:
@@ -42,3 +46,12 @@ def validate_app_tenant_params(user: User, raw_app_tenant_mode: str | None) -> t
 
     app_tenant_id = "" if app_tenant_mode == AppTenantMode.GLOBAL else tenant.id
     return app_tenant_mode, app_tenant_id, tenant
+
+
+def get_tenant_id_for_app(app_code: str) -> str:
+    try:
+        app = Application.objects.get(code=app_code)
+    except Application.DoesNotExist:
+        logger.warning("Application: %s DoesNotExist", app_code)
+        return ""
+    return app.tenant_id

--- a/apiserver/paasng/paasng/platform/applications/views.py
+++ b/apiserver/paasng/paasng/platform/applications/views.py
@@ -53,7 +53,7 @@ from paasng.core.core.storages.object_storage import app_logo_storage
 from paasng.core.core.storages.sqlalchemy import legacy_db
 from paasng.core.region.models import get_all_regions
 from paasng.core.tenant.constants import AppTenantMode
-from paasng.core.tenant.user import DEFAULT_TENANT_ID
+from paasng.core.tenant.user import DEFAULT_TENANT_ID, get_tenant
 from paasng.infras.accounts.constants import AccountFeatureFlag as AFF
 from paasng.infras.accounts.constants import FunctionType
 from paasng.infras.accounts.models import AccountFeatureFlag, make_verifier
@@ -640,7 +640,7 @@ class ApplicationCreateViewSet(viewsets.ViewSet):
             bk_token = request.COOKIES.get(settings.BK_COOKIE_NAME, None)
             try:
                 # 目前页面创建的应用名称都存储在 name_zh_cn 字段中, name_en 只用于 smart 应用
-                make_bk_lesscode_client(login_cookie=bk_token).create_app(
+                make_bk_lesscode_client(login_cookie=bk_token, tenant_id=get_tenant(request.user).id).create_app(
                     params["code"], params["name_zh_cn"], ModuleName.DEFAULT.value
                 )
             except (LessCodeApiError, LessCodeGatewayServiceError) as e:
@@ -707,7 +707,9 @@ class ApplicationCreateViewSet(viewsets.ViewSet):
         """在开发者中心产品页面上创建 Lesscode 应用时，需要同步在 Lesscode 产品上创建应用"""
         bk_token = request.COOKIES.get(settings.BK_COOKIE_NAME, None)
         try:
-            make_bk_lesscode_client(login_cookie=bk_token).create_app(code, name, ModuleName.DEFAULT.value)
+            make_bk_lesscode_client(login_cookie=bk_token, tenant_id=get_tenant(request.user).id).create_app(
+                code, name, ModuleName.DEFAULT.value
+            )
         except (LessCodeApiError, LessCodeGatewayServiceError) as e:
             raise error_codes.CREATE_LESSCODE_APP_ERROR.f(e.message)
 

--- a/apiserver/paasng/paasng/platform/bk_lesscode/client.py
+++ b/apiserver/paasng/paasng/platform/bk_lesscode/client.py
@@ -59,7 +59,8 @@ class LessCodeClient:
                     "bk_app_secret": settings.BK_APP_SECRET,
                     self.login_cookie_name: self.login_cookie,
                 }
-            )
+            ),
+            "X-Bk-Tenant-Id": self.tenant_id,
         }
 
         # 需要 lesscode 的 API 支持国际化

--- a/apiserver/paasng/paasng/platform/bk_lesscode/client.py
+++ b/apiserver/paasng/paasng/platform/bk_lesscode/client.py
@@ -41,10 +41,11 @@ class DummyLessCodeClient:
 class LessCodeClient:
     """bk_lesscode 通过 APIGW 提供的 API"""
 
-    def __init__(self, login_cookie: str, client: Optional[LessCodeGroup] = None):
+    def __init__(self, login_cookie: str, tenant_id: str, client: Optional[LessCodeGroup] = None):
         self.client = client or self._make_api_client()
         self.login_cookie_name = settings.BK_COOKIE_NAME
         self.login_cookie = login_cookie
+        self.tenant_id = tenant_id
 
     def _make_api_client(self) -> LessCodeGroup:
         """Make a client object for requesting"""
@@ -105,8 +106,8 @@ class LessCodeClient:
         return f"{settings.BK_LESSCODE_URL}{address_path}"
 
 
-def make_bk_lesscode_client(login_cookie: str, client: Optional[LessCodeGroup] = None):
+def make_bk_lesscode_client(login_cookie: str, tenant_id: str, client: Optional[LessCodeGroup] = None):
     if settings.ENABLE_BK_LESSCODE_APIGW:
-        return LessCodeClient(login_cookie, client)
+        return LessCodeClient(login_cookie, tenant_id, client)
     else:
         return DummyLessCodeClient()

--- a/apiserver/paasng/paasng/platform/bk_lesscode/views.py
+++ b/apiserver/paasng/paasng/platform/bk_lesscode/views.py
@@ -20,6 +20,7 @@ from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from paasng.core.tenant.user import get_tenant
 from paasng.infras.accounts.permissions.application import application_perm_class
 from paasng.infras.iam.permissions.resources.application import AppAction
 from paasng.platform.applications.mixins import ApplicationCodeInPathMixin
@@ -38,8 +39,8 @@ class LesscodeModuleViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
         address_in_lesscode = ""
         if module.source_origin == SourceOrigin.BK_LESS_CODE:
             bk_token = request.COOKIES.get(settings.BK_COOKIE_NAME, None)
-            address_in_lesscode = make_bk_lesscode_client(login_cookie=bk_token).get_address(
-                application.code, module.name
-            )
+            address_in_lesscode = make_bk_lesscode_client(
+                login_cookie=bk_token, tenant_id=get_tenant(request.user).id
+            ).get_address(application.code, module.name)
 
         return Response(data={"address_in_lesscode": address_in_lesscode, "tips": settings.BK_LESSCODE_TIPS})

--- a/apiserver/paasng/paasng/platform/engine/deploy/bg_build/executors.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/bg_build/executors.py
@@ -36,6 +36,7 @@ from paasng.infras.bk_ci import entities
 from paasng.infras.bk_ci.client import BkCIPipelineClient
 from paasng.infras.bk_ci.constants import PipelineBuildStatus
 from paasng.infras.bk_ci.exceptions import BkCIGatewayServiceError
+from paasng.platform.applications.tenant import get_tenant_id_for_app
 from paasng.platform.engine.constants import BuildStatus
 from paasng.platform.engine.deploy.bg_build.exceptions import (
     BkCIPipelineBuildNotSuccess,
@@ -261,7 +262,8 @@ class PipelineBuildProcessExecutor(DeployStep):
 
         self.bp = bp
         self.wl_app: "WlApp" = bp.app
-        self.ctl = BkCIPipelineClient(bk_username=settings.BK_CI_CLIENT_USERNAME)
+        tenant_id = get_tenant_id_for_app(deployment.get_application().code)
+        self.ctl = BkCIPipelineClient(tenant_id, bk_username=settings.BK_CI_CLIENT_USERNAME)
 
     def execute(self, metadata: Dict):
         """Execute the build process"""

--- a/apiserver/paasng/paasng/platform/modules/views.py
+++ b/apiserver/paasng/paasng/platform/modules/views.py
@@ -35,6 +35,7 @@ from paas_wl.workloads.images.models import AppUserCredential
 from paasng.accessories.publish.market.models import MarketConfig
 from paasng.accessories.publish.market.protections import ModulePublishPreparer
 from paasng.core.region.models import get_region
+from paasng.core.tenant.user import get_tenant
 from paasng.infras.accounts.permissions.application import (
     app_action_required,
     application_perm_class,
@@ -112,7 +113,7 @@ class ModuleViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
         if source_origin == SourceOrigin.BK_LESS_CODE:
             bk_token = request.COOKIES.get(settings.BK_COOKIE_NAME, None)
             try:
-                make_bk_lesscode_client(login_cookie=bk_token).create_app(
+                make_bk_lesscode_client(login_cookie=bk_token, tenant_id=get_tenant(request.user).id).create_app(
                     application.code, application.name, data["name"]
                 )
             except (LessCodeApiError, LessCodeGatewayServiceError) as e:

--- a/apiserver/paasng/paasng/settings/utils.py
+++ b/apiserver/paasng/paasng/settings/utils.py
@@ -169,6 +169,7 @@ def get_service_remote_endpoints(settings: LazySettings) -> List[Dict]:
                     "endpoint_url": otel_ep_url,
                     "provision_params_tmpl": {
                         "app_code": "{application.code}",
+                        "tenant_id": "{application.tenant_id}",
                         "bk_monitor_space_id": "{bk_monitor_space_id}",
                         "env": "{env.environment}",
                     },

--- a/apiserver/paasng/tests/conftest.py
+++ b/apiserver/paasng/tests/conftest.py
@@ -394,10 +394,6 @@ def _mock_iam():
             new=StubBKIAMClient,
         ),
         mock.patch(
-            "paasng.infras.iam.helpers.IAM_CLI",
-            new=StubBKIAMClient(),
-        ),
-        mock.patch(
             "paasng.infras.accounts.permissions.application.user_has_app_action_perm",
             new=mock_user_has_app_action_perm,
         ),
@@ -521,6 +517,11 @@ def bk_deployment(bk_module):
 def bk_deployment_full(bk_module_full):
     """Generate a simple deployment object for bk_module_full(which have source_obj)"""
     return create_fake_deployment(bk_module_full)
+
+
+@pytest.fixture()
+def tenant_id():
+    return "system"
 
 
 @pytest.fixture()

--- a/apiserver/paasng/tests/paasng/accessories/cloudapi/test_bk_apigateway_inner.py
+++ b/apiserver/paasng/tests/paasng/accessories/cloudapi/test_bk_apigateway_inner.py
@@ -34,8 +34,9 @@ class TestBkApigatewayInnerComponent:
                             "bk_app_code": "test",
                             "bk_app_secret": "app-secret",
                             "bk_username": "admin",
-                        }
-                    )
+                        },
+                    ),
+                    "X-Bk-Tenant-Id": "system",
                 },
             ),
             (
@@ -49,11 +50,12 @@ class TestBkApigatewayInnerComponent:
                             "bk_username": "admin",
                         }
                     ),
+                    "X-Bk-Tenant-Id": "system",
                 },
             ),
         ],
     )
-    def test_prepare_headers(self, settings, mocker, fake_language, expected):
+    def test_prepare_headers(self, settings, mocker, tenant_id, fake_language, expected):
         settings.BK_APP_CODE = "test"
         settings.BK_APP_SECRET = "app-secret"
 
@@ -63,6 +65,5 @@ class TestBkApigatewayInnerComponent:
         )
 
         comp = BkApigatewayInnerComponent()
-        result = comp._prepare_headers("admin")
-
+        result = comp._prepare_headers("admin", tenant_id)
         assert result == expected

--- a/apiserver/paasng/tests/paasng/accessories/servicehub/conftest.py
+++ b/apiserver/paasng/tests/paasng/accessories/servicehub/conftest.py
@@ -65,7 +65,7 @@ def _faked_remote_services():
     config_json = {
         "name": "obj_store_remote",
         "endpoint_url": "http://faked-host",
-        "provision_params_tmpl": {"username": "{engine_app.name}"},
+        "provision_params_tmpl": {"username": "{engine_app.name}", "tenant_id": "{application.tenant_id}"},
         "jwt_auth_conf": {"iss": "foo", "key": "s1"},
     }
     meta_info = {"version": None}

--- a/apiserver/paasng/tests/paasng/misc/monitoring/metrics/test_metric_manager.py
+++ b/apiserver/paasng/tests/paasng/misc/monitoring/metrics/test_metric_manager.py
@@ -45,8 +45,8 @@ class TestResourceMetricManager:
         self.worker_process.instances = [create_wl_instance(self.app)]
 
     @pytest.fixture()
-    def metric_client(self):
-        return BkMonitorMetricClient(bk_biz_id="123")
+    def metric_client(self, tenant_id):
+        return BkMonitorMetricClient(bk_biz_id="123", tenant_id=tenant_id)
 
     def test_normal_gen_series_query(self, metric_client):
         manager = ResourceMetricManager(process=self.web_process, metric_client=metric_client, bcs_cluster_id="")

--- a/apiserver/paasng/tests/paasng/platform/test_lesscode.py
+++ b/apiserver/paasng/tests/paasng/platform/test_lesscode.py
@@ -91,8 +91,8 @@ def bk_module_name():
 
 
 class TestBkLesscode:
-    def test_call_api_succeeded(self, bk_token, bk_app_code, bk_app_name, bk_module_name, fake_good_client):
-        lesscode_client = make_bk_lesscode_client(bk_token, fake_good_client)
+    def test_call_api_succeeded(self, bk_token, tenant_id, bk_app_code, bk_app_name, bk_module_name, fake_good_client):
+        lesscode_client = make_bk_lesscode_client(bk_token, tenant_id, fake_good_client)
         is_created = lesscode_client.create_app(bk_app_code, bk_app_name, bk_module_name)
 
         assert is_created is True
@@ -102,19 +102,19 @@ class TestBkLesscode:
         assert kwargs["data"]["appCode"] == bk_app_code
         assert kwargs["data"]["moduleCode"] == bk_module_name
 
-    def test_call_api_failed(self, bk_token, bk_app_code, bk_app_name, bk_module_name, fake_bad_client):
-        lesscode_client = make_bk_lesscode_client(bk_token, fake_bad_client)
+    def test_call_api_failed(self, bk_token, tenant_id, bk_app_code, bk_app_name, bk_module_name, fake_bad_client):
+        lesscode_client = make_bk_lesscode_client(bk_token, tenant_id, fake_bad_client)
         with pytest.raises(LessCodeApiError):
             _ = lesscode_client.create_app(bk_app_code, bk_app_name, bk_module_name)
 
-    def test_get_address_succeeded(self, bk_token, bk_app_code, bk_module_name, fake_good_client):
-        lesscode_client = make_bk_lesscode_client(bk_token, fake_good_client)
+    def test_get_address_succeeded(self, bk_token, tenant_id, bk_app_code, bk_module_name, fake_good_client):
+        lesscode_client = make_bk_lesscode_client(bk_token, tenant_id, fake_good_client)
         address = lesscode_client.get_address(bk_app_code, bk_module_name)
 
         assert address == f"{settings.BK_LESSCODE_URL}/project/168/pages"
 
-    def test_get_address_failed(self, bk_token, bk_app_code, bk_module_name, fake_bad_client):
-        lesscode_client = make_bk_lesscode_client(bk_token, fake_bad_client)
+    def test_get_address_failed(self, bk_token, tenant_id, bk_app_code, bk_module_name, fake_bad_client):
+        lesscode_client = make_bk_lesscode_client(bk_token, tenant_id, fake_bad_client)
         # 获取地址失败时不抛异常，只返回空地址
         address = lesscode_client.get_address(bk_app_code, bk_module_name)
         assert address == ""

--- a/apiserver/paasng/tests/paasng/platform/test_lesscode.py
+++ b/apiserver/paasng/tests/paasng/platform/test_lesscode.py
@@ -99,6 +99,7 @@ class TestBkLesscode:
         assert fake_good_client.create_project_by_app.called
         _, kwargs = fake_good_client.create_project_by_app.call_args_list[0]
         assert kwargs["headers"]["x-bkapi-authorization"] != ""
+        assert kwargs["headers"]["X-Bk-Tenant-Id"] == tenant_id
         assert kwargs["data"]["appCode"] == bk_app_code
         assert kwargs["data"]["moduleCode"] == bk_module_name
 

--- a/svc-otel/README.md
+++ b/svc-otel/README.md
@@ -117,6 +117,7 @@ SERVICE_REMOTE_ENDPOINTS:
       key: xxx # 与增强服务中配置的 PAAS_SERVICE_JWT_CLIENTS_KEY 的值一致
     provision_params_tmpl:
       app_code: "{application.code}"
+      tenant_id: "{application.tenant_id}"
       bk_monitor_space_id: "{bk_monitor_space_id}"
       env: "{env.environment}"
 ```


### PR DESCRIPTION
所有调用 APIGW 的 API 都需要添加 X-Bk-Tenant-Id 请求头，值为 Application 表的 tenant_id，如果调用的地方没有应用信息，则取当前用户的 tenant_id。

TODO：
1. 通过 bk-iam sdk 的 API 调用，需要 SDK 先添加 tenant-id 的请求参数
2. BCS: main 分支中已经优化了 BCS 的调用方法，合入 main 分支后后再修改 BCS API 的请求头
3. 插件中心：PluginInstance 表目前还没有租户信息，后续再单独提 pr 处理