### PR TITLE
chore: update bk-apigateway config

### DIFF
--- a/apiserver/paasng/support-files/apigw/definition.yaml
+++ b/apiserver/paasng/support-files/apigw/definition.yaml
@@ -1,4 +1,4 @@
-spec_version: 1
+spec_version: 2
 
 apigateway:
   description: PaaS3.0 开发者中心 API 网关，包含应用信息查询、应用部署、增强服务、轻应用等 API。
@@ -18,17 +18,18 @@ release:
   comment: "Set as the official gateway, and add the get_service_instance_by_module API."
 
 
-stage:
-  name: "prod"
-  vars:
-    BKPAAS_SUB_PATH: "{{ environ.PAAS_BKPAAS_SUB_PATH }}"
-  proxy_http:
-    timeout: 30
-    upstreams:
-      loadbalance: "roundrobin"
-      hosts:
-        - host: "{{ environ.PAAS_BKPAAS_HOST }}"
-          weight: 100
+stages:
+  - name: "prod"
+    vars:
+      BKPAAS_SUB_PATH: "{{ environ.PAAS_BKPAAS_SUB_PATH }}"
+    backends:
+      - name: "default"
+        config:
+          timeout: 30
+          loadbalance: "roundrobin"
+          hosts:
+            - host: "{{ environ.PAAS_BKPAAS_HOST }}"
+              weight: 100
 
 grant_permissions:
   - bk_app_code: "{{ settings.BK_APP_CODE }}"

--- a/bkpkg-bkpaas3.yaml
+++ b/bkpkg-bkpaas3.yaml
@@ -18,5 +18,5 @@ relations:
   - bk_monitorv3^3.9.0
 - rationale: "注册资源到 API 网关"
   requires:
-  - bk-apigateway^1.20.0
+  - bk-apigateway^1.23.0
 bkimports:


### PR DESCRIPTION
1. 更新网关配置文件到 v2，根据 https://github.com/TencentBlueKing/bkpaas-python-sdk/blob/master/sdks/apigw-manager/docs/sync_apigateway.md
2. bk-apigateway 的依赖升级到 1.23.0