### PR TITLE
fix: 修复资源池将 uuid 类型放入 config 导致的审计失败

### DIFF
--- a/apiserver/paasng/paasng/accessories/services/providers/base.py
+++ b/apiserver/paasng/paasng/accessories/services/providers/base.py
@@ -99,7 +99,7 @@ class ResourcePoolProvider(BaseProvider):
             return InstanceData(
                 credentials=creds,
                 config={
-                    "__pk__": instance.pk,
+                    "__pk__": str(instance.pk),
                     "is_pre_created": True,
                     "provider_name": provider_name,
                     "enable_tls": bool(ca or cert or cert_key),

--- a/apiserver/paasng/tests/paasng/accessories/services/test_provider.py
+++ b/apiserver/paasng/tests/paasng/accessories/services/test_provider.py
@@ -42,7 +42,7 @@ class TestResourcePoolProvider:
         instance = bk_service.create_service_instance_by_plan(bk_plan, {})
         assert json.loads(instance.credentials)["REDIS_IDX"] == json.loads(pools[0].credentials)["idx"]
         expect = PreCreatedInstance.objects.get(pk=pools[0].pk)
-        assert instance.config.pop("__pk__") == expect.pk
+        assert instance.config.pop("__pk__") == str(expect.pk)
         assert instance.config == {"enable_tls": False, "is_pre_created": True, "provider_name": "redis"}
         assert expect.is_allocated
 


### PR DESCRIPTION
config 里面的 kv 应该都是 str
uuid 类型会导致审计操作失败