### PR TITLE
fix: user interrupt not work well sometimes

### DIFF
--- a/apiserver/paasng/paas_wl/bk_app/cnative/specs/constants.py
+++ b/apiserver/paasng/paas_wl/bk_app/cnative/specs/constants.py
@@ -63,6 +63,9 @@ EGRESS_CLUSTER_STATE_NAME_ANNO_KEY = "bkapp.paas.bk.tencent.com/egress-cluster-s
 # 轮询云原生应用的部署状态时，如果获取到失败状态的次数超过最大容忍次数，就认为部署失败
 CNATIVE_DEPLOY_STATUS_POLLING_FAILURE_LIMITS = 3
 
+# 上次部署的状态
+LAST_DEPLOY_STATUS_ANNO_KEY = "bkapp.paas.bk.tencent.com/last-deploy-status"
+
 # PROC_SERVICES_ENABLED_ANNOTATION_KEY 注解表示是否启用 process services 特性, 可选值为 "true" 或 "false".
 # true 表示 operator 将根据 process services 的配置来创建和关联 k8s service.
 # 该注解实际为了向后兼容 spec_version: 2 而设计, 当版本 <= spec_version: 2 时, 设置值为 "false", 否则设置为 "true".

--- a/apiserver/paasng/paasng/platform/bkapp_model/manifest.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/manifest.py
@@ -616,8 +616,9 @@ def apply_egress_annotations(model_res: crd.BkAppResource, env: ModuleEnvironmen
 
 
 def _get_last_deploy_status(env: ModuleEnvironment, deployment: Deployment) -> str:
+    """获取上一次部署的状态"""
     try:
-        latest_dp = Deployment.objects.exclude(pk=deployment.pk).filter_by_env(env=env).latest("created")
+        latest_dp = Deployment.objects.filter_by_env(env).filter(created__lt=deployment.created).latest("created")
     except Deployment.DoesNotExist:
         return ""
     else:

--- a/apiserver/paasng/paasng/platform/bkapp_model/manifest.py
+++ b/apiserver/paasng/paasng/platform/bkapp_model/manifest.py
@@ -71,7 +71,6 @@ from paasng.platform.bkapp_model.utils import (
 )
 from paasng.platform.engine.configurations.config_var import get_env_variables
 from paasng.platform.engine.constants import AppEnvName, ConfigVarEnvName, RuntimeType
-from paasng.platform.engine.models import Deployment
 from paasng.platform.engine.models.config_var import ENVIRONMENT_ID_FOR_GLOBAL, ConfigVar
 from paasng.platform.engine.models.preset_envvars import PresetEnvVariable
 from paasng.platform.modules.constants import DeployHookType
@@ -468,7 +467,6 @@ def get_bkapp_resource_for_deploy(
     force_image: Optional[str] = None,
     image_pull_policy: Optional[str] = None,
     use_cnb: bool = False,
-    deployment: Optional[Deployment] = None,
 ) -> crd.BkAppResource:
     """Get the BkApp manifest for deploy.
 
@@ -477,7 +475,6 @@ def get_bkapp_resource_for_deploy(
     :param force_image: If given, set the image of the application to this value.
     :param image_pull_policy: If given, set the imagePullPolicy to this value.
     :param use_cnb: A bool flag describe if the bkapp image is built with cnb
-    :param deployment: The related deployment instance
     :returns: The BkApp resource that is ready for deploying.
     """
     model_res = get_bkapp_resource(env.module)

--- a/apiserver/paasng/paasng/platform/engine/deploy/bg_command/pre_release.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/bg_command/pre_release.py
@@ -128,7 +128,7 @@ class CommandPoller(DeployPoller):
 
         coordinator = DeploymentCoordinator(deployment.app_environment)
         # 若判断任务状态超时，则认为任务失败，否则更新上报状态时间
-        if coordinator.status_polling_timeout:
+        if coordinator.is_status_polling_timeout:
             command_status = CommandStatus.FAILED
         else:
             coordinator.update_polling_time()

--- a/apiserver/paasng/paasng/platform/engine/deploy/bg_command/pre_release.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/bg_command/pre_release.py
@@ -43,6 +43,10 @@ class ApplicationPreReleaseExecutor(DeployStep):
 
     @DeployStep.procedures
     def start(self):
+        if self.deployment.has_requested_int:
+            self.state_mgr.finish(JobStatus.INTERRUPTED, "app pre-release interrupted")
+            return None
+
         pre_phase_start.send(self, phase=DeployPhaseTypes.RELEASE)
 
         hook = self.deployment.get_deploy_hooks().get_hook(type_=DeployHookType.PRE_RELEASE_HOOK)

--- a/apiserver/paasng/paasng/platform/engine/deploy/building.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/building.py
@@ -451,7 +451,7 @@ class BuildProcessPoller(DeployPoller):
         else:
             coordinator = DeploymentCoordinator(deployment.app_environment)
             # 若判断任务状态超时，则认为任务失败，否则更新上报状态时间
-            if coordinator.status_polling_timeout:
+            if coordinator.is_status_polling_timeout:
                 logger.warning(
                     "Polling status of build process [%s] timed out, consider it failed, deployment: %s",
                     self.params["build_process_id"],

--- a/apiserver/paasng/paasng/platform/engine/deploy/image_release.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/image_release.py
@@ -65,6 +65,10 @@ class ImageReleaseMgr(DeployStep):
 
     @DeployStep.procedures
     def start(self):
+        if self.deployment.has_requested_int:
+            self.state_mgr.finish(JobStatus.INTERRUPTED, "image release interrupted")
+            return
+
         if self.module_environment.application.type == ApplicationType.CLOUD_NATIVE.value:
             # 如果是云原生应用，更新 deployment 的 bkapp_revision_id
             bkapp_revision_id = self.create_bkapp_revision()

--- a/apiserver/paasng/paasng/platform/engine/deploy/image_release.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/image_release.py
@@ -65,10 +65,6 @@ class ImageReleaseMgr(DeployStep):
 
     @DeployStep.procedures
     def start(self):
-        if self.deployment.has_requested_int:
-            self.state_mgr.finish(JobStatus.INTERRUPTED, "image release interrupted")
-            return
-
         if self.module_environment.application.type == ApplicationType.CLOUD_NATIVE.value:
             # 如果是云原生应用，更新 deployment 的 bkapp_revision_id
             bkapp_revision_id = self.create_bkapp_revision()

--- a/apiserver/paasng/paasng/platform/engine/deploy/interruptions.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/interruptions.py
@@ -55,16 +55,7 @@ def interrupt_deployment(deployment: Deployment, user: User):
 
     # 若部署进程的数据上报已经超时，则认为部署失败，主动解锁
     coordinator = DeploymentCoordinator(deployment.app_environment)
-    if (
-        (current_deployment := coordinator.get_current_deployment())
-        and coordinator.status_polling_timeout
-        and current_deployment.pk == deployment.pk
-    ):
-        # Release deploy lock
-        try:
-            coordinator.release_lock(expected_deployment=deployment)
-        except ValueError as e:
-            logger.warning("Failed to release the deployment lock: %s", e)
+    coordinator.release_if_polling_timed_out(expected_deployment=deployment)
 
     if deployment.build_process_id:
         try:

--- a/apiserver/paasng/paasng/platform/engine/deploy/release/legacy.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/release/legacy.py
@@ -54,6 +54,10 @@ class ApplicationReleaseMgr(DeployStep):
 
     @DeployStep.procedures
     def start(self):
+        if self.deployment.has_requested_int:
+            self.state_mgr.finish(JobStatus.INTERRUPTED, "app release interrupted")
+            return
+
         with self.procedure("更新进程配置"):
             # Turn the processes into the corresponding type in paas_wl module
             procs = self.deployment.get_processes()

--- a/apiserver/paasng/paasng/platform/engine/deploy/release/operator.py
+++ b/apiserver/paasng/paasng/platform/engine/deploy/release/operator.py
@@ -128,6 +128,7 @@ def release_by_k8s_operator(
         bkapp_res = get_bkapp_resource_for_deploy(
             env,
             deploy_id=str(app_model_deploy.id),
+            deployment=deployment,
             force_image=build.image,
             image_pull_policy=advanced_options.image_pull_policy if advanced_options else None,
             use_cnb=build.is_build_from_cnb(),

--- a/apiserver/paasng/paasng/platform/engine/models/deployment.py
+++ b/apiserver/paasng/paasng/platform/engine/models/deployment.py
@@ -118,6 +118,7 @@ class Deployment(OperationVersionBase):
     pre_release_status = models.CharField(
         choices=JobStatus.get_choices(), max_length=16, default=JobStatus.PENDING.value
     )
+    # 字段 pre_release_int_requested_at 未实际使用
     pre_release_int_requested_at = models.DateTimeField(null=True, help_text="用户请求中断 pre-release 的时间")
     release_id = models.UUIDField(max_length=32, null=True)
     bkapp_release_id = models.BigIntegerField(null=True, help_text="云原生应用发布记录ID")

--- a/apiserver/paasng/paasng/platform/engine/workflow/flow.py
+++ b/apiserver/paasng/paasng/platform/engine/workflow/flow.py
@@ -273,11 +273,6 @@ class DeploymentCoordinator:
         """Get current deployment"""
         deployment_id = self.redis.get(self.key_name_deployment)
         if deployment_id:
-            # 若存在部署进程，但数据上报已经超时，则认为部署失败，主动解锁并失效
-            if self.status_polling_timeout:
-                self.release_lock()
-                return None
-
             return Deployment.objects.get(pk=force_str(deployment_id))
         return None
 

--- a/apiserver/paasng/paasng/platform/engine/workflow/flow.py
+++ b/apiserver/paasng/paasng/platform/engine/workflow/flow.py
@@ -264,6 +264,19 @@ class DeploymentCoordinator:
 
         self.redis.transaction(execute_release, self.key_name_deployment)
 
+    def release_if_polling_timed_out(self, expected_deployment: Deployment):
+        """release the deploy lock if status polling time out of the deployment"""
+        if (
+            (current_deployment := self.get_current_deployment())
+            and self.is_status_polling_timeout
+            and current_deployment.pk == expected_deployment.pk
+        ):
+            # Release deploy lock
+            try:
+                self.release_lock(expected_deployment=expected_deployment)
+            except ValueError as e:
+                logger.warning("Failed to release the deployment lock: %s", e)
+
     def set_deployment(self, deployment: Deployment):
         """Set current deployment"""
         self.redis.set(self.key_name_deployment, str(deployment.pk), px=self.timeout_ms)
@@ -281,7 +294,7 @@ class DeploymentCoordinator:
         self.redis.set(self.key_name_latest_polling_time, time.time(), px=self.timeout_ms)
 
     @property
-    def status_polling_timeout(self) -> bool:
+    def is_status_polling_timeout(self) -> bool:
         """检查报告时间是否超时. 目前用于 build 和 hook 流程的控制"""
         latest_polling_time = self.redis.get(self.key_name_latest_polling_time)
         # 如果没有上次报告状态时间，则认为未超时，并设置查询时间为上次报告时间

--- a/apiserver/paasng/paasng/platform/engine/workflow/flow.py
+++ b/apiserver/paasng/paasng/platform/engine/workflow/flow.py
@@ -282,7 +282,7 @@ class DeploymentCoordinator:
 
     @property
     def status_polling_timeout(self) -> bool:
-        """检查报告时间是否超时"""
+        """检查报告时间是否超时. 目前用于 build 和 hook 流程的控制"""
         latest_polling_time = self.redis.get(self.key_name_latest_polling_time)
         # 如果没有上次报告状态时间，则认为未超时，并设置查询时间为上次报告时间
         if not latest_polling_time:

--- a/apiserver/paasng/tests/api/core/tenant/test_tenant.py
+++ b/apiserver/paasng/tests/api/core/tenant/test_tenant.py
@@ -14,38 +14,41 @@
 #
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
-
+from typing import List
 from unittest.mock import patch
 
+import cattrs
 import pytest
 from django.urls import reverse
 from rest_framework import status
+
+from paasng.infras.bk_user import entities
 
 
 class TestBCSResourceViewSet:
     @pytest.fixture(autouse=True)
     def _patch_bcs_api(self):
-        with patch(
-            "paasng.infras.bk_user.client.Client.api.list_tenants",
-            return_value={
-                "data": [
-                    {
-                        "id": "system",
-                        "name": "运营租户",
-                        "status": "enabled",
-                    },
-                    {
-                        "id": "blueking",
-                        "name": "蓝鲸",
-                        "status": "enabled",
-                    },
-                    {
-                        "id": "legacy",
-                        "name": "存量",
-                        "status": "disabled",
-                    },
-                ],
+        resp_data = [
+            {
+                "id": "system",
+                "name": "运营租户",
+                "status": "enabled",
             },
+            {
+                "id": "blueking",
+                "name": "蓝鲸",
+                "status": "enabled",
+            },
+            {
+                "id": "legacy",
+                "name": "存量",
+                "status": "disabled",
+            },
+        ]
+
+        with patch(
+            "paasng.core.tenant.views.BkUserClient.list_tenants",
+            return_value=cattrs.structure(resp_data, List[entities.Tenant]),
         ):
             yield
 

--- a/apiserver/paasng/tests/paasng/platform/engine/deploy/test_pre_release.py
+++ b/apiserver/paasng/tests/paasng/platform/engine/deploy/test_pre_release.py
@@ -15,12 +15,16 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
+import datetime
 from unittest import mock
 
 import pytest
 
+from paasng.platform.engine.constants import JobStatus, OperationTypes
 from paasng.platform.engine.deploy.bg_command.pre_release import ApplicationPreReleaseExecutor
 from paasng.platform.engine.handlers import attach_all_phases
+from paasng.platform.engine.models.deployment import Deployment
+from paasng.platform.engine.models.operations import ModuleEnvironmentOperations
 from paasng.platform.engine.utils.output import Style
 from paasng.platform.modules.constants import DeployHookType
 from paasng.platform.modules.models.deploy_config import Hook
@@ -78,3 +82,21 @@ class TestApplicationPreReleaseExecutor:
         assert mocked_stream().write_message.call_args[0][0] == Style.Warning(
             "The Pre-release command is not configured, skip the Pre-release phase."
         )
+
+    def test_interrupted(self, bk_module_full):
+        deployment = create_fake_deployment(bk_module_full)
+        ModuleEnvironmentOperations.objects.create(
+            application=bk_module_full.application,
+            operation_type=OperationTypes.ONLINE.value,
+            object_uid=deployment.pk,
+        )
+
+        deployment.build_int_requested_at = datetime.datetime.now()
+        deployment.release_int_requested_at = datetime.datetime.now()
+        deployment.save()
+
+        attach_all_phases(sender=deployment.app_environment, deployment=deployment)
+        ApplicationPreReleaseExecutor.from_deployment_id(deployment.pk).start()
+
+        assert Deployment.objects.get(pk=deployment.pk).status == JobStatus.INTERRUPTED
+        assert ModuleEnvironmentOperations.objects.get(object_uid=deployment.pk).status == JobStatus.INTERRUPTED

--- a/operator/api/v1alpha2/constants.go
+++ b/operator/api/v1alpha2/constants.go
@@ -118,6 +118,8 @@ const (
 	DeploySkipUpdateAnnoKey = "bkapp.paas.bk.tencent.com/deployment-skip-update"
 	// LastSyncedSerializedBkAppAnnoKey 注解保存上一次用于同步 workloads 资源的序列化过的 BkApp 内容
 	LastSyncedSerializedBkAppAnnoKey = "bkapp.paas.bk.tencent.com/last-synced-serialized-bkapp"
+	// LastDeployStatusAnnoKey 注解保存上一次的部署状态
+	LastDeployStatusAnnoKey = "bkapp.paas.bk.tencent.com/last-deploy-status"
 )
 
 const (

--- a/operator/pkg/controllers/bkapp/deploy_action.go
+++ b/operator/pkg/controllers/bkapp/deploy_action.go
@@ -36,7 +36,7 @@ import (
 	hookres "bk.tencent.com/paas-app-operator/pkg/controllers/bkapp/hooks/resources"
 	procres "bk.tencent.com/paas-app-operator/pkg/controllers/bkapp/processes/resources"
 	"bk.tencent.com/paas-app-operator/pkg/metrics"
-	platform "bk.tencent.com/paas-app-operator/pkg/platform/deploy"
+	platdeploy "bk.tencent.com/paas-app-operator/pkg/platform/deploy"
 )
 
 // NewDeployActionReconciler returns a DeployActionReconciler.
@@ -109,7 +109,7 @@ func (r *DeployActionReconciler) Reconcile(ctx context.Context, bkapp *paasv1alp
 func (r *DeployActionReconciler) validateNoRunningHooks(ctx context.Context, bkapp *paasv1alpha2.BkApp) error {
 	// 如果上一次的部署是被用户主动中断, 则继续执行后续的部署调和流程, 忽略可能处于 progressing 状态的旧 hook
 	// TODO 考虑支持更实时的中断请求, 包括直接删除执行中的 hook 等?
-	if platform.GetLastDeployStatus(bkapp) == "interrupted" {
+	if platdeploy.GetLastDeployStatus(bkapp) == "interrupted" {
 		return nil
 	}
 	// Check pre-release hook

--- a/operator/pkg/platform/deploy/deploy.go
+++ b/operator/pkg/platform/deploy/deploy.go
@@ -1,0 +1,28 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+ * Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *	http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package deploy
+
+import (
+	paasv1alpha2 "bk.tencent.com/paas-app-operator/api/v1alpha2"
+)
+
+// GetLastDeployStatus get last deploy status
+func GetLastDeployStatus(bkapp *paasv1alpha2.BkApp) string {
+	return bkapp.GetAnnotations()[paasv1alpha2.LastDeployStatusAnnoKey]
+}


### PR DESCRIPTION
- 移除 get_current_deployment 方法中释放部署锁的副作用。调整为中断部署时，释放部署锁
- 普通应用的 pre-release, app release, 云原生应用的 bkapp release，在它们的 start 入口增加中断逻辑，提升用户中断部署的有效性(还是看时机)
- 云原生增加 bkapp.paas.bk.tencent.com/last-deploy-status 注解，解决用户主动中断部署之后，再次部署应用时，由于 hook 仍处于progressing 直到现在的 15分钟设置，不能继续部署(调和)的问题