### PR TITLE
feat: 模板 API 添加 language 字段

### DIFF
--- a/apiserver/paasng/paasng/platform/templates/serializers.py
+++ b/apiserver/paasng/paasng/platform/templates/serializers.py
@@ -45,6 +45,7 @@ class TemplateSLZ(serializers.Serializer):
     description = TranslatedCharField()
     tags = serializers.JSONField()
     repo_url = serializers.CharField()
+    language = serializers.CharField()
 
 
 class BuildConfigPreviewSLZ(serializers.Serializer):


### PR DESCRIPTION
方便前端根据选择模板的语言，来确定 “示例目录” 的展示内容