### PR TITLE
fix: operating a process may trigger updates in other processes

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -15,8 +15,9 @@ require (
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.4
-	github.com/samber/lo v1.47.0
+	github.com/samber/lo v1.52.0
 	github.com/tidwall/sjson v1.2.5
+	github.com/xeipuuv/gojsonschema v1.2.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/time v0.10.0
 	gopkg.in/inf.v0 v0.9.1
@@ -24,6 +25,7 @@ require (
 	k8s.io/apimachinery v0.24.17
 	k8s.io/client-go v0.24.17
 	sigs.k8s.io/controller-runtime v0.12.3
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -71,7 +73,6 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
@@ -92,5 +93,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -179,8 +179,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
-github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
+github.com/samber/lo v1.52.0 h1:Rvi+3BFHES3A8meP33VPAxiBZX/Aws5RxrschYGjomw=
+github.com/samber/lo v1.52.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=

--- a/operator/pkg/controllers/bkapp/hooks/resources/hooks.go
+++ b/operator/pkg/controllers/bkapp/hooks/resources/hooks.go
@@ -176,13 +176,13 @@ func BuildPreReleaseHook(bkapp *paasv1alpha2.BkApp, status *paasv1alpha2.HookSta
 		Status: status,
 	}
 
-	mounterMap, err := volumes.GetAllVolumeMounterMap(bkapp)
+	volMounters, err := volumes.GetAllVolumeMounters(bkapp)
 	if err != nil {
 		log.Error(err, "Failed to get volume mounter map for pre-release-hook", "bkappName", bkapp.Name)
 		return nil, err
 	}
 
-	for _, mounter := range mounterMap {
+	for _, mounter := range volMounters {
 		if err = mounter.ApplyToPod(bkapp, hook.Pod); err != nil {
 			log.Error(err, "Failed to inject mounts info to pre-release-hook")
 			return nil, err

--- a/operator/pkg/controllers/bkapp/processes/resources/deployment.go
+++ b/operator/pkg/controllers/bkapp/processes/resources/deployment.go
@@ -67,7 +67,7 @@ func BuildProcDeployment(app *paasv1alpha2.BkApp, procName string) (*appsv1.Depl
 	envVars := common.GetAppEnvs(app)
 	envVars = common.RenderAppVars(envVars, common.VarsRenderContext{ProcessType: procName})
 
-	mounterMap, err := volumes.GetAllVolumeMounterMap(app)
+	volMounters, err := volumes.GetAllVolumeMounters(app)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func BuildProcDeployment(app *paasv1alpha2.BkApp, procName string) (*appsv1.Depl
 		},
 	}
 
-	for _, mounter := range mounterMap {
+	for _, mounter := range volMounters {
 		err = mounter.ApplyToDeployment(app, deployment)
 		if err != nil {
 			log.Error(err, "Failed to inject mounts info to process", proc.Name)

--- a/operator/pkg/controllers/bkapp/processes/volumes/volumes_test.go
+++ b/operator/pkg/controllers/bkapp/processes/volumes/volumes_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,11 +72,12 @@ var _ = Describe("Get VolumeMounterMap", func() {
 	})
 
 	It("mounts without overlay", func() {
-		volMountMap := GetGenericVolumeMountMap(bkapp)
+		volMounts := GetGenericVolumeMounters(bkapp)
 
-		Expect(len(volMountMap)).To(Equal(2))
-		Expect(volMountMap[nginxMountName].GetMountPath()).To(Equal(nginxPath))
-		Expect(volMountMap[redisMountName].GetMountPath()).To(Equal(redisPath))
+		Expect(len(volMounts)).To(Equal(2))
+		resultMap := lo.SliceToMap(volMounts, func(m VolumeMounter) (string, VolumeMounter) { return m.GetName(), m })
+		Expect(resultMap[nginxMountName].GetMountPath()).To(Equal(nginxPath))
+		Expect(resultMap[redisMountName].GetMountPath()).To(Equal(redisPath))
 	})
 
 	It("mounts with overlay", func() {
@@ -119,18 +121,18 @@ var _ = Describe("Get VolumeMounterMap", func() {
 			},
 		}
 
-		volMountMap := GetGenericVolumeMountMap(bkapp)
+		volMounts := GetGenericVolumeMounters(bkapp)
 
-		Expect(len(volMountMap)).To(Equal(3))
-
-		Expect(volMountMap[nginxMountName].GetMountPath()).To(Equal(overlayPath))
-		Expect(volMountMap[etcdName].GetMountPath()).To(Equal(etcdPath))
+		Expect(len(volMounts)).To(Equal(3))
+		resultMap := lo.SliceToMap(volMounts, func(m VolumeMounter) (string, VolumeMounter) { return m.GetName(), m })
+		Expect(resultMap[nginxMountName].GetMountPath()).To(Equal(overlayPath))
+		Expect(resultMap[etcdName].GetMountPath()).To(Equal(etcdPath))
 	})
 
 	It("no mounts", func() {
 		bkapp.Spec.Mounts = []paasv1alpha2.Mount{}
-		volMountMap, _ := GetAllVolumeMounterMap(bkapp)
-		Expect(len(volMountMap)).To(Equal(0))
+		volMounters, _ := GetAllVolumeMounters(bkapp)
+		Expect(len(volMounters)).To(Equal(0))
 	})
 })
 


### PR DESCRIPTION
应用进程数量很多时，操作其中某一个进程，可能导致其他进程也发生滚动。这是由于进程的 Volume Mount 定义顺序发生变化所导致。底层原因，是因为 operator 中不当使用了 Go 的 map 类型（无序）。

本 PR 通过调整数据结构修复了此问题。