### PR TITLE
fix: sanitize Redis instance namespace to DNS-1123 Subdomain Rules

### DIFF
--- a/svc-redis/svc_redis/vendor/provider.py
+++ b/svc-redis/svc_redis/vendor/provider.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import Dict
 
 from paas_service.base_vendor import BaseProvider, InstanceData
+from utils.text import to_dns_safe
 
 from svc_redis.controller.controllers import RedisInstanceController
 from svc_redis.controller.entities import RedisInstanceCredential, RedisPlanConfig
@@ -77,10 +78,9 @@ class Provider(BaseProvider):
         """
         logger.info("Creating service instance...")
 
-        # 创建唯一的 namespace
-        preferred_name = str(params.get("engine_app_name"))
+        # engine_app_name 可能含下划线等非法字符，先转成 DNS-1123 再生成 namespace
+        preferred_name = to_dns_safe(str(params.get("engine_app_name") or "app"))
         uid = gen_unique_id(preferred_name)
-        # 为了 namespace 更具可读性，添加前缀
         namespace = f"svc-redis-{uid}"
 
         try:

--- a/svc-redis/tests/test_utils.py
+++ b/svc-redis/tests/test_utils.py
@@ -17,20 +17,21 @@
 
 import re
 
-# This pattern is widely used by kubernetes
-DNS_SAFE_PATTERN = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-
-# Same replacement as WlApp.namespace — keep underscore distinguishable from hyphen
-_UNDERSCORE_REPLACEMENT = "0us0"
+import pytest
+from utils.text import DNS_SAFE_PATTERN, to_dns_safe
 
 
-def to_dns_safe(name: str) -> str:
-    """Turn an arbitrary string into a Kubernetes DNS-1123 label.
-
-    Underscores follow the platform convention (``_`` -> ``0us0``) used by
-    application namespaces. Other illegal characters become ``-``.
-    """
-    sanitized = name.lower().replace("_", _UNDERSCORE_REPLACEMENT)
-    sanitized = re.sub(r"[^a-z0-9-]+", "-", sanitized)
-    sanitized = re.sub(r"-{2,}", "-", sanitized).strip("-")
-    return sanitized or "ns"
+class TestToDnsSafe:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("bkapp-cloud_stone-m-console-backend-prod", "bkapp-cloud0us0stone-m-console-backend-prod"),
+            ("bkapp-foo-stag", "bkapp-foo-stag"),
+            ("BkApp-Foo_Bar", "bkapp-foo0us0bar"),
+            ("---", "ns"),
+            ("@@@", "ns"),
+        ],
+    )
+    def test_sanitize(self, raw, expected):
+        assert to_dns_safe(raw) == expected
+        assert re.fullmatch(DNS_SAFE_PATTERN, to_dns_safe(raw))


### PR DESCRIPTION
Why:
engine_app_name 可能含下划线（如 bkapp-cloud_stone-...）。原先原样截断后拼成 svc-redis-<uid>，K8s Namespace 不接受 `_`，创建时被 API 以 422 拒绝，用户只看到 CreateRedisFailed: Resource allocation failed。

How:
生成 namespace 前按平台惯例把 `_` 换成 `0us0`，并清掉其余非法字符，保证名称符合 DNS-1123。Redis CRD 名是固定的 svc-redis，不受影响。