### PR TITLE
feat: 替换云原生构建工具中的基础镜像

### DIFF
--- a/cloudnative-buildpacks/builders/heroku-builder/heroku-18.toml
+++ b/cloudnative-buildpacks/builders/heroku-builder/heroku-18.toml
@@ -2,7 +2,7 @@ description = "Ubuntu bionic base image with buildpacks for Apt, Go, Python and 
 
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/procfile:5.6.1"
+  uri = "docker://paketobuildpacks/procfile:5.6.1"
   version = "5.6.1"
 
 

--- a/cloudnative-buildpacks/builders/heroku-builder/heroku-22.toml
+++ b/cloudnative-buildpacks/builders/heroku-builder/heroku-22.toml
@@ -2,7 +2,7 @@ description = "Ubuntu bionic base image with buildpacks for Apt, Go, Python and 
 
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/procfile:5.6.1"
+  uri = "docker://paketobuildpacks/procfile:5.6.1"
   version = "5.6.1"
 
 

--- a/cloudnative-buildpacks/builders/heroku-builder/stack/docker-bake.hcl
+++ b/cloudnative-buildpacks/builders/heroku-builder/stack/docker-bake.hcl
@@ -51,7 +51,7 @@ target "heroku-build-bionic" {
     EOF
   }
   tags = ["${build_image_name("heroku-18", BUILD_IMAGE_NAME)}:${STACK_BUILDER_TAG}"]
-  platforms = ["linux/amd64"]
+  platforms = ["linux"]
 }
 
 target "heroku-run-bionic" {
@@ -79,7 +79,7 @@ target "heroku-run-bionic" {
     EOF
   }
   tags = ["${run_image_name("heroku-18", RUN_IMAGE_NAME)}:${STACK_RUNNER_TAG}"]
-  platforms = ["linux/amd64"]
+  platforms = ["linux"]
 }
 
 
@@ -108,7 +108,7 @@ target "heroku-build-jammy" {
     EOF
   }
   tags = ["${build_image_name("heroku-22", BUILD_IMAGE_NAME)}:${STACK_BUILDER_TAG}"]
-  platforms = ["linux/amd64"]
+  platforms = ["linux"]
 }
 
 target "heroku-run-jammy" {
@@ -136,5 +136,5 @@ target "heroku-run-jammy" {
     EOF
   }
   tags = ["${run_image_name("heroku-22", RUN_IMAGE_NAME)}:${STACK_RUNNER_TAG}"]
-  platforms = ["linux/amd64"]
+  platforms = ["linux"]
 }

--- a/cloudnative-buildpacks/builders/paketo-builder/builder.toml
+++ b/cloudnative-buildpacks/builders/paketo-builder/builder.toml
@@ -1,43 +1,43 @@
 description = "Ubuntu bionic base image with buildpacks for Java, .NET Core, NodeJS, Go, Python, Ruby, Apache HTTPD, NGINX and Procfile"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/dotnet-core:0.35.3"
+  uri = "docker://paketobuildpacks/dotnet-core:0.35.3"
   version = "0.35.3"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/go:4.3.3"
+  uri = "docker://paketobuildpacks/go:4.3.3"
   version = "4.3.3"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/java-native-image:8.3.0"
+  uri = "docker://paketobuildpacks/java-native-image:8.3.0"
   version = "8.3.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/java:9.4.0"
+  uri = "docker://paketobuildpacks/java:9.4.0"
   version = "9.4.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/nodejs:1.6.0"
+  uri = "docker://paketobuildpacks/nodejs:1.6.0"
   version = "1.6.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/procfile:5.6.1"
+  uri = "docker://paketobuildpacks/procfile:5.6.1"
   version = "5.6.1"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/python:2.10.0"
+  uri = "docker://paketobuildpacks/python:2.10.0"
   version = "2.10.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/ruby:0.34.0"
+  uri = "docker://paketobuildpacks/ruby:0.34.0"
   version = "0.34.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/watchexec:2.8.1"
+  uri = "docker://paketobuildpacks/watchexec:2.8.1"
   version = "2.8.1"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/web-servers:0.13.0"
+  uri = "docker://paketobuildpacks/web-servers:0.13.0"
   version = "0.13.0"
 
 [lifecycle]
@@ -101,4 +101,4 @@ description = "Ubuntu bionic base image with buildpacks for Java, .NET Core, Nod
   build-image = "docker.io/paketobuildpacks/build:1.2.62-base-cnb"
   id = "io.buildpacks.stacks.bionic"
   run-image = "index.docker.io/paketobuildpacks/run:base-cnb"
-  run-image-mirrors = ["gcr.io/paketo-buildpacks/run:base-cnb"]
+  run-image-mirrors = ["paketobuildpacks/run:base-cnb"]


### PR DESCRIPTION
从 builder-stack 分支修改中迁移过来, 因为 文件结构的修改, 无法简单的使用 cherry-pick, 故单独提交