### PR TITLE
fix: resource ip 字段拼写错误

### DIFF
--- a/apiserver/paasng/paasng/misc/tracing/setup.py
+++ b/apiserver/paasng/paasng/misc/tracing/setup.py
@@ -42,7 +42,7 @@ def setup_trace_config():
                 {
                     "service.name": settings.OTEL_SERVICE_NAME,
                     "bk.data.token": settings.OTEL_BK_DATA_TOKEN,
-                    "host_ip": host_ip,
+                    "net.host.ip": host_ip,
                 },
             ),
             sampler=_KNOWN_SAMPLERS[settings.OTEL_SAMPLER],  # type: ignore


### PR DESCRIPTION
修正 https://github.com/TencentBlueKing/blueking-paas/pull/2879 中对于 ip 字段名称设置错误