### PR TITLE
chore:  修改 rabbitmq 的告警规则

### DIFF
--- a/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_connections_usage.yaml.j2
+++ b/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_connections_usage.yaml.j2
@@ -10,7 +10,7 @@ query:
   data_source: prometheus
   data_type: time_series
   query_configs:
-  - metric: 'sum({{ rabbitmq_metric_name_prefix }}rabbitmq_instance_connections{vhost="{{ metric_labels['vhost'] }}"}) / sum({{ rabbitmq_metric_name_prefix }}rabbitmq_instance_limits{vhost="{{ metric_labels['vhost'] }}"})'
+  - metric: 'sum({{ rabbitmq_metric_name_prefix }}:connections:rabbitmq_instance_connections{vhost="{{ metric_labels['vhost'] }}"}) / sum({{ rabbitmq_metric_name_prefix }}limits:rabbitmq_instance_limits{vhost="{{ metric_labels['vhost'] }}", resource="connection"})'
     interval: 60 # 单位 s
 
 detect: # 检测配置

--- a/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_connections_usage.yaml.j2
+++ b/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_connections_usage.yaml.j2
@@ -10,7 +10,7 @@ query:
   data_source: prometheus
   data_type: time_series
   query_configs:
-  - metric: 'sum({{ rabbitmq_metric_name_prefix }}:connections:rabbitmq_instance_connections{vhost="{{ metric_labels['vhost'] }}"}) / sum({{ rabbitmq_metric_name_prefix }}limits:rabbitmq_instance_limits{vhost="{{ metric_labels['vhost'] }}", resource="connection"})'
+  - metric: 'sum({{ rabbitmq_metric_name_prefix }}connections:rabbitmq_instance_connections{vhost="{{ metric_labels['vhost'] }}"}) / sum({{ rabbitmq_metric_name_prefix }}limits:rabbitmq_instance_limits{vhost="{{ metric_labels['vhost'] }}", resource="connection"})'
     interval: 60 # 单位 s
 
 detect: # 检测配置

--- a/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_dlx_queue_messages.yaml.j2
+++ b/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_dlx_queue_messages.yaml.j2
@@ -10,7 +10,7 @@ query:
   data_source: prometheus
   data_type: time_series
   query_configs:
-  - metric: 'sum({{ rabbitmq_metric_name_prefix }}rabbitmq_instance_dlx_queue_messages{vhost="{{ metric_labels['vhost'] }}"})'
+  - metric: 'sum({{ rabbitmq_metric_name_prefix }}group3:rabbitmq_instance_dlx_queue_messages{vhost="{{ metric_labels['vhost'] }}"})'
     interval: 60 # 单位 s
 
 detect: # 检测配置

--- a/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_queue_messages.yaml.j2
+++ b/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_queue_messages.yaml.j2
@@ -10,7 +10,7 @@ query:
   data_source: prometheus
   data_type: time_series
   query_configs:
-  - metric: 'sum({{ rabbitmq_metric_name_prefix }}rabbitmq_instance_queue_messages{vhost="{{ metric_labels['vhost'] }}"})'
+  - metric: 'sum({{ rabbitmq_metric_name_prefix }}group3:rabbitmq_instance_queue_messages{vhost="{{ metric_labels['vhost'] }}"})'
     interval: 60 # 单位 s
 
 detect: # 检测配置

--- a/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_queue_usage.yaml.j2
+++ b/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_queue_usage.yaml.j2
@@ -10,7 +10,7 @@ query:
   data_source: prometheus
   data_type: time_series
   query_configs:
-  - metric: 'sum({{ rabbitmq_metric_name_prefix }}rabbitmq_instance_queue_usage{vhost="{{ metric_labels['vhost'] }}"})'
+  - metric: 'sum({{ rabbitmq_metric_name_prefix }}group3:rabbitmq_instance_queue_usage{vhost="{{ metric_labels['vhost'] }}"})'
     interval: 60 # 单位 s
 
 detect: # 检测配置

--- a/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_queues_usage.yaml.j2
+++ b/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/high_rabbitmq_queues_usage.yaml.j2
@@ -10,7 +10,7 @@ query:
   data_source: prometheus
   data_type: time_series
   query_configs:
-  - metric: 'sum({{ rabbitmq_metric_name_prefix }}rabbitmq_instance_queues{vhost="{{ metric_labels['vhost'] }}"}) / sum({{ rabbitmq_metric_name_prefix }}rabbitmq_instance_limits{vhost="{{ metric_labels['vhost'] }}"})'
+  - metric: 'sum({{ rabbitmq_metric_name_prefix }}group3:rabbitmq_instance_queues{vhost="{{ metric_labels['vhost'] }}"}) / sum({{ rabbitmq_metric_name_prefix }}limits:rabbitmq_instance_limits{vhost="{{ metric_labels['vhost'] }}", resource="queue"})'
     interval: 60 # 单位 s
 
 detect: # 检测配置

--- a/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/rabbitmq_instance_down.yaml.j2
+++ b/apiserver/paasng/paasng/misc/monitoring/monitor/alert_rules/ascode/rules_tpl/rabbitmq_instance_down.yaml.j2
@@ -10,7 +10,7 @@ query:
   data_source: prometheus
   data_type: time_series
   query_configs:
-  - metric: 'avg({{ rabbitmq_metric_name_prefix }}rabbitmq_instance_alive{vhost="{{ metric_labels['vhost'] }}"})'
+  - metric: 'avg({{ rabbitmq_metric_name_prefix }}group3:rabbitmq_instance_alive{vhost="{{ metric_labels['vhost'] }}"})'
     interval: 60 # 单位 s
 
 detect: # 检测配置


### PR DESCRIPTION
在告警文件的配置中指定分组名，而非在配置项中