### PR TITLE
feat: 支持更灵活的 Agent Sandbox Router Endpoint 设置

### DIFF
--- a/apiserver/paasng/conf.yaml.tpl
+++ b/apiserver/paasng/conf.yaml.tpl
@@ -849,7 +849,8 @@ DEV_SANDBOX_CLUSTER: ""
 # Sandbox Router 验证 Token，用于 apiserver 与 router 之间的身份校验，不配置则不校验
 # AGENT_SANDBOX_ROUTER_AUTH_TOKEN: "your-secret-token"
 
-# Agent Sandbox Router 的 BaseURL，如果不配置则自动根据集群信息计算得到，注意要与 router 的 ingress 配置保持一致
+# Agent Sandbox Router 的 BaseURL，如果不配置则自动根据集群信息计算得到
+# 注意如果配置，则要与 Agent Sandbox Router 的 Ingress 配置保持一致
 # AGENT_SANDBOX_ROUTER_URL: ""
 
 # ---- Agent Sandbox 镜像仓库配置，业务镜像构建完成后推送到该仓库，例如 skill 镜像等 ----

--- a/apiserver/paasng/conf.yaml.tpl
+++ b/apiserver/paasng/conf.yaml.tpl
@@ -849,6 +849,9 @@ DEV_SANDBOX_CLUSTER: ""
 # Sandbox Router 验证 Token，用于 apiserver 与 router 之间的身份校验，不配置则不校验
 # AGENT_SANDBOX_ROUTER_AUTH_TOKEN: "your-secret-token"
 
+# Agent Sandbox Router 的 BaseURL，如果不配置则自动根据集群信息计算得到，注意要与 router 的 ingress 配置保持一致
+# AGENT_SANDBOX_ROUTER_URL: ""
+
 # ---- Agent Sandbox 镜像仓库配置，业务镜像构建完成后推送到该仓库，例如 skill 镜像等 ----
 
 # 镜像仓库的域名，默认值与 APP_DOCKER_REGISTRY_HOST 相同

--- a/apiserver/paasng/conf.yaml.tpl
+++ b/apiserver/paasng/conf.yaml.tpl
@@ -851,7 +851,7 @@ DEV_SANDBOX_CLUSTER: ""
 
 # Agent Sandbox Router 的 BaseURL，如果不配置则自动根据集群信息计算得到
 # 注意如果配置，则要与 Agent Sandbox Router 的 Ingress 配置保持一致
-# AGENT_SANDBOX_ROUTER_URL: ""
+# AGENT_SANDBOX_ROUTER_ENDPOINT: ""
 
 # ---- Agent Sandbox 镜像仓库配置，业务镜像构建完成后推送到该仓库，例如 skill 镜像等 ----
 

--- a/apiserver/paasng/conf.yaml.tpl
+++ b/apiserver/paasng/conf.yaml.tpl
@@ -849,7 +849,7 @@ DEV_SANDBOX_CLUSTER: ""
 # Sandbox Router 验证 Token，用于 apiserver 与 router 之间的身份校验，不配置则不校验
 # AGENT_SANDBOX_ROUTER_AUTH_TOKEN: "your-secret-token"
 
-# Agent Sandbox Router 的 BaseURL，如果不配置则自动根据集群信息计算得到
+# Agent Sandbox Router 的 Endpoint，如果不配置则自动根据集群信息计算得到
 # 注意如果配置，则要与 Agent Sandbox Router 的 Ingress 配置保持一致
 # AGENT_SANDBOX_ROUTER_ENDPOINT: ""
 

--- a/apiserver/paasng/paas_wl/bk_app/agent_sandbox/cluster.py
+++ b/apiserver/paasng/paas_wl/bk_app/agent_sandbox/cluster.py
@@ -32,7 +32,7 @@ def get_router_endpoint(cluster_name: str) -> str:
     to be exposed at:
     - If configure `AGENT_SANDBOX_ROUTER_URL`, return it directly
     - For SUBDOMAIN cluster type: `{prefix}.{default_root_domain}`
-    - For PATH cluster type: `{default_root_domain}/{prefix}`
+    - For SUBPATH cluster type: `{default_root_domain}/{prefix}`
 
     :param cluster_name: The name of the target cluster
     :returns: The router host string (e.g., "agent-sandbox-router.example.com"

--- a/apiserver/paasng/paas_wl/bk_app/agent_sandbox/cluster.py
+++ b/apiserver/paasng/paas_wl/bk_app/agent_sandbox/cluster.py
@@ -15,6 +15,8 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
+from django.conf import settings
+
 from paas_wl.infras.cluster.models import Cluster
 from paasng.platform.modules.constants import ExposedURLType
 
@@ -27,24 +29,32 @@ def get_router_endpoint(cluster_name: str) -> str:
     domain(first domain) update
 
     The endpoint is derived from the cluster's ingress_config: the router is expected
-    to be exposed at `{prefix}.{default_root_domain}`.
+    to be exposed at:
+    - If configure `AGENT_SANDBOX_ROUTER_URL`, return it directly
+    - For SUBDOMAIN cluster type: `{prefix}.{default_root_domain}`
+    - For PATH cluster type: `{default_root_domain}/{prefix}`
 
-    :param cluster_name: The name of the target cluster.
-    :returns: The router host string (e.g., "agent-sandbox-router.example.com").
-    :raises RuntimeError: If the cluster or its ingress config is missing.
+    :param cluster_name: The name of the target cluster
+    :returns: The router host string (e.g., "agent-sandbox-router.example.com"
+    or "example.com/agent-sandbox-router")
+    :raises RuntimeError: If the cluster or its ingress config is missing
     """
+    if settings.AGENT_SANDBOX_ROUTER_URL:
+        return settings.AGENT_SANDBOX_ROUTER_URL.rstrip("/")
+
     try:
         cluster = Cluster.objects.get(name=cluster_name)
     except Cluster.DoesNotExist:
         raise RuntimeError(f"cluster {cluster_name!r} not found")
 
-    # TODO 适配好集群域名为子路径的情况
     try:
-        root_domain = (
-            cluster.ingress_config.default_root_domain.name
-            if cluster.exposed_url_type == ExposedURLType.SUBDOMAIN
-            else cluster.ingress_config.default_sub_path_domain.name
-        )
+        if cluster.exposed_url_type == ExposedURLType.SUBDOMAIN:
+            root_domain = cluster.ingress_config.default_root_domain.name
+            router_endpoint = f"{AGENT_SANDBOX_ROUTER_SUBDOMAIN_PREFIX}.{root_domain}"
+        else:
+            root_domain = cluster.ingress_config.default_sub_path_domain.name
+            router_endpoint = f"{root_domain}/{AGENT_SANDBOX_ROUTER_SUBDOMAIN_PREFIX}"
     except IndexError:
         raise RuntimeError(f"cluster {cluster_name!r} has no ingress config")
-    return f"{AGENT_SANDBOX_ROUTER_SUBDOMAIN_PREFIX}.{root_domain}"
+
+    return router_endpoint

--- a/apiserver/paasng/paas_wl/bk_app/agent_sandbox/cluster.py
+++ b/apiserver/paasng/paas_wl/bk_app/agent_sandbox/cluster.py
@@ -30,7 +30,7 @@ def get_router_endpoint(cluster_name: str) -> str:
 
     The endpoint is derived from the cluster's ingress_config: the router is expected
     to be exposed at:
-    - If configure `AGENT_SANDBOX_ROUTER_URL`, return it directly
+    - If configure `AGENT_SANDBOX_ROUTER_ENDPOINT`, return it directly
     - For SUBDOMAIN cluster type: `{prefix}.{default_root_domain}`
     - For SUBPATH cluster type: `{default_root_domain}/{prefix}`
 
@@ -39,8 +39,8 @@ def get_router_endpoint(cluster_name: str) -> str:
     or "example.com/agent-sandbox-router")
     :raises RuntimeError: If the cluster or its ingress config is missing
     """
-    if settings.AGENT_SANDBOX_ROUTER_URL:
-        return settings.AGENT_SANDBOX_ROUTER_URL.rstrip("/")
+    if settings.AGENT_SANDBOX_ROUTER_ENDPOINT:
+        return settings.AGENT_SANDBOX_ROUTER_ENDPOINT.rstrip("/")
 
     try:
         cluster = Cluster.objects.get(name=cluster_name)

--- a/apiserver/paasng/paasng/settings/workloads.py
+++ b/apiserver/paasng/paasng/settings/workloads.py
@@ -113,6 +113,9 @@ DEV_SANDBOX_CLUSTER = settings.get("DEV_SANDBOX_CLUSTER", "")
 AGENT_SANDBOX_DEFAULT_IMAGE = settings.get("AGENT_SANDBOX_DEFAULT_IMAGE", "bkpaas/agent-sandbox:latest")
 # Sandbox Router 验证 Token，用于 apiserver 与 router 之间的身份校验，不配置则不校验
 AGENT_SANDBOX_ROUTER_AUTH_TOKEN = settings.get("AGENT_SANDBOX_ROUTER_AUTH_TOKEN", "")
+# Agent Sandbox Router 的 BaseURL，如果不配置则自动根据集群信息计算得到
+# 注意要与 agent sandbox router 的 ingress 配置保持一致
+AGENT_SANDBOX_ROUTER_URL = settings.get("AGENT_SANDBOX_ROUTER_URL")
 
 # ---------------
 # 资源命名配置

--- a/apiserver/paasng/paasng/settings/workloads.py
+++ b/apiserver/paasng/paasng/settings/workloads.py
@@ -114,7 +114,7 @@ AGENT_SANDBOX_DEFAULT_IMAGE = settings.get("AGENT_SANDBOX_DEFAULT_IMAGE", "bkpaa
 # Sandbox Router 验证 Token，用于 apiserver 与 router 之间的身份校验，不配置则不校验
 AGENT_SANDBOX_ROUTER_AUTH_TOKEN = settings.get("AGENT_SANDBOX_ROUTER_AUTH_TOKEN", "")
 # Agent Sandbox Router 的 BaseURL，如果不配置则自动根据集群信息计算得到
-# 注意要与 agent sandbox router 的 ingress 配置保持一致
+# 注意如果配置，则要与 Agent Sandbox Router 的 Ingress 配置保持一致
 AGENT_SANDBOX_ROUTER_URL = settings.get("AGENT_SANDBOX_ROUTER_URL")
 
 # ---------------

--- a/apiserver/paasng/paasng/settings/workloads.py
+++ b/apiserver/paasng/paasng/settings/workloads.py
@@ -113,9 +113,10 @@ DEV_SANDBOX_CLUSTER = settings.get("DEV_SANDBOX_CLUSTER", "")
 AGENT_SANDBOX_DEFAULT_IMAGE = settings.get("AGENT_SANDBOX_DEFAULT_IMAGE", "bkpaas/agent-sandbox:latest")
 # Sandbox Router 验证 Token，用于 apiserver 与 router 之间的身份校验，不配置则不校验
 AGENT_SANDBOX_ROUTER_AUTH_TOKEN = settings.get("AGENT_SANDBOX_ROUTER_AUTH_TOKEN", "")
-# Agent Sandbox Router 的 BaseURL，如果不配置则自动根据集群信息计算得到
-# 注意如果配置，则要与 Agent Sandbox Router 的 Ingress 配置保持一致
-AGENT_SANDBOX_ROUTER_URL = settings.get("AGENT_SANDBOX_ROUTER_URL")
+# Agent Sandbox Router 的 Endpoint，如果不配置则自动根据集群信息计算得到
+# 如果配置，则要与 Agent Sandbox Router 的 Ingress 配置保持一致
+# 示例:'agent-sandbox-router.example.com', 'example.com/agent-sandbox-router'
+AGENT_SANDBOX_ROUTER_ENDPOINT = settings.get("AGENT_SANDBOX_ROUTER_ENDPOINT")
 
 # ---------------
 # 资源命名配置

--- a/apiserver/paasng/tests/paas_wl/bk_app/agent_sandbox/test_cluster.py
+++ b/apiserver/paasng/tests/paas_wl/bk_app/agent_sandbox/test_cluster.py
@@ -16,6 +16,7 @@
 # to the current version of the project delivered to anyone in the future.
 
 import pytest
+from django.test import override_settings
 
 from paas_wl.bk_app.agent_sandbox.cluster import get_router_endpoint
 from tests.utils.cluster import CLUSTER_NAME_FOR_TESTING
@@ -31,6 +32,11 @@ class TestGetRouterEndpoint:
         endpoint = get_router_endpoint(CLUSTER_NAME_FOR_TESTING)
         assert endpoint.startswith("agent-sandbox-router.")
         assert "." in endpoint.split("agent-sandbox-router.")[1]
+
+    @override_settings(AGENT_SANDBOX_ROUTER_ENDPOINT="https://router.example.com/")
+    def test_returns_configured_endpoint(self):
+        """Test that configured endpoint takes precedence and strips trailing slash."""
+        assert get_router_endpoint("non-existent-cluster") == "https://router.example.com"
 
     def test_cluster_not_found(self):
         """Test that RuntimeError is raised for non-existent cluster."""


### PR DESCRIPTION
new: 
1. 对于子路径的集群，使用子路径形式的 endpoint：`example.com/agent-sandbox-router`
2. 可使用配置项 `AGENT_SANDBOX_ROUTER_ENDPOINT` 自定义指定 Agent Sandbox Router 的 Endpoint （该配置项暂无法支持多集群）
