### PR TITLE
fix: codecc 灰度阶段详情渲染报错，首页发布进度与版本列表对齐

### DIFF
--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/bk_devops/definitions.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/bk_devops/definitions.py
@@ -104,7 +104,7 @@ class PipelineBuildStatus(BaseModel):
     """
 
     buildId: str = Field(alias="id")
-    startTime: int
+    startTime: Optional[int] = None
     endTime: Optional[int]
     status: str
     currentTimestamp: str
@@ -244,7 +244,7 @@ class PipelineBuildDetail(BaseModel):
     buildId: str = Field(alias="id")
     pipelineId: str
     pipelineName: str
-    startTime: int
+    startTime: Optional[int] = None
     endTime: Optional[int]
     status: str
     currentTimestamp: str

--- a/apiserver/paasng/paasng/bk_plugins/pluginscenter/releases/stages.py
+++ b/apiserver/paasng/paasng/bk_plugins/pluginscenter/releases/stages.py
@@ -215,6 +215,35 @@ class ItsmStage(BaseStageController):
         }
 
 
+class CanaryWithItsmStage(BaseStageController):
+    """带审批的灰度发布。仅补齐阶段详情渲染，不介入创建/重试/重置。
+
+    审批单据挂在发布策略上，不在 stage.itsm_detail。新建版本仍由
+    PluginReleaseExecutor.execute_gray_release 提单。
+    """
+
+    invoke_method = constants.ReleaseStageInvokeMethod.CANARY_WITH_ITSM
+
+    def execute(self, operator: str):
+        raise error_codes.EXECUTE_STAGE_ERROR.f(_("灰度发布请通过发布策略提单，不能按普通步骤重试"))
+
+    def render_to_view(self) -> Dict:
+        basic_info = super().render_to_view()
+        strategy = self.release.latest_release_strategy
+        if not strategy or not strategy.itsm_detail:
+            return {**basic_info, "detail": {}}
+
+        ticket_info = get_ticket_status(strategy.itsm_detail.sn)
+        ticket_info["fields"] = strategy.itsm_detail.fields
+        detail = ItsmTicketInfoSlz(ticket_info).data
+        # 单据号在策略上，不改 ItsmTicketInfoSlz，避免影响普通 itsm 步骤响应
+        detail["sn"] = strategy.itsm_detail.sn
+        return {
+            **basic_info,
+            "detail": detail,
+        }
+
+
 class PipelineStage(BaseStageController):
     invoke_method = constants.ReleaseStageInvokeMethod.PIPELINE
 

--- a/apiserver/paasng/paasng/infras/bk_ci/entities.py
+++ b/apiserver/paasng/paasng/infras/bk_ci/entities.py
@@ -104,7 +104,7 @@ class PipelineBuildStatus(BaseModel):
     """
 
     buildId: str = Field(alias="id")
-    startTime: int
+    startTime: Optional[int] = None
     endTime: Optional[int]
     status: str
     currentTimestamp: str
@@ -229,7 +229,7 @@ class PipelineBuildDetail(BaseModel):
     buildId: str = Field(alias="id")
     pipelineId: str
     pipelineName: str
-    startTime: int
+    startTime: Optional[int] = None
     endTime: Optional[int]
     status: str
     currentTimestamp: str

--- a/apiserver/paasng/tests/paasng/bk_plugins/pluginscenter/release/test_stages.py
+++ b/apiserver/paasng/tests/paasng/bk_plugins/pluginscenter/release/test_stages.py
@@ -15,11 +15,23 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
-import pytest
+from unittest import mock
 
-from paasng.bk_plugins.pluginscenter.constants import ReleaseStageInvokeMethod
+import pytest
+from blue_krill.web.std_error import APIError
+from django_dynamic_fixture import G
+
+from paasng.bk_plugins.pluginscenter.constants import PluginReleaseStatus, ReleaseStageInvokeMethod
 from paasng.bk_plugins.pluginscenter.definitions import find_stage_by_id
-from paasng.bk_plugins.pluginscenter.releases.stages import PipelineStage
+from paasng.bk_plugins.pluginscenter.exceptions import error_codes
+from paasng.bk_plugins.pluginscenter.models import PluginRelease, PluginReleaseStrategy
+from paasng.bk_plugins.pluginscenter.models.instances import ItsmDetail
+from paasng.bk_plugins.pluginscenter.releases.stages import (
+    BaseStageController,
+    CanaryWithItsmStage,
+    PipelineStage,
+    init_stage_controller,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -70,3 +82,83 @@ class TestPipelineStage:
         stage_definition = find_stage_by_id(pd, release, current_stage.stage_id)  # type: ignore
         assert stage_definition
         assert stage_ctl.build_pipeline_params(stage_definition) == expected
+
+
+class TestCanaryWithItsmStage:
+    @pytest.fixture()
+    def gray_release(self, pd, plugin) -> PluginRelease:
+        """灰度发布阶段：invoke_method 为 canaryWithItsm。"""
+        pd.release_stages = [
+            {
+                "id": "gray",
+                "name": "带审批的灰度发布",
+                "invokeMethod": ReleaseStageInvokeMethod.CANARY_WITH_ITSM,
+            },
+        ]
+        pd.save()
+        pd.refresh_from_db()
+
+        release: PluginRelease = G(
+            PluginRelease,
+            plugin=plugin,
+            source_location=plugin.repository,
+            type="prod",
+            source_version_type="branch",
+            source_version_name="master",
+            version="0.0.2",
+            comment="",
+        )
+        release.initial_stage_set(force_refresh=True)
+        return release
+
+    @pytest.fixture()
+    def stage(self, gray_release):
+        return gray_release.all_stages.get(stage_id="gray")
+
+    def test_get_stage_class(self):
+        assert BaseStageController.get_stage_class(ReleaseStageInvokeMethod.CANARY_WITH_ITSM) is CanaryWithItsmStage
+        assert BaseStageController.get_stage_class("canaryWithItsm") is CanaryWithItsmStage
+
+    def test_init_stage_controller(self, stage):
+        controller = init_stage_controller(stage)
+        assert isinstance(controller, CanaryWithItsmStage)
+
+    def test_render_to_view_without_ticket(self, stage):
+        stage_info = CanaryWithItsmStage(stage).render_to_view()
+        assert stage_info["stage_id"] == "gray"
+        assert stage_info["invoke_method"] == ReleaseStageInvokeMethod.CANARY_WITH_ITSM
+        assert stage_info["detail"] == {}
+
+    def test_render_to_view_with_ticket(self, stage, gray_release):
+        PluginReleaseStrategy.objects.create(
+            release=gray_release,
+            strategy="gray",
+            itsm_detail=ItsmDetail(
+                sn="sn-gray-1",
+                fields=[{"key": "title", "value": "灰度发布审批"}],
+                ticket_url="https://itsm.example.com/ticket/1",
+            ),
+        )
+        ticket_status = {
+            "ticket_url": "https://itsm.example.com/ticket/1",
+            "current_status": "RUNNING",
+            "current_status_display": "处理中",
+            "can_withdraw": True,
+        }
+        with mock.patch(
+            "paasng.bk_plugins.pluginscenter.releases.stages.get_ticket_status",
+            return_value=ticket_status,
+        ):
+            stage_info = CanaryWithItsmStage(stage).render_to_view()
+
+        assert stage_info["detail"]["ticket_url"] == "https://itsm.example.com/ticket/1"
+        assert stage_info["detail"]["can_withdraw"] is True
+        assert stage_info["detail"]["fields"] == [{"key": "title", "value": "灰度发布审批"}]
+        assert stage_info["detail"]["sn"] == "sn-gray-1"
+
+    def test_execute_raises(self, stage):
+        with pytest.raises(APIError) as exc:
+            CanaryWithItsmStage(stage).execute("admin")
+        assert exc.value.code == error_codes.EXECUTE_STAGE_ERROR.code
+        stage.refresh_from_db()
+        assert stage.status == PluginReleaseStatus.INITIAL

--- a/webfe/package_vue/src/common/constants.js
+++ b/webfe/package_vue/src/common/constants.js
@@ -251,6 +251,7 @@ export const PLUGIN_VERSION_MAP = {
   deployAPI: 'deploy',
   subpage: 'test',
   itsm: 'itsm',
+  canaryWithItsm: 'itsm',
 };
 
 /**

--- a/webfe/package_vue/src/views/plugin-center/index.vue
+++ b/webfe/package_vue/src/views/plugin-center/index.vue
@@ -435,11 +435,25 @@ export default {
 
     toNewVersion(data) {
       if (data.ongoing_release && this.releaseStatusMap[data.ongoing_release.status]) {
+        // Codecc 正式版（从已测版本发布）与版本列表「详情」一致，进 version-details
+        const release = data.ongoing_release;
+        const isCodeccOfficialRelease =
+          data.has_test_version && release.type === 'prod' && release.source_version_type === 'tested_version';
+        if (isCodeccOfficialRelease) {
+          this.$router.push({
+            name: 'pluginReleaseDetails',
+            params: { pluginTypeId: data.pd_id, id: data.id },
+            query: {
+              versionId: release.id,
+            },
+          });
+          return;
+        }
         this.$router.push({
           name: 'pluginVersionRelease',
           params: { pluginTypeId: data.pd_id, id: data.id },
           query: {
-            release_id: data.ongoing_release.id,
+            release_id: release.id,
           },
         });
       } else {


### PR DESCRIPTION
- canaryWithItsm 补阶段控制器，仅用于 stages/gray 查询
- 首页进行中的 Codecc 正式版跳转 Codecc 插件专有的正式发布页面
- 蓝盾 v4 构建详情、构建状态偶发不返回 startTime，将 PipelineBuildDetail 与 PipelineBuildStatus 的该字段改为可选，避免结构化失败