### PR TITLE
refactor: remove action-perms decorator

### DIFF
--- a/apiserver/paasng/paasng/accessories/publish/entrance/serializers.py
+++ b/apiserver/paasng/paasng/accessories/publish/entrance/serializers.py
@@ -56,12 +56,12 @@ class ApplicationAvailableEntranceSLZ(serializers.Serializer):
     entrances = PlainEntranceSLZ(many=True)
 
 
-class RootDoaminSLZ(serializers.Serializer):
+class RootDomainSLZ(serializers.Serializer):
     root_domains = serializers.ListField(
         help_text="查看模块所属集群的子域名根域", child=serializers.CharField(), default=[]
     )
     preferred_root_domain = serializers.CharField(help_text="偏好的根域名", default="")
 
 
-class PreferredRootDoaminSLZ(serializers.Serializer):
+class PreferredRootDomainSLZ(serializers.Serializer):
     preferred_root_domain = serializers.CharField(help_text="偏好的根域名", required=True)

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/iam_adaptor/policy/permissions.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/iam_adaptor/policy/permissions.py
@@ -15,7 +15,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
-from typing import List
+from typing import List, Type
 
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import PermissionDenied
@@ -33,7 +33,7 @@ def plugin_action_permission_class(actions: List[PluginPermissionActions], use_c
         @property
         def message(self):
             return _("用户无以下权限 {actions}").format(
-                actions=[PluginPermissionActions.get_choice_label(aciton) for aciton in actions]
+                actions=[PluginPermissionActions.get_choice_label(action) for action in actions]
             )
 
         def has_object_permission(self, request, view, obj):
@@ -52,6 +52,57 @@ def plugin_action_permission_class(actions: List[PluginPermissionActions], use_c
             # 无插件应用权限时，需要返回应用权限申请链接
             if not is_allowed:
                 raise PermissionDenied({"message": self.message, **user_group_apply_url(obj.id)})
+
+            return True
+
+    return PluginActionPermission
+
+
+def plugin_view_actions_perm(
+    view_action_map: dict[str, list[PluginPermissionActions]],
+    default_actions: list[PluginPermissionActions] | None = None,
+    use_cache: bool = False,
+) -> Type[BasePermission]:
+    """Create a permission class for plugin view, it allows using different action(s)
+    for different view actions.
+
+    :param view_action_map: A map from view action to plugin actions.
+    :param default_action: Optional, the default action if the view action
+        is not found.
+    :return: A permission class.
+    """
+
+    class PluginActionPermission(BasePermission):
+        """The permission class for plugin views."""
+
+        @property
+        def message(self):
+            return _("用户无权限执行此操作")
+
+        def has_object_permission(self, request, view, obj):
+            if not isinstance(obj, PluginInstance):
+                return False
+
+            # Get the actions from the view action map, if not found, use the default actions.
+            actions = view_action_map.get(view.action, default_actions)
+            if actions is None:
+                raise ValueError('No plugin actions found for view action "%s".' % view.action)
+
+            iam_resource = gen_iam_resource(obj)
+            if len(actions) == 1:
+                is_allowed = lazy_iam_client.is_action_allowed(
+                    request.user.username, actions[0], [iam_resource], use_cache=use_cache
+                )
+            else:
+                is_allowed = all(
+                    lazy_iam_client.is_actions_allowed(request.user.username, actions, [iam_resource]).values()
+                )
+            # 无插件应用权限时，需要返回应用权限申请链接
+            if not is_allowed:
+                message = _("用户无以下权限 {actions}").format(
+                    actions=[PluginPermissionActions.get_choice_label(action) for action in actions]
+                )
+                raise PermissionDenied({"message": message, **user_group_apply_url(obj.id)})
 
             return True
 

--- a/apiserver/paasng/paasng/infras/accounts/permissions/application.py
+++ b/apiserver/paasng/paasng/infras/accounts/permissions/application.py
@@ -29,7 +29,6 @@ from paasng.infras.iam.permissions.resources.application import AppAction, Appli
 from paasng.platform.applications.models import Application
 from paasng.platform.modules.models import Module
 from paasng.utils.basic import get_username_by_bkpaas_user_id
-from paasng.utils.views import action_perms
 
 logger = logging.getLogger(__name__)
 
@@ -38,16 +37,6 @@ class BaseAppPermission(BasePermission):
     """The base class for application permission. It doesn't provide any functionality
     yet but it can be useful for other modules to check the permission type.
     """
-
-
-def app_action_required(action: AppAction, policy: str = "extend"):
-    """A decorator to require the user to have the specified application action permission,
-    must be used on viewset method.
-
-    :param action: Application action type.
-    :param policy: How to combine the permission classes. Default is "extend".
-    """
-    return action_perms(permission_classes=[application_perm_class(action)], policy=policy)
 
 
 def application_perm_class(action: AppAction) -> Type[BasePermission]:

--- a/apiserver/paasng/paasng/utils/views.py
+++ b/apiserver/paasng/paasng/utils/views.py
@@ -18,7 +18,7 @@
 import functools
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 from blue_krill.web.drf_utils import stringify_validation_error
 from blue_krill.web.std_error import APIError
@@ -27,7 +27,6 @@ from django.utils.translation import gettext as _
 from rest_framework import status
 from rest_framework.exceptions import AuthenticationFailed, NotAuthenticated, ValidationError
 from rest_framework.negotiation import BaseContentNegotiation
-from rest_framework.permissions import BasePermission
 from rest_framework.renderers import BaseRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import exception_handler, set_rollback
@@ -240,78 +239,3 @@ def unwrap_partial(func):
     while isinstance(func, functools.partial):
         func = func.func
     return func
-
-
-def action_perms(permission_classes: List[Type[BasePermission]], policy: str = "replace"):
-    """A decorator that support action level permission_classes for ViewSet.
-
-    WARNING/TODO: This decorator's functionality is flawed; it cannot replace the permission_classes
-    when the policy is set to "replace" because a permission check occurs before the handler function
-    is called. **STOP USING IT!** The existing code will be migrated.
-
-    :param permission_classes: A list of permission classes.
-    :param policy: The policy for setting the permission_classes, default is "replace".
-        Can be "replace" or "extend".
-
-    ### Why we need this?
-
-    DRF provides 2 ways to set permission_classes at method level: `@action' and
-    `@permission_classes`. But they don't work in our case because `@action' must be
-    used with the with DRF's `Router` object and `@permission_classes` is only for
-    function-based views and should be used with `@api_view`.
-
-    Our project uses ViewSet standalone without `Router`, so we need another way to
-    set the permission_classes at method level. This decorator solves this problem by
-    dynamically setting the permission_classes attribute dynamically when the method
-    is invoked.
-
-    ### Examples
-
-    from django.utils.decorators import method_decorator
-    action_perms = <this decorator>
-
-    @method_decorator(action_perms([]), name="action_c")
-    class ViewSet:
-        permission_classes = [Baz]
-
-        @action_perms([Foo])
-        def action_a(self, request):
-            assert self.permission_classes == [Foo]
-
-        @action_perms([Bar], policy="extend")
-        def action_b(self, request):
-            assert self.permission_classes == [Bar, Baz]
-
-        def action_c(self, request):
-            assert self.permission_classes == []
-    """
-
-    def decorator(func):
-        # Set an attribute to store the permission_classes so other module like `perm_insure` knows.
-        func._action_permission_classes = permission_classes
-
-        @functools.wraps(func)
-        def wrapped(*args, **kwargs):
-            # Try to unwrap partial from method_decorator and get the current class
-            # instance object "self".
-            bound_method = unwrap_partial(func)
-            if hasattr(bound_method, "__self__"):
-                # when use permission_classes with django method_decorator, we can only get self from bound_method
-                self = bound_method.__self__
-            else:
-                # when use permission_classes as a normal decorator, we can only get self from args[0]
-                self = args[0]
-
-            # Update the permission_classes attribute based on the policy
-            if policy == "extend":
-                # Use list extend to create a new list to avoid modifying the original list
-                self.permission_classes = getattr(self, "permission_classes", []) + permission_classes
-            elif policy == "replace":
-                self.permission_classes = permission_classes
-            else:
-                raise ValueError(f"Unknown policy: {policy}")
-            return func(*args, **kwargs)
-
-        return wrapped
-
-    return decorator


### PR DESCRIPTION
- refactor: remove action-perms decorator

reason:

```
    WARNING/TODO: This decorator's functionality is flawed; it cannot replace the permission_classes
    when the policy is set to "replace" because a permission check occurs before the handler function
    is called. **STOP USING IT!** The existing code will be migrated.
```