### PR TITLE
fix: 修复查询方案配置传入 search_term 参数后报错问题

### DIFF
--- a/apiserver/paasng/paas_wl/apis/admin/views/processes.py
+++ b/apiserver/paasng/paas_wl/apis/admin/views/processes.py
@@ -47,7 +47,6 @@ class ProcessSpecPlanManageViewSet(PaginationMixin, ListModelMixin, GenericViewS
     serializer_class = ProcessSpecPlanSLZ
     permission_classes = [site_perm_class(SiteAction.MANAGE_PLATFORM)]
     filter_backends = [SearchFilter]
-    search_fields = ["environment"]
     queryset = ProcessSpecPlan.objects.all()
 
     def _list_data(self):


### PR DESCRIPTION
environment 字段很早就从 ProcessSpecPlan 表中删除了