### PR TITLE
fix: race conditaion for file read and write in multithreading

### DIFF
--- a/apiserver/paasng/paas_wl/infras/resources/base/kube_client.py
+++ b/apiserver/paasng/paas_wl/infras/resources/base/kube_client.py
@@ -16,6 +16,9 @@
 # to the current version of the project delivered to anyone in the future.
 
 import logging
+import os
+import tempfile
+import threading
 from collections import defaultdict
 from typing import Any, Dict
 
@@ -99,6 +102,9 @@ class CoreDynamicClient(DynamicClient):
     """为官方 SDK 里的 DynamicClient 追加新功能"""
 
     def __init__(self, client, cache_file=None, discoverer=None):
+        if cache_file is None:
+            name = f"osrcp-{threading.get_ident()}.json"
+            cache_file = os.path.join(tempfile.gettempdir(), name)
         super().__init__(client, cache_file, discoverer=discoverer or LazyDiscoverer)
 
     def serialize_body(self, body: Any) -> Dict[str, Any]:

--- a/apiserver/paasng/paas_wl/infras/resources/base/kube_client.py
+++ b/apiserver/paasng/paas_wl/infras/resources/base/kube_client.py
@@ -102,8 +102,9 @@ class CoreDynamicClient(DynamicClient):
     """为官方 SDK 里的 DynamicClient 追加新功能"""
 
     def __init__(self, client, cache_file=None, discoverer=None):
+        # safe cache_file read and write under multi-threading environment
         if cache_file is None:
-            name = f"osrcp-{threading.get_ident()}.json"
+            name = f"osrcp-{os.getpid()}-{threading.get_ident()}.json"
             cache_file = os.path.join(tempfile.gettempdir(), name)
         super().__init__(client, cache_file, discoverer=discoverer or LazyDiscoverer)
 


### PR DESCRIPTION
问题产生背景：多线程删除过期的 agent sandbox，经常打印错误日志，排查后发现原因在于 https://github.com/kubernetes-client/python/blob/master/kubernetes/base/dynamic/discovery.py#L69 
多个线程会同时尝试读/写一个缓存文件。

多线程删除过期 agent sandbox 必要性：删除一个沙箱的请求耗时约为 1s 左右，那么按照十分钟每次运行的话，容量上限仅在 600