### PR TITLE
test: stabilize unittests by fixing order dependency and configuration

### DIFF
--- a/apiserver/paasng/Makefile
+++ b/apiserver/paasng/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	DJANGO_SETTINGS_MODULE='paasng.settings' pytest -s -p no:warnings --reuse-db --maxfail=1 tests/
+	DJANGO_SETTINGS_MODULE='paas_settings_ieod.dev.lean_ut' pytest -s -p no:warnings --reuse-db --maxfail=1 tests/
 
 .PHONY: edition
 edition:

--- a/apiserver/paasng/Makefile
+++ b/apiserver/paasng/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	DJANGO_SETTINGS_MODULE='paas_settings_ieod.dev.lean_ut' pytest -s -p no:warnings --reuse-db --maxfail=1 tests/
+	DJANGO_SETTINGS_MODULE='paasng.settings' pytest -s -p no:warnings --reuse-db --maxfail=1 tests/
 
 .PHONY: edition
 edition:

--- a/apiserver/paasng/Makefile
+++ b/apiserver/paasng/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	DJANGO_SETTINGS_MODULE='paasng.settings' pytest -s -p no:warnings --reuse-db --maxfail=1 tests/
+	DJANGO_SETTINGS_MODULE='paasng.settings' pytest -p -l no:warnings --reuse-db --maxfail=1 tests/
 
 .PHONY: edition
 edition:

--- a/apiserver/paasng/tests/api/accessories/proc_components/test_proc_components.py
+++ b/apiserver/paasng/tests/api/accessories/proc_components/test_proc_components.py
@@ -15,6 +15,7 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
+from operator import itemgetter
 from pathlib import Path
 
 import pytest
@@ -35,36 +36,39 @@ class TestProcessComponentViewSet:
         """测试获取进程组件列表"""
         resp = api_client.get("/api/proc_components")
         assert resp.status_code == 200
-        assert resp.data == [
-            {
-                "name": "test_env_overlay",
-                "version": "v1",
-                "schema": {
-                    "type": "object",
-                    "required": ["env"],
-                    "properties": {
-                        "env": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "required": ["name", "value"],
-                                "properties": {
-                                    "name": {"type": "string", "minLength": 1},
-                                    "value": {"type": "string"},
+        assert sorted(resp.data, key=itemgetter("name")) == sorted(
+            [
+                {
+                    "name": "test_env_overlay",
+                    "version": "v1",
+                    "schema": {
+                        "type": "object",
+                        "required": ["env"],
+                        "properties": {
+                            "env": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": ["name", "value"],
+                                    "properties": {
+                                        "name": {"type": "string", "minLength": 1},
+                                        "value": {"type": "string"},
+                                    },
+                                    "additionalProperties": False,
                                 },
-                                "additionalProperties": False,
-                            },
-                            "minItems": 1,
-                        }
+                                "minItems": 1,
+                            }
+                        },
+                        "additionalProperties": False,
                     },
-                    "additionalProperties": False,
+                    "documentation": "test_env_overlay\n",
                 },
-                "documentation": "test_env_overlay\n",
-            },
-            {
-                "name": "test_sidecar",
-                "version": "v1",
-                "schema": {"description": "不需要任何参数", "type": "object", "additionalProperties": False},
-                "documentation": "test_sidecar\n",
-            },
-        ]
+                {
+                    "name": "test_sidecar",
+                    "version": "v1",
+                    "schema": {"description": "不需要任何参数", "type": "object", "additionalProperties": False},
+                    "documentation": "test_sidecar\n",
+                },
+            ],
+            key=itemgetter("name"),
+        )

--- a/apiserver/paasng/tests/api/accessories/proc_components/test_proc_components.py
+++ b/apiserver/paasng/tests/api/accessories/proc_components/test_proc_components.py
@@ -36,39 +36,36 @@ class TestProcessComponentViewSet:
         """测试获取进程组件列表"""
         resp = api_client.get("/api/proc_components")
         assert resp.status_code == 200
-        assert sorted(resp.data, key=itemgetter("name")) == sorted(
-            [
-                {
-                    "name": "test_env_overlay",
-                    "version": "v1",
-                    "schema": {
-                        "type": "object",
-                        "required": ["env"],
-                        "properties": {
-                            "env": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "required": ["name", "value"],
-                                    "properties": {
-                                        "name": {"type": "string", "minLength": 1},
-                                        "value": {"type": "string"},
-                                    },
-                                    "additionalProperties": False,
+        assert sorted(resp.data, key=itemgetter("name")) == [
+            {
+                "name": "test_env_overlay",
+                "version": "v1",
+                "schema": {
+                    "type": "object",
+                    "required": ["env"],
+                    "properties": {
+                        "env": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": ["name", "value"],
+                                "properties": {
+                                    "name": {"type": "string", "minLength": 1},
+                                    "value": {"type": "string"},
                                 },
-                                "minItems": 1,
-                            }
-                        },
-                        "additionalProperties": False,
+                                "additionalProperties": False,
+                            },
+                            "minItems": 1,
+                        }
                     },
-                    "documentation": "test_env_overlay\n",
+                    "additionalProperties": False,
                 },
-                {
-                    "name": "test_sidecar",
-                    "version": "v1",
-                    "schema": {"description": "不需要任何参数", "type": "object", "additionalProperties": False},
-                    "documentation": "test_sidecar\n",
-                },
-            ],
-            key=itemgetter("name"),
-        )
+                "documentation": "test_env_overlay\n",
+            },
+            {
+                "name": "test_sidecar",
+                "version": "v1",
+                "schema": {"description": "不需要任何参数", "type": "object", "additionalProperties": False},
+                "documentation": "test_sidecar\n",
+            },
+        ]

--- a/apiserver/paasng/tests/paas_wl/bk_app/cnative/specs/test_resource.py
+++ b/apiserver/paasng/tests/paas_wl/bk_app/cnative/specs/test_resource.py
@@ -165,6 +165,7 @@ class Test__list_mres_by_env:
                 "build": {"image": "nginx:latest"},
                 "processes": [{"name": "web", "replicas": 1, "resQuotaPlan": "default"}],
                 "hooks": {"preRelease": {"command": ["/bin/echo"], "args": ["Hello"]}},
+                "configuration": {},
             },
         }
 

--- a/apiserver/paasng/tests/paasng/platform/sourcectl/test_source_types.py
+++ b/apiserver/paasng/tests/paasng/platform/sourcectl/test_source_types.py
@@ -160,11 +160,11 @@ class TestSourceTypes:
     def source_types(self):
         source_type_spec_configs = [
             {
-                "spec_cls": "tests.paasng.platform.sourcectl.test_source_types.DummySourceTypeSpec",
+                "spec_cls": "sourcectl.test_source_types.DummySourceTypeSpec",
                 "attrs": {"name": "my_dummy_1", "label": "Dummy-1"},
             },
             {
-                "spec_cls": "tests.paasng.platform.sourcectl.test_source_types.GitDummySourceTypeSpec",
+                "spec_cls": "sourcectl.test_source_types.GitDummySourceTypeSpec",
                 "attrs": {"name": "my_dummy_2"},
             },
         ]

--- a/apiserver/paasng/tests/paasng/platform/sourcectl/test_source_types.py
+++ b/apiserver/paasng/tests/paasng/platform/sourcectl/test_source_types.py
@@ -160,11 +160,11 @@ class TestSourceTypes:
     def source_types(self):
         source_type_spec_configs = [
             {
-                "spec_cls": "sourcectl.test_source_types.DummySourceTypeSpec",
+                "spec_cls": "tests.paasng.platform.sourcectl.test_source_types.DummySourceTypeSpec",
                 "attrs": {"name": "my_dummy_1", "label": "Dummy-1"},
             },
             {
-                "spec_cls": "sourcectl.test_source_types.GitDummySourceTypeSpec",
+                "spec_cls": "tests.paasng.platform.sourcectl.test_source_types.GitDummySourceTypeSpec",
                 "attrs": {"name": "my_dummy_2"},
             },
         ]


### PR DESCRIPTION
## 修复测试样例
- `Test__list_mres_by_env.test_list`, 添加 `spec.configuraiton` 字段
- 消除数据顺序对 assert 的影响

## 更新 Makefile 的 test 指令
- 修改 `DJANGO_SETTINGS_MODULE` 路径
- 去除 pytest 的 `-s` 选项: 默认的日志级别为 INFO , 开启 `-s` 会输出大量低级别日志干扰
- 添加 `-l` 选项, 在出错时打印出调用栈, 方便排查问题