### PR TITLE
feat: 替换云原生构建工具中的基础镜像

### DIFF
--- a/cloudnative-buildpacks/builders/heroku-builder/heroku-24.toml
+++ b/cloudnative-buildpacks/builders/heroku-builder/heroku-24.toml
@@ -1,23 +1,23 @@
 description = "Ubuntu noble base image with buildpacks for Java, .NET Core, NodeJS, Go, Python, Ruby, Apache HTTPD, NGINX and Procfile"
 
 [[buildpacks]]
-uri = "docker://gcr.io/paketo-buildpacks/go:4.3.3"
+uri = "docker://paketobuildpacks/go:4.3.3"
 version = "4.3.3"
 
 [[buildpacks]]
-uri = "docker://gcr.io/paketo-buildpacks/java-native-image:8.3.0"
+uri = "docker://paketobuildpacks/java-native-image:8.3.0"
 version = "8.3.0"
 
 [[buildpacks]]
-uri = "docker://gcr.io/paketo-buildpacks/java:9.4.0"
+uri = "docker://paketobuildpacks/java:9.4.0"
 version = "9.4.0"
 
 [[buildpacks]]
-uri = "docker://gcr.io/paketo-buildpacks/nodejs:1.6.0"
+uri = "docker://paketobuildpacks/nodejs:1.6.0"
 version = "1.6.0"
 
 [[buildpacks]]
-uri = "docker://gcr.io/paketo-buildpacks/procfile:5.6.1"
+uri = "docker://paketobuildpacks/procfile:5.6.1"
 version = "5.6.1"
 
 

--- a/cloudnative-buildpacks/builders/heroku-builder/stack/docker-bake.hcl
+++ b/cloudnative-buildpacks/builders/heroku-builder/stack/docker-bake.hcl
@@ -38,7 +38,7 @@ target "heroku-build-noble" {
     packages = "${BASE_PACKAGES}"
   }
   tags = ["${STACK_BUILDER_IMAGE_NAME}:${STACK_BUILDER_TAG}"]
-  platforms = ["linux/amd64"]
+  platforms = ["linux"]
 }
 
 target "heroku-run-noble" {
@@ -50,5 +50,5 @@ target "heroku-run-noble" {
     packages = "${BASE_PACKAGES}"
   }
   tags = ["${STACK_RUNNER_IMAGE_NAME}:${STACK_RUNNER_TAG}"]
-  platforms = ["linux/amd64"]
+  platforms = ["linux"]
 }


### PR DESCRIPTION
因为 gcr.io 已经关停, 将云原生构建工具中的基础镜像更改为 dockerhub 中相关镜像

关停公告如下:

https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown