### PR TITLE
cherry-pick: fix: replace unsafe option for Popen (#2317)

### DIFF
--- a/apiserver/paasng/paasng/platform/sourcectl/package/client.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/package/client.py
@@ -144,8 +144,7 @@ class BinaryTarClient(BasePackageClient):
         """
         with generate_temp_dir() as temp_dir:
             p = subprocess.Popen(
-                f'tar -xf "{self.filepath.absolute()}" -C "{temp_dir.absolute()}" "{filename}"',
-                shell=True,
+                ["tar", "-xf", str(self.filepath.absolute()), "-C", str(temp_dir.absolute()), filename],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 encoding="utf-8",
@@ -204,8 +203,7 @@ class BinaryTarClient(BasePackageClient):
             might be corrupt.
         """
         p = subprocess.Popen(
-            f'tar -tf "{self.filepath.absolute()}"',
-            shell=True,
+            ["tar", "-tf", str(self.filepath.absolute())],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",

--- a/apiserver/paasng/paasng/platform/sourcectl/utils.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/utils.py
@@ -151,10 +151,10 @@ def compress_directory(source_path, target_path):
     # Add "GZIP=-n" to disable gzip timestamp
     # see: https://serverfault.com/questions/110208/different-md5sums-for-same-tar-contents
     p = subprocess.Popen(
-        f"GZIP=-n tar --exclude=.svn -czf {target_path} -C {source_path} .",
-        shell=True,
+        ["tar", "--exclude=.svn", "-czf", str(target_path), "-C", str(source_path), "."],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env={"GZIP": "-n"},
         encoding="utf-8",
     )
     _, stderr = p.communicate()
@@ -168,8 +168,7 @@ def uncompress_directory(source_path, target_path):
     target_path = os.path.abspath(target_path)
     # -m, --touch                don't extract file modified time
     p = subprocess.Popen(
-        f'tar -m -xf "{source_path}" -C "{target_path}"',
-        shell=True,
+        ["tar", "-m", "-xf", str(source_path), "-C", str(target_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/apiserver/paasng/paasng/utils/basic.py
+++ b/apiserver/paasng/paasng/utils/basic.py
@@ -67,8 +67,7 @@ def sha256_checksum(file_path):
     possible_names = ["sha256sum", "gsha256sum"]
     for sha256_bin in possible_names:
         p = subprocess.Popen(
-            "%s %s" % (sha256_bin, file_path),
-            shell=True,
+            [sha256_bin, str(file_path)],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",


### PR DESCRIPTION
- fix: replace unsafe option for Popen (#2317)