### PR TITLE
fix: set uncorrect status condition for type AppAvailable because of …

### DIFF
--- a/operator/pkg/controllers/bkapp/processes/deployments.go
+++ b/operator/pkg/controllers/bkapp/processes/deployments.go
@@ -238,6 +238,10 @@ func (r *DeploymentReconciler) updateCondition(ctx context.Context, bkapp *paasv
 			continue
 		}
 
+		if healthStatus.Phase == paasv1alpha2.HealthProgressing {
+			continue
+		}
+
 		failMessage, err := health.GetDeploymentDirectFailMessage(ctx, r.Client, deployment)
 		if errors.Is(err, health.ErrDeploymentStillProgressing) {
 			continue

--- a/operator/pkg/health/deployment.go
+++ b/operator/pkg/health/deployment.go
@@ -121,6 +121,10 @@ func GetDeploymentDirectFailMessage(
 		return "", err
 	}
 	for _, pod := range pods.Items {
+		// WARNING: 删除 Deployment 后，集群可能有秒级时延才能将关联的 Pod 标记为删除状态.
+		// 因此, 立即通过 MatchLabels 过滤 Pod, 再忽略已删除的 Pod, 可能会出现不准确的情况.
+		// 如果需要精确查询 Deployment 关联的 Pod, 需要通过 ownerReference 精准过滤.
+
 		// 忽略已被标记删除的 Pod
 		if !pod.DeletionTimestamp.IsZero() {
 			continue


### PR DESCRIPTION
…mismatch pod failed message

部署时，AppAvailable Condition 未正确更新状态，而是使用了旧 failed pod 的信息。推测可能是获取到了上一个 Deployment 的 pod，但不太好复现。在上云环境收到过一例用户反馈，v3tnew 也出现过一次。

<img width="1952" height="842" alt="image" src="https://github.com/user-attachments/assets/1629340a-b94b-4321-a3ed-787ab0f24939" />

目前解法是：优化逻辑，规避问题。
