### PR TITLE
refactor: remove region parameter from various functions and models of sourcectl app

### DIFF
--- a/apiserver/paasng/paasng/core/region/models.py
+++ b/apiserver/paasng/paasng/core/region/models.py
@@ -82,7 +82,6 @@ class RegionBasicInfo:
 
     description: str
     link_production_app: str
-    deploy_ver_for_update_svn_account: str
     legacy_deploy_version: str
     extra_logo_bucket_info: dict = field(default_factory=dict)
     built_in_config_var: dict = field(default_factory=dict)

--- a/apiserver/paasng/paasng/plat_admin/numbers/app.py
+++ b/apiserver/paasng/paasng/plat_admin/numbers/app.py
@@ -684,7 +684,7 @@ def calculate_user_contribution_in_app(username: str, app: SimpleApp):
     if not app.source_repo_type:
         raise RuntimeError("No repo provided")
 
-    repo_admin_credentials = get_bksvn_config(app.region, name=app.source_repo_type).get_admin_credentials()
+    repo_admin_credentials = get_bksvn_config(name=app.source_repo_type).get_admin_credentials()
     user_credentials = {}
 
     if app.source_repo_type in get_sourcectl_names().filter_by_basic_type("git"):
@@ -697,7 +697,7 @@ def calculate_user_contribution_in_app(username: str, app: SimpleApp):
         user_credentials["__token_holder"] = token_holder
 
     type_spec = get_sourcectl_type(app.source_repo_type)
-    repo_info = type_spec.config_as_arguments(app.region)
+    repo_info = type_spec.config_as_arguments()
 
     if app.source_repo_type == get_sourcectl_names().bk_svn:
         svn_cls = cast(Type[SvnRepoController], type_spec.repo_controller_class)

--- a/apiserver/paasng/paasng/platform/modules/serializers.py
+++ b/apiserver/paasng/paasng/platform/modules/serializers.py
@@ -179,9 +179,7 @@ class CreateModuleSLZ(serializers.Serializer):
         source_origin = SourceOrigin(data["source_origin"])
 
         if source_origin == SourceOrigin.IMAGE_REGISTRY:
-            data["source_repo_url"] = validate_image_url(
-                data["source_repo_url"], region=self.context["application"].region
-            )
+            data["source_repo_url"] = validate_image_url(data["source_repo_url"])
 
         return data
 

--- a/apiserver/paasng/paasng/platform/sourcectl/connector.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/connector.py
@@ -102,7 +102,6 @@ class DBBasedMixin:
     def _get_or_create_repo_obj(self, repo_url: str, source_dir: str) -> Any:
         """Get or create a repository object by given url and source_dir."""
         repo_kwargs = {
-            "region": self.application.region,
             "server_name": self.repo_type,
             "repo_url": repo_url,
             "source_dir": source_dir,
@@ -155,7 +154,7 @@ class IntegratedSvnAppRepoConnector(ModuleRepoConnector, DBBasedMixin):
         self.auth_manager.initialize(desired_root)
 
         # 创建目录
-        base_info = get_sourcectl_type(self.repo_type).config_as_arguments(self.application.region)
+        base_info = get_sourcectl_type(self.repo_type).config_as_arguments()
         try:
             self.auth_manager.set_paas_user_root_privilege(path=desired_root, write=True, read=True)
             return self._acquire_repo(
@@ -171,7 +170,7 @@ class IntegratedSvnAppRepoConnector(ModuleRepoConnector, DBBasedMixin):
         # 创建目录
         try:
             self.auth_manager.set_paas_user_root_privilege(path=desired_root, write=True, read=True)
-            server_config = get_bksvn_config(self.application.region, name=self.repo_type)
+            server_config = get_bksvn_config(name=self.repo_type)
             return self._acquire_repo(
                 desired_name=unique_id_generator(self.module.name),
                 base_info=server_config.as_module_arguments(root_path=desired_root),
@@ -201,7 +200,7 @@ class IntegratedSvnAppRepoConnector(ModuleRepoConnector, DBBasedMixin):
         repo_url = self.get_repo().get_repo_url()
         with generate_temp_dir() as source_path, promote_repo_privilege_temporary(self.application):
             self.write_templates_to_dir(source_path, self.module.source_init_template, context)
-            svn_credentials = get_bksvn_config(context["region"], name=self.repo_type).get_admin_credentials()
+            svn_credentials = get_bksvn_config(name=self.repo_type).get_admin_credentials()
 
             sync_procedure = SvnSyncProcedure(repo_url, svn_credentials["username"], svn_credentials["password"])
             return sync_procedure.run(source_path=str(source_path))

--- a/apiserver/paasng/paasng/platform/sourcectl/controllers/bk_svn.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/controllers/bk_svn.py
@@ -41,7 +41,7 @@ class SvnRepoController:
     @classmethod
     def init_by_module(cls, module: "Module", operator: Optional[str] = None):
         repo_url = module.get_source_obj().get_repo_url()
-        repo_admin_credentials = get_bksvn_config(module.region, name=module.source_type).get_admin_credentials()
+        repo_admin_credentials = get_bksvn_config(name=module.source_type).get_admin_credentials()
         return cls(repo_url=repo_url, repo_admin_credentials=repo_admin_credentials)
 
     @classmethod

--- a/apiserver/paasng/paasng/platform/sourcectl/docker/models.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/docker/models.py
@@ -29,7 +29,6 @@ def get_or_create_repo_obj(
 ) -> DockerRepository:
     """Get or create a repository object by given url and source_dir."""
     repo_kwargs = {
-        "region": application.region,
         "server_name": repo_type,
         "repo_url": repo_url,
         "source_dir": source_dir,

--- a/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
@@ -125,7 +125,7 @@ class BaseGitRepoController:
 
     @classmethod
     def init_by_module(cls, module: "Module", operator: Optional[str] = None):
-        repo_info = get_sourcectl_type(module.source_type).config_as_arguments(module.region)
+        repo_info = get_sourcectl_type(module.source_type).config_as_arguments()
         repo_url = module.get_source_obj().get_repo_url()
         if not repo_url:
             raise ValueError("Require repo_url to init GitRepoController")
@@ -192,5 +192,5 @@ def list_git_repositories(source_control_type: str, operator: str) -> List[Repos
     }
 
     type_spec = get_sourcectl_type(source_control_type)
-    repo_info = type_spec.config_as_arguments(None)
+    repo_info = type_spec.config_as_arguments()
     return cls.list_all_repositories(**user_credentials, **repo_info)

--- a/apiserver/paasng/paasng/platform/sourcectl/serializers.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/serializers.py
@@ -18,7 +18,6 @@
 import logging
 
 from rest_framework import serializers
-from rest_framework.validators import UniqueTogetherValidator
 
 from paasng.platform.sourcectl.constants import VersionType
 from paasng.platform.sourcectl.models import RepositoryInstance, SvnAccount, SvnRepository
@@ -81,7 +80,6 @@ class RepositorySLZ(serializers.Serializer):
 class SVNAccountResponseSLZ(serializers.Serializer):
     account = serializers.CharField()
     user = serializers.CharField()
-    region = serializers.CharField()
     id = serializers.IntegerField()
     password = serializers.CharField()
 
@@ -94,23 +92,7 @@ class SvnAccountSLZ(serializers.ModelSerializer):
 
     class Meta:
         model = SvnAccount
-        fields = ("region", "account", "user", "id", "verification_code", "synced_from_paas20")
-        lookup_field = "id"
-
-
-class SvnAccountCreateSLZ(serializers.ModelSerializer):
-    account = serializers.ReadOnlyField()
-    user = serializers.HiddenField(default=serializers.CurrentUserDefault())
-
-    validators = [
-        UniqueTogetherValidator(
-            queryset=SvnAccount.objects.all(), fields=("user", "region"), message="用户在当前Region的SVN账号已经存在"
-        )
-    ]
-
-    class Meta:
-        model = SvnAccount
-        fields = ("region", "account", "user", "id")
+        fields = ("account", "user", "id", "verification_code", "synced_from_paas20")
         lookup_field = "id"
 
 

--- a/apiserver/paasng/paasng/platform/sourcectl/signals.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/signals.py
@@ -17,7 +17,7 @@
 
 from django.dispatch import Signal
 
-# providing_args: [username: str, account: str, password: str, created: bool, region: str]
+# providing_args: [username: str, account: str, password: str, created: bool]
 svn_account_updated = Signal()
 
 # providing_args: [username: str]

--- a/apiserver/paasng/paasng/platform/sourcectl/svn/admin.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/svn/admin.py
@@ -15,8 +15,8 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
-"""A simple SVN client by wrapping svn command line tool
-"""
+"""A simple SVN client by wrapping svn command line tool"""
+
 import contextlib
 import inspect
 import json
@@ -62,7 +62,6 @@ class BaseSvnAuthClient:
 
 
 class BaseRealSvnAuthClient(BaseSvnAuthClient):
-    REGION: str
     SVN_SECRET = "32fc6114554e3c53d5952594510021e2"
     SVN_OPERATE_ERROR_NOTIFIER = "admin"
     DUMMY = True
@@ -77,7 +76,7 @@ class BaseRealSvnAuthClient(BaseSvnAuthClient):
     BASE_SVN_DEL_AUTHZ = "{admin_url}svn_del/authz/"
 
     def __init__(self):
-        admin_url = self.get_admin_url(self.REGION)
+        admin_url = self.get_admin_url()
         if not admin_url:
             return
         if not admin_url.endswith("/"):
@@ -91,9 +90,9 @@ class BaseRealSvnAuthClient(BaseSvnAuthClient):
         self.SVN_DEL_AUTHZ = self.BASE_SVN_DEL_AUTHZ.format(admin_url=admin_url)  # svn 权限删除
 
     @staticmethod
-    def get_admin_url(region: str) -> Optional[str]:
+    def get_admin_url() -> Optional[str]:
         try:
-            return get_bksvn_config(region).admin_url
+            return get_bksvn_config().admin_url
         except RuntimeError:
             logger.warning("No bk svn sourcectl was configured")
             return None
@@ -246,7 +245,6 @@ class BaseRealSvnAuthClient(BaseSvnAuthClient):
 class IeodSvnAuthClient(BaseRealSvnAuthClient):
     """SVN用户账号注册及授权（互娱内部版）"""
 
-    REGION = "ieod"
     BASE_SVN_ADD_DIR = "{admin_url}svn_add/app_dir_trunk/"
 
 
@@ -279,7 +277,7 @@ class SvnApplicationAuthorization:
         self.update_developers()
         # 修改目录权限
         # `v3apps/` + `somecode-123`
-        repo_path = get_bksvn_config(self.application.region).get_base_path() + path
+        repo_path = get_bksvn_config().get_base_path() + path
         self.svn_client.mod_authz(repo_path=repo_path, group_name=self.code, is_code_private=True)
 
     def update_developers(self):
@@ -292,11 +290,11 @@ class SvnApplicationAuthorization:
         :param path 不包含通用根目录的 应用path
         """
         privilege = "%s%s" % ("r" if read else "", "w" if write else "")
-        admin_credentials = get_bksvn_config(self.application.region).get_admin_credentials()
+        admin_credentials = get_bksvn_config().get_admin_credentials()
 
         # 修改目录权限
         # `v3apps/` + `somecode-123`
-        repo_path = get_bksvn_config(self.application.region).get_base_path() + path
+        repo_path = get_bksvn_config().get_base_path() + path
         self.svn_client.mod_authz_common(
             repo_path=repo_path, group_or_user_name=admin_credentials["username"], authz=privilege
         )
@@ -304,7 +302,7 @@ class SvnApplicationAuthorization:
     def set_paas_user_privilege(self, read=True, write=False):
         """设置paas账户的权限"""
         privilege = "%s%s" % ("r" if read else "", "w" if write else "")
-        admin_credentials = get_bksvn_config(self.application.region).get_admin_credentials()
+        admin_credentials = get_bksvn_config().get_admin_credentials()
 
         # 需要保证 repo obj 已经生成
         # 由于不容易切分 app_code/module，所以这里将平台账号在每一个使用了 svn module 路径下授权
@@ -381,16 +379,15 @@ class DummyAppAuthorization(SvnApplicationAuthorization):
     svn_client_cls = SvnAuthClient4Developer
 
 
-def get_svn_authorization_manager_cls(region: str) -> Type[SvnApplicationAuthorization]:
-    config = get_bksvn_config(region)
+def get_svn_authorization_manager_cls() -> Type[SvnApplicationAuthorization]:
+    config = get_bksvn_config()
     if not config.auth_mgr_cls:
         return DummyAppAuthorization
     return import_string(config.auth_mgr_cls)
 
 
 def get_svn_authorization_manager(application):
-    region = application.region
-    cls = get_svn_authorization_manager_cls(region)
+    cls = get_svn_authorization_manager_cls()
     return cls(application)
 
 

--- a/apiserver/paasng/paasng/platform/sourcectl/svn/server_config.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/svn/server_config.py
@@ -16,6 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 
 """Bk Svn server config helper utilities"""
+
 from dataclasses import dataclass
 from typing import Dict, Optional
 from urllib.parse import urlparse
@@ -54,8 +55,8 @@ class BkSvnServerConfig:
         }
 
 
-def get_bksvn_config(region: str, name: Optional[str] = None) -> BkSvnServerConfig:
-    """Get the config object of bk svn source controll type
+def get_bksvn_config(name: Optional[str] = None) -> BkSvnServerConfig:
+    """Get the config object of bk svn source control type
 
     :param name: if given, will get spec type object by name, otherwise try to find the spec type object which was
         registered with type `BkSvnSourceTypeSpec` instead.
@@ -73,8 +74,6 @@ def get_bksvn_config(region: str, name: Optional[str] = None) -> BkSvnServerConf
         try:
             sourcectl_type = sourcectl_types.find_by_type(BkSvnSourceTypeSpec)
         except ValueError:
-            raise RuntimeError(f"No sourcectl type spec can be found, region: {region}, name: {name}")
+            raise RuntimeError(f"No sourcectl type spec can be found, name: {name}")
 
-    # Return a default server config value when requested region was not configured,
-    # which might happens when running mgrlegacy's unit tests
-    return BkSvnServerConfig(**sourcectl_type.get_server_config(region, use_default_value=True))
+    return BkSvnServerConfig(**sourcectl_type.get_server_config())

--- a/apiserver/paasng/paasng/platform/sourcectl/type_specs.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/type_specs.py
@@ -19,7 +19,8 @@
 
 包含可供用户使用的“源码控制系统配置”
 """
-from typing import Dict, Optional
+
+from typing import Dict
 
 from django.utils.translation import gettext_lazy as _
 
@@ -52,8 +53,8 @@ class BkSvnSourceTypeSpec(SourceTypeSpec):
         "description": _("（蓝鲸平台提供的源码托管服务）"),
     }
 
-    def config_as_arguments(self, region: Optional[str]) -> Dict:
-        server_config = self.get_server_config(region)
+    def config_as_arguments(self) -> Dict:
+        server_config = self.get_server_config()
         return {
             "base_url": server_config["base_url"],
             "username": server_config["su_name"],

--- a/apiserver/paasng/paasng/platform/sourcectl/validators.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/validators.py
@@ -20,7 +20,7 @@ from rest_framework.exceptions import ValidationError
 from paasng.platform.sourcectl.source_types import docker_registry_config
 
 
-def validate_image_url(url: str, region: str) -> str:
+def validate_image_url(url: str) -> str:
     """检查镜像地址(判断是否支持第三方镜像)"""
     default_registry = docker_registry_config.default_registry
     allow_third_party_registry = docker_registry_config.allow_third_party_registry

--- a/apiserver/paasng/paasng/settings/__init__.py
+++ b/apiserver/paasng/paasng/settings/__init__.py
@@ -934,7 +934,6 @@ DEFAULT_REGION_TEMPLATE = {
         "description": "默认版",
         "link_production_app": BK_CONSOLE_URL + "?app={code}",
         "extra_logo_bucket_info": {},
-        "deploy_ver_for_update_svn_account": "default",
         "legacy_deploy_version": "default",
         "built_in_config_var": {
             "LOGIN_URL": {

--- a/apiserver/paasng/tests/api/test_sourcectl.py
+++ b/apiserver/paasng/tests/api/test_sourcectl.py
@@ -45,17 +45,6 @@ def svn_account(bk_user):
 
 
 class TestSvnAPI:
-    @mock.patch("paasng.platform.sourcectl.svn.admin.IeodSvnAuthClient.add_user")
-    def test_create_account(self, add_user, mocked_call_api, api_client, bk_user):
-        def mock_add_user(account, password):
-            return {"account": account.strip(), "password": password.strip()}
-
-        add_user.side_effect = mock_add_user
-        data = {"region": settings.DEFAULT_REGION_NAME}
-        response = api_client.post(reverse("api.sourcectl.bksvn.accounts"), data)
-
-        assert response.status_code == 201
-
     def test_reset_account_error(self, mocked_call_api, api_client, bk_user, svn_account):
         data = {"verification_code": "000000", "region": settings.DEFAULT_REGION_NAME}
         with override_settings(ENABLE_VERIFICATION_CODE=True):

--- a/apiserver/paasng/tests/paasng/platform/sourcectl/svn/test_server_config.py
+++ b/apiserver/paasng/tests/paasng/platform/sourcectl/svn/test_server_config.py
@@ -25,25 +25,12 @@ from paasng.platform.sourcectl.svn.server_config import BkSvnServerConfig, get_b
 def server_config_factory():
     def _factory():
         return {
-            "_lookup_field": "region",
-            "data": {
-                "r1": {
-                    "base_url": "svn://127.0.0.1:3690/r1_base",
-                    "legacy_base_url": "svn://127.0.0.1:3690/r1_legacy_base",
-                    "su_name": "r1_user",
-                    "su_pass": "r1_pass",
-                    "need_security": False,
-                    "admin_url": "127.0.0.1:3690/r1_admin",
-                },
-                "r2": {
-                    "base_url": "svn://127.0.0.1:3690/r2_base",
-                    "legacy_base_url": "svn://127.0.0.1:3690/r2_legacy_base",
-                    "su_name": "r2_user",
-                    "su_pass": "r2_pass",
-                    "need_security": True,
-                    "admin_url": "127.0.0.1:3690/r2_admin",
-                },
-            },
+            "base_url": "svn://127.0.0.1:3690/r1_base",
+            "legacy_base_url": "svn://127.0.0.1:3690/r1_legacy_base",
+            "su_name": "r1_user",
+            "su_pass": "r1_pass",
+            "need_security": False,
+            "admin_url": "127.0.0.1:3690/r1_admin",
         }
 
     return _factory
@@ -51,19 +38,12 @@ def server_config_factory():
 
 class TestBkSvnConfig:
     def test_get_base_path(self, server_config_factory):
-        config = BkSvnServerConfig(**server_config_factory()["data"]["r1"])
+        config = BkSvnServerConfig(**server_config_factory())
         assert config.get_base_path() == "/r1_base"
 
 
 class TestGetBkSvnConfig:
-    @pytest.mark.parametrize(
-        ("region", "base_url"),
-        [
-            ("r1", "svn://127.0.0.1:3690/r1_base"),
-            ("r2", "svn://127.0.0.1:3690/r2_base"),
-        ],
-    )
-    def test_single_svn(self, region, base_url, server_config_factory):
+    def test_single_svn(self, server_config_factory):
         source_type_spec_configs = [
             {
                 "spec_cls": "paasng.platform.sourcectl.type_specs.BkSvnSourceTypeSpec",
@@ -71,11 +51,11 @@ class TestGetBkSvnConfig:
             },
         ]
         refresh_sourcectl_types(source_type_spec_configs)
-        assert get_bksvn_config(region).base_url == base_url
+        assert get_bksvn_config().base_url == "svn://127.0.0.1:3690/r1_base"
 
     def test_multi_svn(self, settings, server_config_factory):
         server_config_copy = server_config_factory()
-        server_config_copy["data"]["r1"]["base_url"] = "http://modified-base/"
+        server_config_copy["base_url"] = "http://modified-base/"
         source_type_spec_configs = [
             {
                 "spec_cls": "paasng.platform.sourcectl.type_specs.BkSvnSourceTypeSpec",
@@ -87,5 +67,5 @@ class TestGetBkSvnConfig:
             },
         ]
         refresh_sourcectl_types(source_type_spec_configs)
-        assert get_bksvn_config("r1").base_url == "svn://127.0.0.1:3690/r1_base"
-        assert get_bksvn_config("r1", name="bk_svn_2").base_url == "http://modified-base/"
+        assert get_bksvn_config().base_url == "svn://127.0.0.1:3690/r1_base"
+        assert get_bksvn_config(name="bk_svn_2").base_url == "http://modified-base/"

--- a/apiserver/paasng/tests/paasng/platform/sourcectl/test_validators.py
+++ b/apiserver/paasng/tests/paasng/platform/sourcectl/test_validators.py
@@ -34,4 +34,4 @@ from paasng.platform.sourcectl.validators import validate_image_url
 )
 def test_validate_image_url(url, repo_info):
     with override_settings(DOCKER_REGISTRY_CONFIG=repo_info):
-        assert validate_image_url(url, "dummy") == url
+        assert validate_image_url(url) == url


### PR DESCRIPTION
This PR removes the usage of the "region" property from the sourcectl application. Details:

- The bk_svn source control type no longer supports region-specific server configuration
- Remove "deploy_ver_for_update_svn_account" from settings/region_config
- Remove the create svn account API (no longer used)

**Further integrated tests on the bk_svn API are needed after merge.**