### PR TITLE
feat: SafePathField support unicode char

### DIFF
--- a/apiserver/paasng/paasng/utils/serializers.py
+++ b/apiserver/paasng/paasng/utils/serializers.py
@@ -332,9 +332,8 @@ class StringArrayField(fields.CharField):
 
 
 class SafePathField(serializers.RegexField):
-    """安全路径字段，只允许包含字母、数字、下划线、横线、点、斜杠，不允许绝对路径 & 路径逃逸（../）"""
+    """安全路径字段，只允许包含 Unicode字符（字母，汉字等）数字、下划线、横线、点、斜杠，不允许绝对路径 & 路径逃逸（../）"""
 
-    # \w: Unicode 字母，数字，下划线
     regex = re.compile(r"^[\w\-./]+$")
     default_error_messages = {
         "invalid": _("路径 {path} 不合法"),

--- a/apiserver/paasng/paasng/utils/serializers.py
+++ b/apiserver/paasng/paasng/utils/serializers.py
@@ -334,7 +334,8 @@ class StringArrayField(fields.CharField):
 class SafePathField(serializers.RegexField):
     """安全路径字段，只允许包含字母、数字、下划线、横线、点、斜杠，不允许绝对路径 & 路径逃逸（../）"""
 
-    regex = re.compile(r"^[a-zA-Z0-9_\-./]+$")
+    # \w: Unicode 字母，数字，下划线
+    regex = re.compile(r"^[\w\-./]+$")
     default_error_messages = {
         "invalid": _("路径 {path} 不合法"),
         "escape_risk": _("路径 {path} 存在逃逸风险"),

--- a/apiserver/paasng/tests/paasng/test_utils/test_serializers.py
+++ b/apiserver/paasng/tests/paasng/test_utils/test_serializers.py
@@ -135,6 +135,10 @@ class TestSafePathField:
             "foo/bar",
             "foo/bar/baz",
             "./foo/bar/baz",
+            # Unicode (e.g. Chinese) filenames are valid
+            "你好.md",
+            "日志/2026年/总结.md",
+            "こんにちは.md",
         ],
     )
     def test_valid(self, safe_path):
@@ -152,6 +156,10 @@ class TestSafePathField:
             "foo/%2e%2e/bar/baz",
             "foo/%2e%2e%2fbar/baz",
             "/safe////../etc/passwd",
+            # Unicode does not bypass the traversal checks
+            "你好/../bar",
+            "/你好/bar",
+            "こん..にちは.md",
         ],
     )
     def test_invalid(self, safe_path):

--- a/apiserver/paasng/tests/paasng/test_utils/test_serializers.py
+++ b/apiserver/paasng/tests/paasng/test_utils/test_serializers.py
@@ -160,6 +160,7 @@ class TestSafePathField:
             "你好/../bar",
             "/你好/bar",
             "こん..にちは.md",
+            "😄.txt",
         ],
     )
     def test_invalid(self, safe_path):


### PR DESCRIPTION
在原来的实现中，SafePathField 会校验中文字符失败，原因是使用的正则表达式为 `[a-zA-Z0-9_\-./]+`

改为 `[\w\-./]+`，以支持unicode 字符（不包括 emoji）作为路径