### PR TITLE
 fix: 增加本地增强服务创建&更新时 name 校验，禁止与现有的远程增强服务 id 相同

### DIFF
--- a/apiserver/paasng/locale/en/LC_MESSAGES/django.po
+++ b/apiserver/paasng/locale/en/LC_MESSAGES/django.po
@@ -2330,6 +2330,10 @@ msgstr ""
 "letters, numbers, hyphens (-) or underscores (_), must start with a letter "
 "and end with a letter or number."
 
+#: paasng/plat_mgt/infras/services/serializers/services.py:152
+msgid "{} 不符合规范: 与远程增强服务 id 冲突"
+msgstr "{} does not meet requirements: Conflicts with a remote service name."
+
 #: paasng/plat_admin/admin42/utils/__init__.py:35
 #, python-brace-format
 msgid "由于: {reason}, 该功能暂不支持"

--- a/apiserver/paasng/locale/en/LC_MESSAGES/django.po
+++ b/apiserver/paasng/locale/en/LC_MESSAGES/django.po
@@ -2331,8 +2331,8 @@ msgstr ""
 "and end with a letter or number."
 
 #: paasng/plat_mgt/infras/services/serializers/services.py:152
-msgid "{} 不符合规范: 与远程增强服务 id 冲突"
-msgstr "{} does not meet requirements: Conflicts with a remote service name."
+msgid "{} 不符合规范: 与远程增强服务 ID 冲突"
+msgstr "{} does not meet requirements: Conflicts with a remote service ID"
 
 #: paasng/plat_admin/admin42/utils/__init__.py:35
 #, python-brace-format

--- a/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
+++ b/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
@@ -146,7 +146,7 @@ class ServiceCreateSLZ(serializers.Serializer):
                 ).format(name)
             )
 
-        # 存在使用 service_name 来使用增强服务的场景， 故禁止本地增强服务和远程增强服务重名
+        #  创建 S-Mart 应用时，使用 service_name 来指定增强服务， 故禁止本地增强服务和远程增强服务重名
         remote_svc_names = [e.get("name") for e in settings.SERVICE_REMOTE_ENDPOINTS]
         if name in remote_svc_names:
             raise ValidationError(_("{} 不符合规范: 与远程增强服务 id 冲突").format(name))

--- a/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
+++ b/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
@@ -146,7 +146,7 @@ class ServiceCreateSLZ(serializers.Serializer):
                 ).format(name)
             )
 
-        # 存在场景使用 service_name 来使用增强服务， 故禁止本地增强服务和远程增强服务重名
+        # 存在使用 service_name 来使用增强服务的场景， 故禁止本地增强服务和远程增强服务重名
         remote_svc_names = [e.get("name") for e in settings.SERVICE_REMOTE_ENDPOINTS]
         if name in remote_svc_names:
             raise ValidationError(_("{} 不符合规范: 与远程增强服务 id 冲突").format(name))

--- a/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
+++ b/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
@@ -149,7 +149,7 @@ class ServiceCreateSLZ(serializers.Serializer):
         #  创建 S-Mart 应用时，使用 service_name 来指定增强服务， 故禁止本地增强服务和远程增强服务重名
         remote_svc_names = [e.get("name") for e in settings.SERVICE_REMOTE_ENDPOINTS]
         if name in remote_svc_names:
-            raise ValidationError(_("{} 不符合规范: 与远程增强服务 id 冲突").format(name))
+            raise ValidationError(_("{} 不符合规范: 与远程增强服务 ID 冲突").format(name))
 
         return name
 

--- a/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
+++ b/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
@@ -16,6 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 import re
 
+from django.conf import settings
 from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 from drf_yasg.utils import swagger_serializer_method
@@ -144,6 +145,11 @@ class ServiceCreateSLZ(serializers.Serializer):
                     "{} 不符合规范: 由 3-32 位字母、数字、连接符(-)、下划线(_) 字符组成，以字母开头，字母或数字结尾"
                 ).format(name)
             )
+
+        # 存在场景使用 service_name 来使用增强服务， 故禁止本地增强服务和远程增强服务重名
+        remote_svc_names = [e.get("name") for e in settings.SERVICE_REMOTE_ENDPOINTS]
+        if name in remote_svc_names:
+            raise ValidationError(_("{} 不符合规范: 与远程增强服务 id 冲突").format(name))
 
         return name
 


### PR DESCRIPTION
存在使用 service_name 来使用增强服务的场景， 故禁止本地增强服务和远程增强服务重名