### PR TITLE
fix: bkrepo preview url

### DIFF
--- a/apiserver/paasng/paasng/platform/agent_sandbox/artifact.py
+++ b/apiserver/paasng/paasng/platform/agent_sandbox/artifact.py
@@ -22,13 +22,18 @@ URLs and tells the resident daemon to archive (daemon reads CFS, computes sha256
 directly to bkrepo). Downloads are served by the frontend hitting the signed bkrepo URL.
 """
 
+from urllib.parse import quote, urlencode
+
 from blue_krill.storages.blobstore.base import SignatureType
+from blue_krill.storages.blobstore.bkrepo import TIMEOUT_THRESHOLD, BKGenericRepo, safe_urljoin
+from blue_krill.storages.blobstore.exceptions import RequestError
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone
 
 from paasng.utils.blobstore import make_blob_store
 
-from .constants import UPLOAD_URL_EXPIRES_IN
+from .constants import PREVIEW_EXTRA_PARAM, PREVIEW_REPO_TYPE, PREVIEW_TOKEN_TYPE, UPLOAD_URL_EXPIRES_IN
 from .exceptions import SandboxFileNotFound
 from .models import Volume, VolumeArtifact
 from .resident_daemon_client import ResidentDaemonClient, get_resident_daemon_client
@@ -103,3 +108,65 @@ def build_download_url(artifact: VolumeArtifact, expires_in: int) -> str:
     return store.generate_presigned_url(
         key=artifact.bkrepo_key, expires_in=expires_in, signature_type=SignatureType.DOWNLOAD
     )
+
+
+def build_preview_url(artifact: VolumeArtifact, expires_in: int) -> str:
+    """Build a bkrepo web preview page URL for an archived object.
+
+    Unlike :func:`build_download_url`, this is *not* a presigned object URL — it points at
+    bkrepo's frontend preview route, which renders the file (images, PDF, ...) in a page:
+
+        {BK_REPO_URL}/ui/{project}/filePreview/local/0/{repo}/{key}?token={token}
+
+    The token must be created with type ``PREVIEW``; bkrepo's preview service rejects
+    ``DOWNLOAD`` tokens, so ``generate_presigned_url`` cannot be reused here.
+
+    :raises ImproperlyConfigured: When ``BK_REPO_URL`` is not configured, or the artifact
+        bucket is not backed by bkrepo (preview is a bkrepo-only capability).
+    """
+    if not settings.BK_REPO_URL:
+        raise ImproperlyConfigured('"BK_REPO_URL" is required to build bkrepo preview URLs')
+
+    store = make_blob_store(settings.AGENT_SANDBOX_ARTIFACT_BUCKET)
+    if not isinstance(store, BKGenericRepo):
+        raise ImproperlyConfigured(f"preview URL is only supported by bkrepo, not {type(store).__name__}")
+
+    token = create_preview_token(store, artifact.bkrepo_key, expires_in)
+    # key 内含用户可控的文件名，逐段转义；"/" 是路由分隔符，需保留
+    quoted_key = quote(artifact.bkrepo_key, safe="/")
+    return (
+        f"{settings.BK_REPO_URL.rstrip('/')}/ui/{store.project}/filePreview"
+        f"/{PREVIEW_REPO_TYPE}/{PREVIEW_EXTRA_PARAM}/{store.bucket}/{quoted_key}"
+        f"?{urlencode({'token': token})}"
+    )
+
+
+def create_preview_token(store: BKGenericRepo, key: str, expires_in: int) -> str:
+    """Create a bkrepo temporary token of type ``PREVIEW`` for a single object.
+
+    :param expires_in: Token lifetime in seconds; ``<= 0`` means never expires.
+    :raises RequestError: When bkrepo rejects the request or returns no token.
+    """
+    url = safe_urljoin(store.endpoint_url, "generic/temporary/token/create")
+    resp = store.get_client().post(
+        url,
+        json={
+            "projectId": store.project,
+            "repoName": store.bucket,
+            "fullPathSet": [f"/{key.lstrip('/')}"],
+            "expireSeconds": expires_in,
+            "type": PREVIEW_TOKEN_TYPE,
+        },
+        timeout=TIMEOUT_THRESHOLD,
+    )
+    try:
+        data = resp.json()
+    except ValueError as e:
+        raise RequestError(str(e), code="Unknown", response=resp) from e
+    if data.get("code") != 0:
+        raise RequestError(data.get("message"), code=str(data.get("code")), response=resp)
+
+    tokens = data.get("data") or []
+    if not tokens:
+        raise RequestError("bkrepo returned no preview token", code=str(data.get("code")), response=resp)
+    return tokens[0]["token"]

--- a/apiserver/paasng/paasng/platform/agent_sandbox/constants.py
+++ b/apiserver/paasng/paasng/platform/agent_sandbox/constants.py
@@ -44,3 +44,13 @@ DEFAULT_SANDBOX_MEMORY = Decimal(2)
 
 # 上传临时 URL 的有效期，给 daemon 读大文件 + PUT 留足余量
 UPLOAD_URL_EXPIRES_IN = 3600
+
+# bkrepo 临时 token 类型。预览页仅接受 PREVIEW 类型的 token（DOWNLOAD token 会被 bkrepo
+# preview 服务直接拒绝），因此不能复用签发下载 URL 的 generic/temporary/url/create
+PREVIEW_TOKEN_TYPE = "PREVIEW"
+
+# bkrepo 预览页路由 /ui/{project}/filePreview/{repoType}/{extraParam}/{repo}/{path}
+# 中的两个固定段：平台产物仓库均为本地仓库，repoType 取 local；extraParam 仅 remote 仓库
+# 需要传 base64 编码的源地址，本地仓库固定为 0
+PREVIEW_REPO_TYPE = "local"
+PREVIEW_EXTRA_PARAM = "0"

--- a/apiserver/paasng/paasng/platform/agent_sandbox/views.py
+++ b/apiserver/paasng/paasng/platform/agent_sandbox/views.py
@@ -36,7 +36,12 @@ from paasng.accessories.cloudapi_v2.apigateway.exceptions import ApiGatewayServi
 from paasng.infras.accounts.utils import ForceAllowAuthedApp
 from paasng.infras.sysapi_client.constants import ClientAction
 from paasng.infras.sysapi_client.roles import sysapi_client_perm_class
-from paasng.platform.agent_sandbox.artifact import archive_volume_file, build_download_url, delete_volume_artifact
+from paasng.platform.agent_sandbox.artifact import (
+    archive_volume_file,
+    build_download_url,
+    build_preview_url,
+    delete_volume_artifact,
+)
 from paasng.platform.agent_sandbox.exceptions import (
     SandboxAlreadyExists,
     SandboxArchiveFailed,
@@ -276,9 +281,10 @@ class VolumeFileViewSet(viewsets.GenericViewSet, ApplicationCodeInPathMixin):
     )
     @handle_volume_file_errors("build download url")
     def download_url(self, request, code, volume_id):
-        """归档到 bkrepo(按需)并签发下载/预览 URL,一次返回两个互斥 URL。
+        """归档到 bkrepo(按需)并签发下载 URL 与预览页 URL。
 
-        ``download_url`` 带 ``download=true``(attachment),``preview_url`` 带 ``preview=true``(inline)。
+        ``download_url`` 是直连对象存储的临时签名地址(带 ``download=true``, 浏览器另存为);
+        ``preview_url`` 指向 bkrepo 前端预览页, 由 bkrepo 渲染图片/PDF 等富类型文件。
         """
         volume = self._get_volume(volume_id)
         data = self._validate(VolumeFileDownloadURLInputSLZ, request.query_params)
@@ -288,7 +294,7 @@ class VolumeFileViewSet(viewsets.GenericViewSet, ApplicationCodeInPathMixin):
             base_url = build_download_url(artifact, expires_in=data["expires_in"])
             sep = "&" if urlparse(base_url).query else "?"
             download_url = f"{base_url}{sep}{urlencode({'download': 'true'})}"
-            preview_url = f"{base_url}{sep}{urlencode({'preview': 'true'})}"
+            preview_url = build_preview_url(artifact, expires_in=data["expires_in"])
         except SandboxFileTooLarge:
             raise error_codes.AGENT_SANDBOX_FILE_TOO_LARGE
         except SandboxArchiveFailed:


### PR DESCRIPTION
根据临时 token 拼接出 bkrepo 预览 url