### PR TITLE
fix(svc-bkrepo): 构造 BKGenericRepoManager 时补上实例 tenant_id

### DIFF
--- a/svc-bkrepo/svc_bk_repo/monitoring/jobs.py
+++ b/svc-bkrepo/svc_bk_repo/monitoring/jobs.py
@@ -33,7 +33,7 @@ def update_bkrepo_quota_statistics():
     """Update bkrepo quota statistics periodically"""
     logger.info("Starting update bkrepo quota.")
     for instance in ServiceInstance.objects.all():
-        manager = get_repo_manager(instance.plan_id)
+        manager = get_repo_manager(instance)
 
         credentials = instance.get_credentials()
         private_bucket = credentials["private_bucket"]

--- a/svc-bkrepo/svc_bk_repo/vendor/helper.py
+++ b/svc-bkrepo/svc_bk_repo/vendor/helper.py
@@ -23,7 +23,8 @@ from typing import Dict, List, Optional
 import curlify
 import requests
 from blue_krill.storages.blobstore.bkrepo import safe_urljoin
-from paas_service.models import Plan
+from paas_service.constants import DEFAULT_TENANT_ID
+from paas_service.models import Plan, ServiceInstance
 from requests.auth import HTTPBasicAuth
 
 from svc_bk_repo.vendor.exceptions import RequestError
@@ -165,10 +166,30 @@ class BKGenericRepoManager:
         _validate_resp(client.post(url, data={"quota": quota}))
 
 
+def resolve_instance_tenant_id(instance: ServiceInstance) -> str:
+    """解析实例访问 BKRepo 时应携带的租户 ID.
+
+    优先使用申请实例时写入 config 的 tenant_id（与 Provider 创建仓库时一致）；
+    老实例缺失该字段时回退到实例表字段，再回退到平台默认租户。
+    """
+    config = instance.config or {}
+    return config.get("tenant_id") or instance.tenant_id or DEFAULT_TENANT_ID
+
+
 @functools.lru_cache()
-def get_repo_manager(plan_id: str):
-    """根据 Plan ID 获取对应的 BKGenericRepoManager 实例"""
+def _get_repo_manager(plan_id: str, tenant_id: str) -> BKGenericRepoManager:
+    """根据 Plan ID 和租户 ID 获取 BKGenericRepoManager 实例."""
     plan = Plan.objects.get(pk=plan_id)
     plan_config = plan.get_config()
-    manager = BKGenericRepoManager(**plan_config)
-    return manager
+    return BKGenericRepoManager(
+        endpoint_url=plan_config["endpoint_url"],
+        username=plan_config["username"],
+        password=plan_config["password"],
+        project=plan_config["project"],
+        tenant_id=tenant_id,
+    )
+
+
+def get_repo_manager(instance: ServiceInstance) -> BKGenericRepoManager:
+    """根据增强服务实例获取对应的 BKGenericRepoManager."""
+    return _get_repo_manager(str(instance.plan_id), resolve_instance_tenant_id(instance))

--- a/svc-bkrepo/svc_bk_repo/vendor/jobs.py
+++ b/svc-bkrepo/svc_bk_repo/vendor/jobs.py
@@ -45,7 +45,7 @@ def auto_extend_bkrepo_quota():
 
         logger.info("Starting auto-extend bkrepo quota.")
         for instance in ServiceInstance.objects.all():
-            manager = get_repo_manager(instance.plan_id)
+            manager = get_repo_manager(instance)
             credentials = instance.get_credentials()
             private_bucket = credentials["private_bucket"]
             public_bucket = credentials["public_bucket"]

--- a/svc-bkrepo/svc_bk_repo/vendor/management/commands/extend_bkrepo_quota.py
+++ b/svc-bkrepo/svc_bk_repo/vendor/management/commands/extend_bkrepo_quota.py
@@ -22,7 +22,7 @@ from paas_service.models import ServiceInstance
 from paas_service.utils import get_paas_app_info
 
 from svc_bk_repo.vendor.actions import extend_quota
-from svc_bk_repo.vendor.helper import BKGenericRepoManager
+from svc_bk_repo.vendor.helper import get_repo_manager
 from svc_bk_repo.vendor.render import humanize_bytes
 
 
@@ -63,8 +63,7 @@ class Command(BaseCommand):
         except ServiceInstance.DoesNotExist:
             raise CommandError(f"ServiceInstance 不存在: {instance_id}")
 
-        plan_config = instance.plan.get_config()
-        manager = BKGenericRepoManager(**plan_config)
+        manager = get_repo_manager(instance)
 
         credentials = instance.get_credentials()
         if bucket_type == "private":

--- a/svc-bkrepo/svc_bk_repo/vendor/views.py
+++ b/svc-bkrepo/svc_bk_repo/vendor/views.py
@@ -32,7 +32,7 @@ from rest_framework.views import APIView
 
 from svc_bk_repo.vendor.actions import extend_quota
 from svc_bk_repo.vendor.exceptions import ExtendQuotaMaxSizeExceeded, ExtendQuotaUsageTooLow, NoNeedToExtendQuota
-from svc_bk_repo.vendor.helper import BKGenericRepoManager
+from svc_bk_repo.vendor.helper import get_repo_manager
 from svc_bk_repo.vendor.render import humanize_bytes
 from svc_bk_repo.vendor.serializers import ServiceInstanceForManageSLZ
 
@@ -59,8 +59,7 @@ class BKRepoIndexView(TemplateView):
     def get_context_data(self, **kwargs):
         instance = get_object_or_404(ServiceInstance, pk=self.kwargs["instance_id"])
 
-        plan_config = instance.plan.get_config()
-        manager = BKGenericRepoManager(**plan_config)
+        manager = get_repo_manager(instance)
 
         credentials = instance.get_credentials()
         private_bucket = credentials["private_bucket"]
@@ -96,8 +95,7 @@ class BKRepoManageView(APIView):
         """自助扩容"""
         instance = get_object_or_404(ServiceInstance, uuid=instance_id)
 
-        plan_config = instance.plan.get_config()
-        manager = BKGenericRepoManager(**plan_config)
+        manager = get_repo_manager(instance)
 
         credentials = instance.get_credentials()
         private_bucket = credentials["private_bucket"]


### PR DESCRIPTION
Why:
多租户改造后 BKGenericRepoManager 必须带 tenant_id（X-Bk-Tenant-Id）， 但配额采集等路径仍用 Plan 配置 unpack 构造。Plan 里没有该字段，
定时任务 TypeError，RepoQuotaStatistics 停更。

How:
从实例 config.tenant_id 解析租户（缺失则回退实例表字段 / default），
配额采集、自动扩容、管理页、扩容命令统一走 get_repo_manager(instance)。

多租户改造pr：https://github.com/TencentBlueKing/blueking-paas/pull/2789/changes#diff-48509b791a738dce3c3627224601628c1b719ab3110d55f8b9d65b068f19b770R65