### PR TITLE
fix: 创建和更新本地增强服务时, 禁止存在和远程增强服务 name  相同的

### DIFF
--- a/apiserver/paasng/locale/en/LC_MESSAGES/django.po
+++ b/apiserver/paasng/locale/en/LC_MESSAGES/django.po
@@ -2350,9 +2350,9 @@ msgstr ""
 "letters, numbers, hyphens (-) or underscores (_), must start with a letter "
 "and end with a letter or number."
 
-#: paasng/plat_mgt/infras/services/serializers/services.py:152
-msgid "{} 不符合规范: 与远程增强服务 ID 冲突"
-msgstr "{} does not meet requirements: Conflicts with a remote service ID"
+#: paasng/plat_mgt/infras/services/serializers/services.py:151
+msgid "{} 不符合规范: 禁止存在相同的增强服务 ID"
+msgstr "{} dose not meet requirements: Duplicate Enhanced Service IDs are prohibited"
 
 #: paasng/plat_admin/admin42/utils/__init__.py:35
 #, python-brace-format

--- a/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
+++ b/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
@@ -16,7 +16,6 @@
 # to the current version of the project delivered to anyone in the future.
 import re
 
-from django.conf import settings
 from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 from drf_yasg.utils import swagger_serializer_method
@@ -26,6 +25,7 @@ from rest_framework.exceptions import ValidationError
 from paasng.accessories.servicehub.constants import ServiceType
 from paasng.accessories.servicehub.local.manager import LocalServiceObj
 from paasng.accessories.servicehub.remote.manager import RemoteServiceObj
+from paasng.accessories.servicehub.remote.store import get_remote_store
 from paasng.utils.i18n import to_translated_field
 
 # 增强服务名称规范
@@ -147,7 +147,7 @@ class ServiceCreateSLZ(serializers.Serializer):
             )
 
         #  创建 S-Mart 应用时，使用 service_name 来指定增强服务， 故禁止本地增强服务和远程增强服务重名
-        remote_svc_names = [e.get("name") for e in settings.SERVICE_REMOTE_ENDPOINTS]
+        remote_svc_names = [svc.get("name") for svc in get_remote_store().all()]
         if name in remote_svc_names:
             raise ValidationError(_("{} 不符合规范: 与远程增强服务 ID 冲突").format(name))
 

--- a/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
+++ b/apiserver/paasng/paasng/plat_mgt/infras/services/serializers/services.py
@@ -24,8 +24,8 @@ from rest_framework.exceptions import ValidationError
 
 from paasng.accessories.servicehub.constants import ServiceType
 from paasng.accessories.servicehub.local.manager import LocalServiceObj
+from paasng.accessories.servicehub.manager import mixed_service_mgr
 from paasng.accessories.servicehub.remote.manager import RemoteServiceObj
-from paasng.accessories.servicehub.remote.store import get_remote_store
 from paasng.utils.i18n import to_translated_field
 
 # 增强服务名称规范
@@ -147,9 +147,11 @@ class ServiceCreateSLZ(serializers.Serializer):
             )
 
         #  创建 S-Mart 应用时，使用 service_name 来指定增强服务， 故禁止本地增强服务和远程增强服务重名
-        remote_svc_names = [svc.get("name") for svc in get_remote_store().all()]
-        if name in remote_svc_names:
-            raise ValidationError(_("{} 不符合规范: 与远程增强服务 ID 冲突").format(name))
+        service_id_ctx = getattr(self.context.get("service"), "uuid")
+        for svc in mixed_service_mgr.list():
+            # 更新时，允许和自己重名
+            if svc.name == name and svc.uuid != service_id_ctx:
+                raise ValidationError(_("{} 不符合规范: 禁止存在相同的增强服务 ID").format(name))
 
         return name
 

--- a/apiserver/paasng/tests/paasng/plat_mgt/infras/services/test_serializers.py
+++ b/apiserver/paasng/tests/paasng/plat_mgt/infras/services/test_serializers.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+from dataclasses import dataclass
+from unittest import mock
+
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from paasng.accessories.servicehub.services import ServiceObj
+from paasng.plat_mgt.infras.services.serializers.services import ServiceCreateSLZ
+
+
+@dataclass
+class StubServiceObj(ServiceObj):
+    """用于测试的简单 ServiceObj 存根"""
+
+
+def _make_stub_service(uuid: str, name: str) -> StubServiceObj:
+    """创建一个用于测试的 ServiceObj 存根对象"""
+    return StubServiceObj(uuid=uuid, name=name, logo="", is_visible=True)
+
+
+class TestServiceCreateSLZValidateNameDuplication:
+    """测试 ServiceCreateSLZ.validate_name 中禁止增强服务重名的逻辑"""
+
+    @pytest.fixture()
+    def current_service(self) -> StubServiceObj:
+        """当前正在创建/更新的服务对象（放入 serializer context）"""
+        return _make_stub_service(uuid="aaaa-1111", name="my-svc")
+
+    @pytest.fixture()
+    def existing_services(self) -> list:
+        """模拟 mixed_service_mgr.list() 返回的已有服务列表"""
+        return [
+            _make_stub_service(uuid="bbbb-2222", name="mysql"),
+            _make_stub_service(uuid="cccc-3333", name="redis"),
+        ]
+
+    @pytest.fixture()
+    def _mock_list(self, existing_services):
+        """Mock mixed_service_mgr.list() 返回预设的已有服务列表"""
+        with mock.patch("paasng.plat_mgt.infras.services.serializers.services.mixed_service_mgr") as m:
+            m.list.return_value = existing_services
+            yield m
+
+    def _run_validate_name(self, current_service: StubServiceObj, name: str) -> str:
+        """构造 serializer 实例并调用 validate_name"""
+        slz = ServiceCreateSLZ(context={"service": current_service})
+        return slz.validate_name(name)
+
+    @pytest.mark.usefixtures("_mock_list")
+    def test_name_no_conflict(self, current_service):
+        """名称与已有服务均不冲突时，校验通过并返回原名称"""
+        result = self._run_validate_name(current_service, "new-svc")
+        assert result == "new-svc"
+
+    @pytest.mark.usefixtures("_mock_list")
+    def test_name_conflicts_with_existing_service(self, current_service):
+        """名称与另一个已有服务重名时，应抛出 ValidationError"""
+        with pytest.raises(ValidationError, match="禁止存在相同的增强服务"):
+            self._run_validate_name(current_service, "mysql")
+
+    @pytest.mark.usefixtures("_mock_list")
+    def test_update_allows_same_name_as_self(self, existing_services):
+        """更新时，允许与自身重名（UUID 相同）"""
+        # 使用已有服务列表中的第一个服务作为当前服务（模拟更新场景）
+        self_service = existing_services[0]
+        result = self._run_validate_name(self_service, self_service.name)
+        assert result == self_service.name


### PR DESCRIPTION
fix: 远程增强服务的 name 源找错了