### PR TITLE
feat: 优化创建代码仓库时获取 oauth 凭证逻辑

### DIFF
--- a/apiserver/paasng/paasng/infras/accounts/entities.py
+++ b/apiserver/paasng/paasng/infras/accounts/entities.py
@@ -1,0 +1,34 @@
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+
+from typing import List
+
+from attrs import define
+
+
+@define
+class OauthCredential:
+    """OAuth 授权凭证
+
+    :param oauth_token: OAuth 授权凭证
+    :param scope_list: OAuth 授权范围
+    """
+
+    oauth_token: str
+    scope_list: List
+
+    def to_dict(self) -> dict:
+        """将对象转换为字典格式
+
+        :return: 包含凭证信息的字典，格式为 {
+            'oauth_token': 'xxx',
+            'scope_list': ['scope1', 'scope2']
+        }
+        """
+        return {"oauth_token": self.oauth_token, "scope_list": self.scope_list}

--- a/apiserver/paasng/paasng/infras/accounts/entities.py
+++ b/apiserver/paasng/paasng/infras/accounts/entities.py
@@ -22,13 +22,3 @@ class OauthCredential:
 
     oauth_token: str
     scope_list: List
-
-    def to_dict(self) -> dict:
-        """将对象转换为字典格式
-
-        :return: 包含凭证信息的字典，格式为 {
-            'oauth_token': 'xxx',
-            'scope_list': ['scope1', 'scope2']
-        }
-        """
-        return {"oauth_token": self.oauth_token, "scope_list": self.scope_list}

--- a/apiserver/paasng/paasng/infras/accounts/models.py
+++ b/apiserver/paasng/paasng/infras/accounts/models.py
@@ -207,25 +207,25 @@ class Oauth2TokenHolderQS(models.QuerySet):
 
         :param provider: Oauth2 授权提供商，如 Github
         """
+
         for token_holder in self.filter(provider=provider):
             try:
                 scope = Scope.parse_from_str(token_holder.get_scope())
                 if scope.type == ScopeType.USER:
                     return token_holder
-            except (ValueError, KeyError) as e:
+            except (ValueError, KeyError):
                 # 记录解析 scope 时的格式错误
-                logger.warning(
-                    "Parse scope failed for token_holder<%s> provider=%s, error: %s",
+                logger.exception(
+                    "Parse scope failed for token_holder<%s> provider=%s",
                     token_holder.id,
                     provider,
-                    str(e),
                 )
-            except Exception as e:
-                logger.warning(
-                    "Unexpected error when processing token_holder<%s> provider=%s, error: %s",
+                continue
+            except Exception:
+                logger.exception(
+                    "Unexpected error when processing token_holder<%s> provider=%s",
                     token_holder.id,
                     provider,
-                    str(e),
                 )
                 continue
         raise self.model.DoesNotExist

--- a/apiserver/paasng/paasng/infras/accounts/utils.py
+++ b/apiserver/paasng/paasng/infras/accounts/utils.py
@@ -15,7 +15,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
-from typing import Set, Type
+from typing import Literal, Set, Type
 
 from bkpaas_auth import get_user_by_user_id
 from django.conf import settings
@@ -75,31 +75,27 @@ def create_app_oauth_backend(application: Application, env_name: str = settings.
 
 
 def get_oauth_credential(
-    source_type: str, user_id: str, mode: str = "default", repo_url: str | None = None
+    source_type: str, user_id: str, mode: Literal["user", "repo", "merged"], repo_url: str | None = None
 ) -> OauthCredential:
     """获取 OAuth 凭证的统一入口函数
 
     该函数根据不同的模式获取不同范围的 OAuth 凭证：
-    - default: 获取第一个可用凭证（适用于获取用户所有有权限的代码和项目组等）
     - repo: 根据仓库地址获取精确匹配的凭证（适用于仓库创建等需要精确权限的场景）
     - user: 获取用户级别凭证（适用于用户默认个人空间操作）
+    - merged: 获取第一个可用凭证，但授权范围是所有可用凭证的集合（适用于需要合并多个凭证权限的场景）
 
     :param source_type: 源码仓库类型，需与认证提供商标识一致（如 'gitlab'/'github'）
     :param user_id: 用户唯一标识，用于查询关联的授权凭证
     :param mode: 凭证获取模式，可选值：
-        - 'default' (默认): 获取第一个可用凭证
+        - 'merged': 获取第一个可用凭证，但授权范围是所有可用凭证的集合
         - 'repo': 根据仓库地址获取精确匹配凭证
         - 'user': 获取用户级别 scope 的凭证
     :param repo_url: 当 mode='repo' 时必须提供，仓库地址（支持未创建仓库的地址）
     :return: 包含 access_token 和 scope 列表的凭证对象
-    :raises:
-        Oauth2TokenHolder.DoesNotExist: 当凭证不存在时
-        ValueError: 当参数不合法或缺少必要参数时
-        UserProfile.DoesNotExist: 当用户资料不存在时
 
     示例用法：
-        # 获取默认凭证
-        cred = get_oauth_credential('gitlab', 'user123')
+        # 获取第一个可用凭证，但合并所有可用凭证的授权范围
+        cred = get_oauth_credential('gitlab', 'user123', mode='merged')
 
         # 获取仓库匹配凭证
         cred = get_oauth_credential('gitlab', 'user123', mode='repo', repo_url='http://git.example.com/my/repo.git')
@@ -107,12 +103,6 @@ def get_oauth_credential(
         # 获取用户级别凭证
         cred = get_oauth_credential('gitlab', 'user123', mode='user')
     """
-    # 校验 mode 的合法性
-    mode = mode.lower()
-    valid_modes = ("default", "repo", "user")
-    if mode not in valid_modes:
-        raise ValueError(f"Invalid mode: {mode}, must be one of {valid_modes}")
-
     try:
         profile = UserProfile.objects.get(user=user_id)
     except UserProfile.DoesNotExist:
@@ -125,20 +115,32 @@ def get_oauth_credential(
         token_holder = profile.token_holder.get_by_project(project)
         return OauthCredential(token_holder.access_token, [token_holder.get_scope()])
 
-    if mode == "user":
+    elif mode == "user":
         token_holder = profile.token_holder.filter_user_scope(source_type)
         return OauthCredential(token_holder.access_token, [token_holder.get_scope()])
 
-    # 默认模式：获取第一个可用凭证
-    token_holder_list = profile.token_holder.filter(provider=source_type).all()
-    if not token_holder_list:
-        raise Oauth2TokenHolder.DoesNotExist
-    return OauthCredential(
-        oauth_token=token_holder_list[0].access_token, scope_list=[th.get_scope() for th in token_holder_list]
-    )
+    elif mode == "merged":
+        token_holder_list = profile.token_holder.filter(provider=source_type).all()
+        if not token_holder_list:
+            raise Oauth2TokenHolder.DoesNotExist
+
+        # 工蜂等 Git 代码仓库任意的授权 Token 都可以拉取项目列表，通过 scope_list 来限制拉取的范围
+        # 所以 oauth_token 直接取第一个，而 scope_list 则需要遍历所有凭证
+        return OauthCredential(
+            oauth_token=token_holder_list[0].access_token, scope_list=[th.get_scope() for th in token_holder_list]
+        )
+    else:
+        raise ValueError(f"Invalid mode: {mode}")
 
 
-get_oauth_credentials = get_oauth_credential
+def get_oauth_credential_with_merged_scopes(source_type: str, user_id: str) -> OauthCredential:
+    """获取第一个可用凭证，但合并所有可用凭证的授权范围。用于拉取用户明下所有仓库列表、项目组等场景
+
+    :param source_type: 源码仓库类型
+    :param user_id: 用户 ID
+    :return: 包含第一个凭证的access_token和所有凭证合并后的scope列表
+    """
+    return get_oauth_credential(source_type, user_id, "merged")
 
 
 def get_oauth_credential_by_repo(source_type: str, repo_url: str, user_id: str) -> OauthCredential:

--- a/apiserver/paasng/paasng/infras/accounts/utils.py
+++ b/apiserver/paasng/paasng/infras/accounts/utils.py
@@ -79,15 +79,40 @@ def get_oauth_credential(
 ) -> OauthCredential:
     """获取 OAuth 凭证的统一入口函数
 
-    :param source_type: 源码仓库类型，如 gitlab
-    :param user_id: 用户 ID，用于查询用户对应的授权凭证
+    该函数根据不同的模式获取不同范围的 OAuth 凭证：
+    - default: 获取第一个可用凭证（适用于获取用户所有有权限的代码和项目组等）
+    - repo: 根据仓库地址获取精确匹配的凭证（适用于仓库创建等需要精确权限的场景）
+    - user: 获取用户级别凭证（适用于用户默认个人空间操作）
+
+    :param source_type: 源码仓库类型，需与认证提供商标识一致（如 'gitlab'/'github'）
+    :param user_id: 用户唯一标识，用于查询关联的授权凭证
     :param mode: 凭证获取模式，可选值：
-        - 'default': 获取第一个可用凭证（原 get_oauth_credentials）
-        - 'repo': 根据仓库地址获取精确匹配凭证（原 get_oauth_credential_by_repo）
-        - 'user': 获取用户级别 scope 的凭证（原 get_oauth_credential_by_user）
-    :param repo_url: 可选，当 mode='repo' 时必须提供，仓库地址
-    :raises: Oauth2TokenHolder.DoesNotExist 当凭证不存在时
+        - 'default' (默认): 获取第一个可用凭证
+        - 'repo': 根据仓库地址获取精确匹配凭证
+        - 'user': 获取用户级别 scope 的凭证
+    :param repo_url: 当 mode='repo' 时必须提供，仓库地址（支持未创建仓库的地址）
+    :return: 包含 access_token 和 scope 列表的凭证对象
+    :raises:
+        Oauth2TokenHolder.DoesNotExist: 当凭证不存在时
+        ValueError: 当参数不合法或缺少必要参数时
+        UserProfile.DoesNotExist: 当用户资料不存在时
+
+    示例用法：
+        # 获取默认凭证
+        cred = get_oauth_credential('gitlab', 'user123')
+
+        # 获取仓库匹配凭证
+        cred = get_oauth_credential('gitlab', 'user123', mode='repo', repo_url='http://git.example.com/my/repo.git')
+
+        # 获取用户级别凭证
+        cred = get_oauth_credential('gitlab', 'user123', mode='user')
     """
+    # 校验 mode 的合法性
+    mode = mode.lower()
+    valid_modes = ("default", "repo", "user")
+    if mode not in valid_modes:
+        raise ValueError(f"Invalid mode: {mode}, must be one of {valid_modes}")
+
     try:
         profile = UserProfile.objects.get(user=user_id)
     except UserProfile.DoesNotExist:

--- a/apiserver/paasng/paasng/infras/accounts/utils.py
+++ b/apiserver/paasng/paasng/infras/accounts/utils.py
@@ -74,59 +74,65 @@ def create_app_oauth_backend(application: Application, env_name: str = settings.
     )
 
 
-def get_oauth_credentials(source_control_type: str, user_id: str) -> OauthCredential:
-    """获取用户的OAuth凭证用于访问代码仓库
+def get_oauth_credential(
+    source_type: str, user_id: str, mode: str = "default", repo_url: str | None = None
+) -> OauthCredential:
+    """获取 OAuth 凭证的统一入口函数
 
-    :param source_control_type: 源码控制类型，如 gitlab
+    :param source_type: 源码仓库类型，如 gitlab
     :param user_id: 用户 ID，用于查询用户对应的授权凭证
+    :param mode: 凭证获取模式，可选值：
+        - 'default': 获取第一个可用凭证（原 get_oauth_credentials）
+        - 'repo': 根据仓库地址获取精确匹配凭证（原 get_oauth_credential_by_repo）
+        - 'user': 获取用户级别 scope 的凭证（原 get_oauth_credential_by_user）
+    :param repo_url: 可选，当 mode='repo' 时必须提供，仓库地址
+    :raises: Oauth2TokenHolder.DoesNotExist 当凭证不存在时
     """
-    profile = UserProfile.objects.get(user=user_id)
-    token_holder_list = profile.token_holder.filter(provider=source_control_type).all()
-    if not token_holder_list:
+    try:
+        profile = UserProfile.objects.get(user=user_id)
+    except UserProfile.DoesNotExist:
         raise Oauth2TokenHolder.DoesNotExist
 
-    # 使用第一个 token_holder 的 access_token
-    token_holder = token_holder_list[0]
+    if mode == "repo":
+        if not repo_url:
+            raise ValueError("repo_url is required when mode='repo'")
+        project = GitProject.parse_from_repo_url(repo_url, sourcectl_type=source_type)
+        token_holder = profile.token_holder.get_by_project(project)
+        return OauthCredential(token_holder.access_token, [token_holder.get_scope()])
+
+    if mode == "user":
+        token_holder = profile.token_holder.filter_user_scope(source_type)
+        return OauthCredential(token_holder.access_token, [token_holder.get_scope()])
+
+    # 默认模式：获取第一个可用凭证
+    token_holder_list = profile.token_holder.filter(provider=source_type).all()
+    if not token_holder_list:
+        raise Oauth2TokenHolder.DoesNotExist
     return OauthCredential(
-        oauth_token=token_holder.access_token, scope_list=[th.get_scope() for th in token_holder_list]
+        oauth_token=token_holder_list[0].access_token, scope_list=[th.get_scope() for th in token_holder_list]
     )
+
+
+get_oauth_credentials = get_oauth_credential
 
 
 def get_oauth_credential_by_repo(source_type: str, repo_url: str, user_id: str) -> OauthCredential:
     """根据仓库地址获取对应的 OAuth 凭证
+    该函数用于需要精确匹配仓库权限的场景（如创建特定项目组的仓库），会根据仓库地址解析项目信息并匹配 scope 能覆盖该项目的授权凭证。
+    例如：授权凭证的 scope 为: group:test1, user:user，创建 groups/test2 项目组下的代码仓库时必须根据要创建的代码仓库地址获取到正确的凭证（user:user）。
 
     :param source_type: 源码仓库类型
-    :param repo_url: 仓库地址
-    :param user_id: 用户 ID，用于查询用户对应的授权凭证
+    :param repo_url: 仓库地址（可以是未创建的仓库），用于匹配对应的授权凭证
+    :param user_id: 用户 ID
     """
-    project = GitProject.parse_from_repo_url(repo_url, sourcectl_type=source_type)
-    try:
-        profile = UserProfile.objects.get(user=user_id)
-    except UserProfile.DoesNotExist:
-        raise Oauth2TokenHolder.DoesNotExist
-
-    try:
-        token_holder = profile.token_holder.get_by_project(project)
-    except Oauth2TokenHolder.DoesNotExist:
-        raise Oauth2TokenHolder.DoesNotExist
-
-    return OauthCredential(token_holder.access_token, [token_holder.get_scope()])
+    return get_oauth_credential(source_type, user_id, "repo", repo_url)
 
 
 def get_oauth_credential_by_user(source_type: str, user_id: str) -> OauthCredential:
     """根据用户 ID 获取用户级别的 OAuth 凭证
+    该函数用于需要用户级别权限的场景（如创建用户默认空间下代码仓库），会根据用户 ID 获取用户级别的授权凭证。
 
     :param source_type: 源码仓库类型
-    :param user_id: 用户 ID，用于查询用户对应的授权凭证
+    :param user_id: 用户 ID
     """
-    try:
-        profile = UserProfile.objects.get(user=user_id)
-    except UserProfile.DoesNotExist:
-        raise Oauth2TokenHolder.DoesNotExist
-
-    try:
-        token_holder = profile.token_holder.filter_user_scope(source_type)
-    except Oauth2TokenHolder.DoesNotExist:
-        raise Oauth2TokenHolder.DoesNotExist
-
-    return OauthCredential(token_holder.access_token, [token_holder.get_scope()])
+    return get_oauth_credential(source_type, user_id, "user")

--- a/apiserver/paasng/paasng/platform/applications/views/creation.py
+++ b/apiserver/paasng/paasng/platform/applications/views/creation.py
@@ -65,7 +65,6 @@ from paasng.platform.modules.manager import (
     delete_repo_on_error,
     init_module_in_view,
 )
-from paasng.platform.sourcectl.exceptions import AccessTokenError, AccessTokenForbidden, RepoNameConflict
 from paasng.platform.templates.models import Template
 from paasng.utils.error_codes import error_codes
 
@@ -171,22 +170,11 @@ class ApplicationCreateViewSet(viewsets.ViewSet):
         # 由平台创建代码仓库
         auto_repo_url = None
         if src_cfg.get("auto_create_repo"):
-            try:
-                # 不传仓库名称，则使用平台账号创建仓库
-                if not repo_name:
-                    auto_repo_url = create_repo_with_platform_account(module, repo_type, username)
-                else:
-                    auto_repo_url = create_repo_with_user_account(module, repo_type, repo_name, username, repo_group)
-            except (AccessTokenError, AccessTokenForbidden):
-                # 前端需要根据这个 error_code，在错误信息中添加操作指引
-                raise error_codes.REPO_ACCESS_TOKEN_ERROR.f(
-                    _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息。")
-                )
-            except RepoNameConflict:
-                raise error_codes.CREATE_APP_FAILED.f(_("仓库名称已存在"))
-            except Exception:
-                logger.exception("create repo failed")
-                raise error_codes.CREATE_APP_FAILED.f(_("创建代码仓库失败"))
+            # 不传仓库名称，则使用平台账号创建仓库
+            if not repo_name:
+                auto_repo_url = create_repo_with_platform_account(module, repo_type, username)
+            else:
+                auto_repo_url = create_repo_with_user_account(module, repo_type, repo_name, username, repo_group)
 
             repo_url = auto_repo_url
 

--- a/apiserver/paasng/paasng/platform/applications/views/creation.py
+++ b/apiserver/paasng/paasng/platform/applications/views/creation.py
@@ -65,6 +65,7 @@ from paasng.platform.modules.manager import (
     delete_repo_on_error,
     init_module_in_view,
 )
+from paasng.platform.sourcectl.exceptions import AccessTokenError, AccessTokenForbidden, RepoNameConflict
 from paasng.platform.templates.models import Template
 from paasng.utils.error_codes import error_codes
 
@@ -176,6 +177,13 @@ class ApplicationCreateViewSet(viewsets.ViewSet):
                     auto_repo_url = create_repo_with_platform_account(module, repo_type, username)
                 else:
                     auto_repo_url = create_repo_with_user_account(module, repo_type, repo_name, username, repo_group)
+            except (AccessTokenError, AccessTokenForbidden):
+                # 前端需要根据这个 error_code，在错误信息中添加操作指引
+                raise error_codes.REPO_ACCESS_TOKEN_ERROR.f(
+                    _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息。")
+                )
+            except RepoNameConflict:
+                raise error_codes.CREATE_APP_FAILED.f(_("仓库名称已存在"))
             except Exception:
                 logger.exception("create repo failed")
                 raise error_codes.CREATE_APP_FAILED.f(_("创建代码仓库失败"))

--- a/apiserver/paasng/paasng/platform/modules/manager.py
+++ b/apiserver/paasng/paasng/platform/modules/manager.py
@@ -37,6 +37,7 @@ from paas_wl.infras.cluster.shim import EnvClusterService, get_exposed_url_type
 from paasng.accessories.servicehub.exceptions import ServiceObjNotFound
 from paasng.accessories.servicehub.manager import mixed_service_mgr
 from paasng.accessories.servicehub.sharing import SharingReferencesManager
+from paasng.infras.accounts.utils import get_oauth_credential_by_repo, get_oauth_credential_by_user
 from paasng.platform.applications.constants import AppEnvironment, ApplicationType
 from paasng.platform.applications.models import ModuleEnvironment
 from paasng.platform.bkapp_model.entities import Monitoring, Process
@@ -61,6 +62,7 @@ from paasng.platform.modules.specs import ModuleSpecs
 from paasng.platform.modules.utils import get_module_init_repo_context
 from paasng.platform.sourcectl.connector import get_repo_connector
 from paasng.platform.sourcectl.docker.models import init_image_repo
+from paasng.platform.sourcectl.exceptions import AccessTokenError, AccessTokenForbidden, RepoNameConflict
 from paasng.platform.sourcectl.source_types import get_sourcectl_type
 from paasng.platform.templates.constants import TemplateType
 from paasng.platform.templates.manager import AppBuildPack, TemplateRuntimeManager
@@ -222,8 +224,8 @@ class ModuleInitializer:
 
         # 将模板代码初始化到应用的代码仓库中
         if write_template_to_repo and repo_url:
-            source_type = get_sourcectl_type(self.module.source_type)
-            repo_controller = source_type.repo_controller_class.init_by_module(self.module, self.module.owner)
+            source_spec = get_sourcectl_type(self.module.source_type)
+            repo_controller = source_spec.repo_controller_class.init_by_module(self.module, self.module.owner)
             repo_controller.commit_and_push(initial_code_path, commit_message="init repo")
 
         # 返回应用初始化代码同步到对象存储的地址信息，用于前端创建成功页面的展示
@@ -376,26 +378,32 @@ def create_repo_with_platform_account(module: Module, repo_type: str, username: 
     :param repo_type: 代码仓库类型
     :return: 新创建的代码仓库地址
     """
-    source_type = get_sourcectl_type(repo_type)
-    source_type_config = source_type.config_as_arguments()
+    source_spec = get_sourcectl_type(repo_type)
+    source_spec_config = source_spec.config_as_arguments()
 
-    if "repository_group" not in source_type_config:
+    if "repository_group" not in source_spec_config:
         logger.error("repo_group is not found in source type config")
         raise error_codes.CANNOT_CREATE_APP.f(_("平台代码仓库组配置缺失"))
 
-    if not source_type.repo_provisioner_class:
+    if not source_spec.repo_provisioner_class:
         raise error_codes.CANNOT_CREATE_APP.f(_("当前代码源不支持新建仓库"))
 
-    repo_group = source_type_config["repository_group"]
-    repo_name = f"{module.application.code}_{module.name}"
-    repo_provisioner = source_type.repo_provisioner_class.init_by_platform_account(repo_type)
+    try:
+        repo_group = source_spec_config["repository_group"]
+        repo_name = f"{module.application.code}_{module.name}"
+        repo_provisioner = source_spec.repo_provisioner_class.init_by_platform_account(repo_type)
 
-    return repo_provisioner.create_with_member(
-        repo_name=repo_name,
-        description=f"{module.application.name}({module.name} 模块)",
-        username=username,
-        repo_group=repo_group,
-    )
+        return repo_provisioner.create_with_member(
+            repo_name=repo_name,
+            description=f"{module.application.name}({module.name} 模块)",
+            username=username,
+            repo_group=repo_group,
+        )
+    except RepoNameConflict:
+        raise error_codes.CREATE_APP_FAILED.f(_("仓库名称已存在"))
+    except Exception:
+        logger.exception("create repo failed")
+        raise error_codes.CREATE_APP_FAILED.f(_("创建代码仓库失败"))
 
 
 def create_repo_with_user_account(
@@ -414,18 +422,51 @@ def create_repo_with_user_account(
     :param repo_group: 代码仓库组，可选，不填则默认在用户命名空间下创建
     :return: 新创建的代码仓库地址
     """
-    source_type = get_sourcectl_type(repo_type)
-    if not source_type.repo_provisioner_class:
+    # 1. 验证仓库类型是否支持创建
+    source_spec = get_sourcectl_type(repo_type)
+    if not source_spec.repo_provisioner_class:
         raise error_codes.CANNOT_CREATE_APP.f(_("当前代码源不支持新建仓库"))
 
-    repo_provisioner = source_type.repo_provisioner_class.init_by_user(repo_type, user_id=module.owner)
+    # 2. 获取用户凭证
+    user_id = module.owner
+    if repo_group:
+        repo_url = f"{repo_group}/{repo_name}"
+        try:
+            oauth_credential = get_oauth_credential_by_repo(repo_type, repo_url, user_id)
+        except ObjectDoesNotExist:
+            raise error_codes.REPO_ACCESS_TOKEN_ERROR.f(
+                _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息")
+            )
+    else:
+        try:
+            # 未指定仓库组，则在用户默认命名空间下创建仓库，则代码仓库必须按 user 级别授权
+            oauth_credential = get_oauth_credential_by_user(repo_type, user_id)
+        except ObjectDoesNotExist:
+            raise error_codes.REPO_DEFAULT_SCOPE_PERMISSION_ERROR.f(
+                _("必须使用“当前账号”授权才能在用户命名空间下创建仓库")
+            )
 
-    return repo_provisioner.create_with_member(
-        repo_name=repo_name,
-        description=f"{module.application.name}({module.name} 模块)",
-        username=username,
-        repo_group=repo_group,
-    )
+    try:
+        # 3. 初始化仓库操作器
+        repo_provisioner = source_spec.repo_provisioner_class.init_by_user(repo_type, oauth_credential)
+
+        # 4. 创建仓库并添加成员
+        return repo_provisioner.create_with_member(
+            repo_name=repo_name,
+            description=f"{module.application.name}({module.name} 模块)",
+            username=username,
+            repo_group=repo_group,
+        )
+    except (AccessTokenError, AccessTokenForbidden):
+        # 前端需要根据这个 error_code，在错误信息中添加操作指引
+        raise error_codes.REPO_ACCESS_TOKEN_ERROR.f(
+            _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息")
+        )
+    except RepoNameConflict:
+        raise error_codes.CREATE_APP_FAILED.f(_("仓库名称已存在"))
+    except Exception:
+        logger.exception("create repo failed")
+        raise error_codes.CREATE_APP_FAILED.f(_("创建代码仓库失败"))
 
 
 def delete_repo(repo_type: str, repo_url: str, user_id: str):
@@ -435,11 +476,12 @@ def delete_repo(repo_type: str, repo_url: str, user_id: str):
     :param repo_url: 仓库地址
     :param user_id: 用户 ID，用于查询用户对应的授权凭证
     """
-    source_type = get_sourcectl_type(repo_type)
-    if not source_type.repo_provisioner_class:
+    source_spec = get_sourcectl_type(repo_type)
+    if not source_spec.repo_provisioner_class:
         raise error_codes.CANNOT_CREATE_APP.f(_("当前代码源不支持删除仓库"))
 
-    repo_provisioner = source_type.repo_provisioner_class.init_by_user(repo_type, user_id)
+    oauth_credential = get_oauth_credential_by_repo(repo_type, repo_url, user_id)
+    repo_provisioner = source_spec.repo_provisioner_class.init_by_user(repo_type, oauth_credential)
     repo_provisioner.delete_project(repo_url)
 
 

--- a/apiserver/paasng/paasng/platform/modules/manager.py
+++ b/apiserver/paasng/paasng/platform/modules/manager.py
@@ -434,8 +434,8 @@ def create_repo_with_user_account(
         try:
             oauth_credential = get_oauth_credential_by_repo(repo_type, repo_url, user_id)
         except ObjectDoesNotExist:
-            raise error_codes.REPO_ACCESS_TOKEN_ERROR.f(
-                _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息")
+            raise error_codes.REPO_ACCESS_TOKEN_PERM_DENIED.f(
+                _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息"), replace=True
             )
     else:
         try:
@@ -443,7 +443,7 @@ def create_repo_with_user_account(
             oauth_credential = get_oauth_credential_by_user(repo_type, user_id)
         except ObjectDoesNotExist:
             raise error_codes.REPO_DEFAULT_SCOPE_PERMISSION_ERROR.f(
-                _("必须使用“当前账号”授权才能在用户命名空间下创建仓库")
+                _("必须使用“当前账号”授权才能在用户命名空间下创建仓库"), replace=True
             )
 
     try:
@@ -459,8 +459,8 @@ def create_repo_with_user_account(
         )
     except (AccessTokenError, AccessTokenForbidden):
         # 前端需要根据这个 error_code，在错误信息中添加操作指引
-        raise error_codes.REPO_ACCESS_TOKEN_ERROR.f(
-            _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息")
+        raise error_codes.REPO_ACCESS_TOKEN_PERM_DENIED.f(
+            _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息"), replace=True
         )
     except RepoNameConflict:
         raise error_codes.CREATE_APP_FAILED.f(_("仓库名称已存在"))

--- a/apiserver/paasng/paasng/platform/modules/manager.py
+++ b/apiserver/paasng/paasng/platform/modules/manager.py
@@ -434,6 +434,7 @@ def create_repo_with_user_account(
         try:
             oauth_credential = get_oauth_credential_by_repo(repo_type, repo_url, user_id)
         except ObjectDoesNotExist:
+            logger.exception("get oauth credential failed")
             raise error_codes.REPO_ACCESS_TOKEN_PERM_DENIED.f(
                 _("您没有权限操作该代码仓库，请确认您的授权信息"), replace=True
             )
@@ -460,9 +461,7 @@ def create_repo_with_user_account(
     except (AccessTokenError, AccessTokenForbidden):
         logger.exception("create repo failed")
         # 前端需要根据这个 error_code，在错误信息中添加操作指引
-        raise error_codes.REPO_ACCESS_TOKEN_PERM_DENIED.f(
-            _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息"), replace=True
-        )
+        raise error_codes.REPO_ACCESS_TOKEN_PERM_DENIED.f(_("创建代码仓库失败，请确认您的授权信息"), replace=True)
     except RepoNameConflict:
         raise error_codes.CREATE_APP_FAILED.f(_("仓库名称已存在"))
     except Exception:

--- a/apiserver/paasng/paasng/platform/modules/manager.py
+++ b/apiserver/paasng/paasng/platform/modules/manager.py
@@ -435,7 +435,7 @@ def create_repo_with_user_account(
             oauth_credential = get_oauth_credential_by_repo(repo_type, repo_url, user_id)
         except ObjectDoesNotExist:
             raise error_codes.REPO_ACCESS_TOKEN_PERM_DENIED.f(
-                _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息"), replace=True
+                _("您没有权限操作该代码仓库，请确认您的授权信息"), replace=True
             )
     else:
         try:
@@ -458,6 +458,7 @@ def create_repo_with_user_account(
             repo_group=repo_group,
         )
     except (AccessTokenError, AccessTokenForbidden):
+        logger.exception("create repo failed")
         # 前端需要根据这个 error_code，在错误信息中添加操作指引
         raise error_codes.REPO_ACCESS_TOKEN_PERM_DENIED.f(
             _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息"), replace=True

--- a/apiserver/paasng/paasng/platform/modules/views.py
+++ b/apiserver/paasng/paasng/platform/modules/views.py
@@ -89,7 +89,6 @@ from paasng.platform.modules.serializers import (
     ModuleSLZ,
 )
 from paasng.platform.modules.specs import ModuleSpecs
-from paasng.platform.sourcectl.exceptions import AccessTokenError, AccessTokenForbidden, RepoNameConflict
 from paasng.platform.templates.constants import TemplateType
 from paasng.platform.templates.models import Template
 from paasng.platform.templates.serializers import TemplateRenderOutputSLZ
@@ -325,22 +324,11 @@ class ModuleViewSet(viewsets.ViewSet, ApplicationCodeInPathMixin):
         # 由平台创建代码仓库
         auto_repo_url = None
         if source_config.get("auto_create_repo"):
-            try:
-                # 不传仓库名称，则使用平台账号创建仓库
-                if not repo_name:
-                    auto_repo_url = create_repo_with_platform_account(module, repo_type, username)
-                else:
-                    auto_repo_url = create_repo_with_user_account(module, repo_type, repo_name, username, repo_group)
-            except (AccessTokenError, AccessTokenForbidden):
-                # 前端需要根据这个 error_code，在错误信息中添加操作指引
-                raise error_codes.REPO_ACCESS_TOKEN_ERROR.f(
-                    _("您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息。")
-                )
-            except RepoNameConflict:
-                raise error_codes.CREATE_APP_FAILED.f(_("仓库名称已存在"))
-            except Exception:
-                logger.exception("create repo failed")
-                raise error_codes.CREATE_APP_FAILED.f(_("创建代码仓库失败"))
+            # 不传仓库名称，则使用平台账号创建仓库
+            if not repo_name:
+                auto_repo_url = create_repo_with_platform_account(module, repo_type, username)
+            else:
+                auto_repo_url = create_repo_with_user_account(module, repo_type, repo_name, username, repo_group)
 
             repo_url = auto_repo_url
 

--- a/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
@@ -26,7 +26,7 @@ from cattr import unstructure
 from typing_extensions import Protocol
 
 from paasng.infras.accounts.models import Oauth2TokenHolder, PrivateTokenHolder, UserProfile
-from paasng.infras.accounts.utils import get_oauth_credential_with_merged_scopes
+from paasng.infras.accounts.utils import get_oauth_credential_with_union_scopes
 from paasng.platform.modules.constants import SourceOrigin
 from paasng.platform.sourcectl import exceptions
 from paasng.platform.sourcectl.models import (
@@ -224,7 +224,7 @@ def list_git_repositories(source_control_type: str, user_id: str) -> List[Reposi
     """
     cls = get_sourcectl_type(source_control_type).repo_controller_class
 
-    user_credentials = get_oauth_credential_with_merged_scopes(source_control_type, user_id)
+    user_credentials = get_oauth_credential_with_union_scopes(source_control_type, user_id)
     type_spec = get_sourcectl_type(source_control_type)
     repo_info = type_spec.config_as_arguments()
     return cls.list_all_repositories(api_url=repo_info["api_url"], user_credentials=unstructure(user_credentials))

--- a/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
@@ -226,4 +226,4 @@ def list_git_repositories(source_control_type: str, user_id: str) -> List[Reposi
     user_credentials = get_oauth_credentials(source_control_type, user_id)
     type_spec = get_sourcectl_type(source_control_type)
     repo_info = type_spec.config_as_arguments()
-    return cls.list_all_repositories(api_url=repo_info["api_url"], user_credentials=user_credentials)
+    return cls.list_all_repositories(api_url=repo_info["api_url"], user_credentials=user_credentials.to_dict())

--- a/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 from bkpaas_auth.core.encoder import ProviderType, user_id_encoder
+from cattr import unstructure
 from typing_extensions import Protocol
 
 from paasng.infras.accounts.models import Oauth2TokenHolder, PrivateTokenHolder, UserProfile
@@ -226,4 +227,4 @@ def list_git_repositories(source_control_type: str, user_id: str) -> List[Reposi
     user_credentials = get_oauth_credentials(source_control_type, user_id)
     type_spec = get_sourcectl_type(source_control_type)
     repo_info = type_spec.config_as_arguments()
-    return cls.list_all_repositories(api_url=repo_info["api_url"], user_credentials=user_credentials.to_dict())
+    return cls.list_all_repositories(api_url=repo_info["api_url"], user_credentials=unstructure(user_credentials))

--- a/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/repo_controller.py
@@ -26,7 +26,7 @@ from cattr import unstructure
 from typing_extensions import Protocol
 
 from paasng.infras.accounts.models import Oauth2TokenHolder, PrivateTokenHolder, UserProfile
-from paasng.infras.accounts.utils import get_oauth_credentials
+from paasng.infras.accounts.utils import get_oauth_credential_with_merged_scopes
 from paasng.platform.modules.constants import SourceOrigin
 from paasng.platform.sourcectl import exceptions
 from paasng.platform.sourcectl.models import (
@@ -224,7 +224,7 @@ def list_git_repositories(source_control_type: str, user_id: str) -> List[Reposi
     """
     cls = get_sourcectl_type(source_control_type).repo_controller_class
 
-    user_credentials = get_oauth_credentials(source_control_type, user_id)
+    user_credentials = get_oauth_credential_with_merged_scopes(source_control_type, user_id)
     type_spec = get_sourcectl_type(source_control_type)
     repo_info = type_spec.config_as_arguments()
     return cls.list_all_repositories(api_url=repo_info["api_url"], user_credentials=unstructure(user_credentials))

--- a/apiserver/paasng/paasng/platform/sourcectl/repo_provisioner.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/repo_provisioner.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional
 from cattr import unstructure
 from typing_extensions import Protocol
 
-from paasng.infras.accounts.utils import OauthCredential, get_oauth_credential_with_merged_scopes
+from paasng.infras.accounts.utils import OauthCredential, get_oauth_credential_with_union_scopes
 from paasng.platform.sourcectl.models import GitGroup
 from paasng.platform.sourcectl.source_types import get_sourcectl_type
 
@@ -104,7 +104,7 @@ def list_all_owned_groups(source_type: str, user_id: str) -> List[GitGroup]:
     if not repo_provisioner_class:
         raise ValueError(f"Source type {source_type} not support list repository groups")
 
-    user_credentials = get_oauth_credential_with_merged_scopes(source_type, user_id)
+    user_credentials = get_oauth_credential_with_union_scopes(source_type, user_id)
     type_spec = get_sourcectl_type(source_type)
     source_config = type_spec.config_as_arguments()
     return repo_provisioner_class.list_owned_groups(source_config["api_url"], unstructure(user_credentials))

--- a/apiserver/paasng/paasng/platform/sourcectl/repo_provisioner.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/repo_provisioner.py
@@ -14,9 +14,9 @@
 #
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
-
 from typing import Dict, List, Optional
 
+from cattr import unstructure
 from typing_extensions import Protocol
 
 from paasng.infras.accounts.utils import OauthCredential, get_oauth_credentials
@@ -91,7 +91,7 @@ class BaseGitProvisioner:
         if "api_url" not in source_config:
             raise ValueError("Require api_url to init GitRepoController")
 
-        return cls(api_url=source_config["api_url"], user_credentials=oauth_credential.to_dict())
+        return cls(api_url=source_config["api_url"], user_credentials=unstructure(oauth_credential))
 
 
 def list_all_owned_groups(source_type: str, user_id: str) -> List[GitGroup]:
@@ -107,4 +107,4 @@ def list_all_owned_groups(source_type: str, user_id: str) -> List[GitGroup]:
     user_credentials = get_oauth_credentials(source_type, user_id)
     type_spec = get_sourcectl_type(source_type)
     source_config = type_spec.config_as_arguments()
-    return repo_provisioner_class.list_owned_groups(source_config["api_url"], user_credentials.to_dict())
+    return repo_provisioner_class.list_owned_groups(source_config["api_url"], unstructure(user_credentials))

--- a/apiserver/paasng/paasng/platform/sourcectl/repo_provisioner.py
+++ b/apiserver/paasng/paasng/platform/sourcectl/repo_provisioner.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional
 from cattr import unstructure
 from typing_extensions import Protocol
 
-from paasng.infras.accounts.utils import OauthCredential, get_oauth_credentials
+from paasng.infras.accounts.utils import OauthCredential, get_oauth_credential_with_merged_scopes
 from paasng.platform.sourcectl.models import GitGroup
 from paasng.platform.sourcectl.source_types import get_sourcectl_type
 
@@ -104,7 +104,7 @@ def list_all_owned_groups(source_type: str, user_id: str) -> List[GitGroup]:
     if not repo_provisioner_class:
         raise ValueError(f"Source type {source_type} not support list repository groups")
 
-    user_credentials = get_oauth_credentials(source_type, user_id)
+    user_credentials = get_oauth_credential_with_merged_scopes(source_type, user_id)
     type_spec = get_sourcectl_type(source_type)
     source_config = type_spec.config_as_arguments()
     return repo_provisioner_class.list_owned_groups(source_config["api_url"], unstructure(user_credentials))

--- a/apiserver/paasng/paasng/utils/error_codes.py
+++ b/apiserver/paasng/paasng/utils/error_codes.py
@@ -171,6 +171,7 @@ class ErrorCodes:
     # 创建应用相关
     CREATE_LESSCODE_APP_ERROR = ErrorCode(_("创建蓝鲸运维开发平台应用错误"))
     CREATE_APP_FAILED = ErrorCode(_("创建应用失败"))
+    REPO_ACCESS_TOKEN_ERROR = ErrorCode(_("没有权限操作代码仓库"))
 
     # Admin 相关
     CONTROLLER_INTERNAL_ERROR = ErrorCode(_("engine 服务错误"))

--- a/apiserver/paasng/paasng/utils/error_codes.py
+++ b/apiserver/paasng/paasng/utils/error_codes.py
@@ -171,7 +171,7 @@ class ErrorCodes:
     # 创建应用相关
     CREATE_LESSCODE_APP_ERROR = ErrorCode(_("创建蓝鲸运维开发平台应用错误"))
     CREATE_APP_FAILED = ErrorCode(_("创建应用失败"))
-    REPO_ACCESS_TOKEN_ERROR = ErrorCode(_("没有权限操作代码仓库"))
+    REPO_ACCESS_TOKEN_PERM_DENIED = ErrorCode(_("没有权限操作代码仓库"))
     REPO_DEFAULT_SCOPE_PERMISSION_ERROR = ErrorCode(_("没有权在默认空间创建仓库"))
 
     # Admin 相关

--- a/apiserver/paasng/paasng/utils/error_codes.py
+++ b/apiserver/paasng/paasng/utils/error_codes.py
@@ -172,6 +172,7 @@ class ErrorCodes:
     CREATE_LESSCODE_APP_ERROR = ErrorCode(_("创建蓝鲸运维开发平台应用错误"))
     CREATE_APP_FAILED = ErrorCode(_("创建应用失败"))
     REPO_ACCESS_TOKEN_ERROR = ErrorCode(_("没有权限操作代码仓库"))
+    REPO_DEFAULT_SCOPE_PERMISSION_ERROR = ErrorCode(_("没有权在默认空间创建仓库"))
 
     # Admin 相关
     CONTROLLER_INTERNAL_ERROR = ErrorCode(_("engine 服务错误"))


### PR DESCRIPTION
1. 授权 token 的 scope 为：group:test1,  user:user
- 创建 groups/test2 项目组下的代码仓库成功

2. 授权 token 的 scope 为：group:test1
- 创建 group:test2 项目组下代码仓库失败，并报错
```
{
    "code": "REPO_ACCESS_TOKEN_ERROR",
    "detail": "您没有权限操作该代码仓库，请在“代码库管理”页面确认您的授权信息"
}
```


3. 授权 token 的 scope 为：group:test1
- 创建用户默认命名空间下创建仓库失败，并报错：
```
{
    "code": "REPO_DEFAULT_SCOPE_PERMISSION_ERROR",
    "detail": "必须使用“当前账号”授权才能在用户命名空间下创建仓库"
}
```

