### PR TITLE
feat: add credential masking and structured logging --story=137664839

### DIFF
--- a/app-spark/agent/Dockerfile
+++ b/app-spark/agent/Dockerfile
@@ -21,15 +21,15 @@ ADD ./uv.lock .
 ADD ./README.md .
 ADD ./app_spark_agent ./app_spark_agent
 
-# Frozen runtime deps; workspace and state must be distinct paths
+# Frozen runtime deps; workspace and state must be distinct paths under /data
 RUN uv sync --frozen --no-dev \
-    && mkdir -p /workspace /state
+    && mkdir -p /data/workspace /data/state
 
 ENV PATH="/app/.venv/bin:${PATH}"
 # Listen on 8090; fall back to these paths when APP_SPARK_AGENT_* is unset
 ENV APP_SPARK_AGENT_PORT=8090
-ENV APP_SPARK_AGENT_WORKSPACE=/workspace
-ENV APP_SPARK_AGENT_STATE_DIR=/state
+ENV APP_SPARK_AGENT_WORKSPACE=/data/workspace
+ENV APP_SPARK_AGENT_STATE_DIR=/data/state
 
 EXPOSE 8090
 

--- a/app-spark/agent/README.md
+++ b/app-spark/agent/README.md
@@ -18,15 +18,25 @@ uv sync
 
 文档只用占位符，不要填真实密钥。
 
+`APP_SPARK_AGENT_*` 由接入层创建沙箱时注入，只从进程环境读取（不读配置文件）；键名与端口数值已锁定。
+
 | 变量 | 必需 | 说明 |
 |------|------|------|
-| `APP_SPARK_AGENT_RUNTIME_TOKEN` | 是 | `GET /health` 的 query `token`，以及 `POST /runs` / 控制面接口的 Bearer |
+| `APP_SPARK_AGENT_RUNTIME_TOKEN` | 是 | 所有 HTTP 接口的 Bearer（含 `GET /health`、`POST /runs`、控制面） |
 | `APP_SPARK_AGENT_MODEL_API_KEY` | 调用 `/runs` 时是 | 模型密钥。缺失则 `model_ready=false`，`POST /runs` 返回 503 |
+| `APP_SPARK_AGENT_MODEL_NAME` | 是 | 不带 vendor 前缀。当前只读入，尚未用于构造模型客户端 |
+| `APP_SPARK_AGENT_MODEL_BASE_URL` | 是 | 自研网关 OpenAI 兼容入口。同上，当前只读入 |
+| `APP_SPARK_AGENT_APP_PORT` | 是 | 用户应用约定端口，锁定 `8000`；本组件只读入，不拉起应用也不校验 |
 | `APP_SPARK_AGENT_PORT` | 否 | 监听端口，缺省 `8090` |
 | `APP_SPARK_AGENT_IDLE_TIMEOUT_SECONDS` | 否 | 空闲秒数，从进程启动起算，每次 `POST /runs` 结束后重置；从未收到 `/runs` 也会到期退出。缺省 `1800`，到期以退出码 0 退出。`GET /health` 不续命。`<= 0` 关闭空闲退出 |
-| `APP_SPARK_AGENT_WORKSPACE` | 本地是；容器缺省 `/workspace` | Agent 工具可见目录 |
-| `APP_SPARK_AGENT_STATE_DIR` | 本地是；容器缺省 `/state` | 必须在 workspace 外 |
+| `APP_SPARK_AGENT_SESSION_ID` | 否 | 只进日志与指标 |
+| `APP_SPARK_AGENT_TENANT_ID` | 否 | 只进日志与指标，不做业务分支 |
+| `APP_SPARK_AGENT_WORKSPACE` | 本地是；容器缺省 `/data/workspace` | Agent 工具可见目录 |
+| `APP_SPARK_AGENT_STATE_DIR` | 本地是；容器缺省 `/data/state` | 必须在 workspace 外 |
 | `APP_SPARK_AGENT_MODEL` | 否 | 缺省 `deepseek:deepseek-v4-flash` |
+
+模型凭据取值顺序：`APP_SPARK_AGENT_MODEL_API_KEY` → provider 自有环境变量。
+只注入契约键即可启动并调通。
 
 示例：
 
@@ -38,20 +48,21 @@ export APP_SPARK_AGENT_STATE_DIR=/tmp/app-spark-state
 make run
 ```
 
-其余压缩策略、游标 limit 等配置见 `app_spark_agent/settings.py`（`APP_SPARK_AGENT_*`）。
+其余压缩策略、游标 limit 等配置见 `app_spark_agent/settings.py`（`APP_SPARK_AGENT_*`，`.env` 也会自动读取）。
 
 ## 调用 HTTP
 
-`GET /health` 必须带 query token，缺或错误返回 401，且不返回状态字段：
+`GET /health` 必须带 Bearer，缺或错误返回 401，且不返回状态字段：
 
 ```bash
-curl -sS "http://127.0.0.1:8090/health?token=${APP_SPARK_AGENT_RUNTIME_TOKEN}"
+curl -sS -H "Authorization: Bearer ${APP_SPARK_AGENT_RUNTIME_TOKEN}" \
+  http://127.0.0.1:8090/health
 ```
 
 成功时 JSON 含锁定四字段 `version`、`model_ready`、`running`、`app_status`，以及会话游标
-`conversation_id`、`context_version`、`log_seq`、`ui_event_seq`。kube / 接入层探针使用同一 URL。
+`conversation_id`、`context_version`、`log_seq`、`ui_event_seq`。kube 探针用同一接口，走 `httpHeaders`。
 
-`POST /runs` 为 AG-UI over SSE，必须 `Authorization: Bearer <APP_SPARK_AGENT_RUNTIME_TOKEN>`：
+`POST /runs` 为 AG-UI over SSE，同样必须 `Authorization: Bearer <APP_SPARK_AGENT_RUNTIME_TOKEN>`：
 
 ```bash
 curl -sS -N -H "Authorization: Bearer ${APP_SPARK_AGENT_RUNTIME_TOKEN}" \
@@ -81,15 +92,39 @@ curl -sS -N -H "Authorization: Bearer ${APP_SPARK_AGENT_RUNTIME_TOKEN}" \
 
 `/log`、`/ui-events`、`GET/PUT /context` 同样需要 Bearer，供控制面读取或迁移会话状态。
 
+## 凭据屏蔽
+
+两层。第二层存在的理由是**第一层静默失效**：新增一个密钥键却忘了登记、或 harness 升级改了名单语义，
+测试全绿、功能正常，密钥却已经进了模型能读的环境。
+
+**一、密钥不进子进程**：harness `Shell` 从继承环境里剥掉 `APP_SPARK_AGENT_*` 及各 provider 密钥变量（`agent.py`）。
+
+**二、出站文本脱敏**（`masking.py`），匹配值而非键名，多个密钥按长度降序替换：
+
+| 出口 | 实现位置 |
+|---|---|
+| AG-UI **落盘**事件 | `ui_events.py` |
+| HTTP 错误响应体（401 / 409 / 422 / 503 及异常文本） | `server/errors.py` |
+| 进程日志（含 uvicorn） | `observability.py` |
+
+**实时 SSE 不脱敏**，是有意的：逐 delta 匹配要在每个 token 上跑，而它要防的值只有在第一层已经失效时才可能出现；
+且模型把密钥切成两个 chunk 时它照样漏。落盘副本按消息合并后才脱敏，拿到的是完整字符串，且它才是审计要看的那份。
+客户端在自己的流里看到凭据，本来就是个已经持有凭据的客户端。
+
+第二层是**兜底而非控制措施**，两条限制得清楚：只匹配精确的配置值（变形过的——重编码、截断、拆分——一律穿过）；
+只匹配值不匹配键名（否则 `APP_SPARK_AGENT_MODEL_API_KEY` 这种名字在日志里就没法读了）。
+
+日志每条带 `session_id` / `tenant_id`（缺省 `-`），`POST /runs` 在开始和流结束各打一条。
+
 ## 会话状态
 
 会话状态按「怎么变」分成三类，都由 `app_spark_agent/state/` 下的类型实现：
 
-| 数据 | 文件 | 形态 | 实现类型 | 单测 |
-| --- | --- | --- | --- | --- |
-| 原始对话记录 | `log.jsonl` | append-only，`seq` 连续递增 | `AppendLog` / `LogRecord`（`state/log.py`） | `tests/state/test_log.py` |
-| AG-UI 事件历史 | `ui_events.jsonl` | append-only，`seq` 连续递增 | `AppendLog`（同上） | `tests/state/test_log.py` |
-| 会话上下文 | `context.json` | 可变 blob，原子整体替换，带 `context_version` | `ContextStore` / `ConversationContext`（`state/context.py`） | `tests/state/test_context.py` |
+| 数据         | 文件                | 形态                                 | 实现类型                                                       | 单测                            |
+|------------|-------------------|------------------------------------|------------------------------------------------------------|-------------------------------|
+| 原始对话记录     | `log.jsonl`       | append-only，`seq` 连续递增             | `AppendLog` / `LogRecord`（`state/log.py`）                  | `tests/state/test_log.py`     |
+| AG-UI 事件历史 | `ui_events.jsonl` | append-only，`seq` 连续递增             | `AppendLog`（同上）                                            | `tests/state/test_log.py`     |
+| 会话上下文      | `context.json`    | 可变 blob，原子整体替换，带 `context_version` | `ContextStore` / `ConversationContext`（`state/context.py`） | `tests/state/test_context.py` |
 
 关键点：
 
@@ -110,7 +145,8 @@ docker run --rm -p 8090:8090 \
   app-spark-agent:dev
 ```
 
-入口为 tini（PID 1）。`make docker-build` 使用 `--load` 写入本地 daemon。镜像内 workspace / state 锁定为 `/workspace` 与 `/state`，二者必须是独立路径，文件工具只能看见 `/workspace`。
+入口为 tini（PID 1）。`make docker-build` 使用 `--load` 写入本地 daemon。镜像内 workspace / state 锁定为 `/data/workspace` 与
+`/data/state`，二者必须是独立路径，文件工具只能看见 `/data/workspace`。
 
 ## 开发指南
 

--- a/app-spark/agent/app_spark_agent/__main__.py
+++ b/app-spark/agent/app_spark_agent/__main__.py
@@ -1,15 +1,15 @@
 """Bind the Agent HTTP server to 0.0.0.0."""
 
-from __future__ import annotations
-
 import uvicorn
 
 from app_spark_agent import settings
+from app_spark_agent.observability import configure_logging
 from app_spark_agent.server.app import create_app_from_settings
 
 
 def main() -> None:
     """Start uvicorn on ``0.0.0.0:<APP_SPARK_AGENT_PORT>``."""
+    configure_logging()
     # Default drain wait is unbounded; an in-flight SSE would hold SIGTERM until the
     # run ends and might persist that turn as success. A short timeout drops the
     # connection, then lifespan calls stop_all. A cancelled run skips on_complete.
@@ -18,6 +18,9 @@ def main() -> None:
         host="0.0.0.0",
         port=settings.PORT,
         timeout_graceful_shutdown=settings.GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS,
+        # Uvicorn would otherwise install its own handlers on the loggers
+        # `configure_logging` just pointed at the root, restoring unmasked output.
+        log_config=None,
     )
 
 

--- a/app-spark/agent/app_spark_agent/agent.py
+++ b/app-spark/agent/app_spark_agent/agent.py
@@ -37,6 +37,7 @@ def build_model() -> Model:
         if settings.MODEL_API_KEY is None:
             # No configured key: fall back to whatever variable the provider reads itself.
             return provider_class()
+
         return cast(ApiKeyProvider, provider_class)(api_key=settings.MODEL_API_KEY)
 
     return infer_model(settings.MODEL, provider_factory=provider_factory)

--- a/app-spark/agent/app_spark_agent/masking.py
+++ b/app-spark/agent/app_spark_agent/masking.py
@@ -1,0 +1,93 @@
+"""Replace injected credential values on the way out of the process.
+
+The Shell capability strips credentials from the environment the model's subprocesses inherit,
+so under normal operation nothing here has anything to mask. What makes a second layer worth
+having is that the first one fails *silently*: add a credential key without listing it, or take
+a harness upgrade that changes how the list is applied, and every test still passes while the
+model can read the value. This is what would notice.
+
+Applied to the durable, searchable surfaces -- the persisted AG-UI events, HTTP error bodies,
+and the process log. Deliberately not to the live event stream; see
+:mod:`app_spark_agent.ui_events`.
+
+Two limits worth knowing before treating this as a control rather than a backstop:
+
+- Only exact configured values match. A credential that has been transformed on the way out --
+  re-encoded, truncated, or split across two strings -- passes through untouched.
+- Values, not names. Masking ``APP_SPARK_AGENT_MODEL_API_KEY`` as a string would make the settings table
+  and every log line about it unreadable while protecting nothing.
+"""
+
+from functools import lru_cache
+from typing import Any, cast
+
+from app_spark_agent import settings
+
+SECRET_PLACEHOLDER = "***"
+
+
+@lru_cache(maxsize=8)
+def _ordered(configured: tuple[str | None, ...]) -> tuple[str, ...]:
+    """Return the non-empty values of ``configured``, longest first.
+
+    Ordering matters when one credential contains another -- masking the shorter one first
+    would leave the remainder of the longer one in the output, which reads as a partial leak.
+
+    Cached on the values themselves rather than on nothing, so :func:`secret_values` can keep
+    reading the settings on every call without repeating the sort. A handful of entries is
+    enough for one process; the extra slots absorb tests that patch the credentials.
+    """
+    return tuple(sorted({value for value in configured if value}, key=len, reverse=True))
+
+
+def secret_values() -> tuple[str, ...]:
+    """Return the configured credential values, longest first.
+
+    The settings are read on call rather than captured at import: a tuple built once at import
+    would keep masking the values from whichever environment happened to be present then, and
+    tests patch the module.
+
+    :return: Every non-empty credential value, sorted by descending length.
+    """
+    return _ordered(
+        (
+            settings.MODEL_API_KEY,
+            settings.RUNTIME_TOKEN,
+        )
+    )
+
+
+def mask_text(text: str) -> str:
+    """Return ``text`` with every configured credential value replaced."""
+    for secret in secret_values():
+        text = text.replace(secret, SECRET_PLACEHOLDER)
+    return text
+
+
+def mask_payload(value: Any) -> Any:
+    """Return ``value`` with every credential value inside it replaced.
+
+    Walks dictionaries, lists, and tuples so a whole JSON document can be handed over without
+    the caller knowing which field might hold model output or echoed request content.
+
+    Values only. A credential arrives as a value everywhere this is used -- a validation error
+    puts the rejected input under ``input`` and the schema's own field names under ``loc`` --
+    so walking keys as well would only cost a pass over data that cannot hold one.
+
+    :param value: Any JSON-shaped structure, or a scalar to pass through.
+    :return: A structure of the same shape with credentials replaced.
+    """
+    match value:
+        case str():
+            return mask_text(value)
+        case dict():
+            mapping = cast("dict[Any, Any]", value)
+            return {key: mask_payload(item) for key, item in mapping.items()}
+        case list():
+            items = cast("list[Any]", value)
+            return [mask_payload(item) for item in items]
+        case tuple():
+            elements = cast("tuple[Any, ...]", value)
+            return tuple(mask_payload(item) for item in elements)
+        case _:
+            return value

--- a/app-spark/agent/app_spark_agent/observability.py
+++ b/app-spark/agent/app_spark_agent/observability.py
@@ -1,0 +1,132 @@
+"""Process logging: sandbox labels on every record, credentials on none.
+
+``APP_SPARK_AGENT_SESSION_ID`` and ``APP_SPARK_AGENT_TENANT_ID`` exist only to make one sandbox's output findable
+among many, so they belong on every record rather than on the handful of call sites that
+remember to pass them. They are labels and nothing more: no code branches on either.
+
+Masking is applied twice on purpose: on this module's logger, so a record never carries a
+credential in the first place, and on the handler, so records from uvicorn and from any other
+library are covered as well. The leak worth defending against is the one written by code that
+never heard of this module.
+"""
+
+import logging
+import sys
+from collections.abc import MutableMapping
+from typing import Any
+
+from app_spark_agent import settings
+from app_spark_agent.masking import mask_payload, mask_text
+
+LOGGER_NAME = "app_spark_agent"
+
+# Rendered when the injection layer left the label out. An empty field would silently look
+# like a formatting bug in whatever collects these lines.
+UNLABELLED = "-"
+
+LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s session_id=%(session_id)s tenant_id=%(tenant_id)s %(message)s"
+
+# Their records reach the root handler by propagation once their own handlers are removed;
+# leaving both in place would print every line twice and skip the masking filter on one copy.
+_UVICORN_LOGGERS = ("uvicorn", "uvicorn.error", "uvicorn.access")
+
+
+def sandbox_labels() -> dict[str, str]:
+    """Return the sandbox labels to stamp on a log record.
+
+    Read per call, so a value patched in tests or resolved late still shows up.
+    """
+    return {
+        "session_id": settings.SESSION_ID or UNLABELLED,
+        "tenant_id": settings.TENANT_ID or UNLABELLED,
+    }
+
+
+class SandboxLabelFilter(logging.Filter):
+    """Give records that came from elsewhere the label fields the formatter expects.
+
+    Attached to the handler rather than to a logger: uvicorn's records never pass through
+    :data:`log`, and a formatter missing one key raises instead of printing the line.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Fill in any label the record does not already carry, and keep the record."""
+        for field, value in sandbox_labels().items():
+            if not hasattr(record, field):
+                setattr(record, field, value)
+        return True
+
+
+class SecretMaskingFilter(logging.Filter):
+    """Replace credential values in a record, in place.
+
+    Both the template and its arguments are masked. Masking only the rendered line would mean
+    rendering first, which is what a handler does after every filter has already run -- and
+    would leave the values on the record for anything else that reads it.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Mask the record in place and keep it."""
+        if isinstance(record.msg, str):
+            record.msg = mask_text(record.msg)
+        if record.args:
+            # `args` is a tuple for positional formatting and a mapping for `%(name)s`
+            # templates; `mask_payload` walks both and leaves non-string leaves alone.
+            record.args = mask_payload(record.args)
+        return True
+
+
+class SandboxLoggerAdapter(logging.LoggerAdapter[logging.Logger]):
+    """Logger that stamps the sandbox labels onto each record as it is created.
+
+    Set at creation instead of by a handler filter so the fields survive anywhere records are
+    inspected rather than printed -- ``caplog`` in the tests, and any future handler that does
+    not go through :func:`configure_logging`.
+    """
+
+    def process(self, msg: Any, kwargs: MutableMapping[str, Any]) -> tuple[Any, MutableMapping[str, Any]]:
+        """Merge the sandbox labels into the record's ``extra``, without overriding a caller."""
+        extra = {**sandbox_labels(), **dict(kwargs.get("extra") or {})}
+        kwargs["extra"] = extra
+        return msg, kwargs
+
+
+_logger = logging.getLogger(LOGGER_NAME)
+# Masked where the record is made, not only where it is written. A record that still holds the
+# value leaks through every other handler -- a host application's, a test's capture, anything
+# added later -- and a logger filter runs before any handler is called.
+_logger.addFilter(SecretMaskingFilter())
+
+log = SandboxLoggerAdapter(_logger, {})
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Send this process's logs to stderr with sandbox labels and credentials masked.
+
+    Idempotent: a repeated call replaces the handler it installed rather than adding a second
+    one, so an entry point that runs twice does not double every line.
+
+    :param level: Threshold for the root logger.
+    """
+    root = logging.getLogger()
+    for existing in list(root.handlers):
+        if getattr(existing, "_app_spark_agent_handler", False):
+            root.removeHandler(existing)
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    # Labels first: masking must run on a record the formatter can already render, and the
+    # label values themselves are not credentials.
+    handler.addFilter(SandboxLabelFilter())
+    handler.addFilter(SecretMaskingFilter())
+    handler.set_name(LOGGER_NAME)
+    # Marks ownership so a second call can tell this handler from one a host application added.
+    handler._app_spark_agent_handler = True  # type: ignore[attr-defined]
+
+    root.addHandler(handler)
+    root.setLevel(level)
+
+    for name in _UVICORN_LOGGERS:
+        uvicorn_logger = logging.getLogger(name)
+        uvicorn_logger.handlers.clear()
+        uvicorn_logger.propagate = True

--- a/app-spark/agent/app_spark_agent/recorder.py
+++ b/app-spark/agent/app_spark_agent/recorder.py
@@ -1,7 +1,5 @@
 """Capture the raw model transcript before compaction can rewrite it."""
 
-from __future__ import annotations
-
 import json
 from collections.abc import Sequence
 from typing import Any

--- a/app-spark/agent/app_spark_agent/server/__init__.py
+++ b/app-spark/agent/app_spark_agent/server/__init__.py
@@ -4,8 +4,9 @@
   guard that admits one mutating operation at a time. No HTTP.
 - :mod:`app_spark_agent.server.run_input` -- the trust boundary: validates an inbound AG-UI run
   and reduces it to a single new user turn.
-- :mod:`app_spark_agent.server.routes` -- the views, and the only place that deals in status
-  codes, headers, and response bodies.
+- :mod:`app_spark_agent.server.routes` -- the views: health, drain, context, and AG-UI run.
+- :mod:`app_spark_agent.server.errors` -- exception handlers: 409 mapping and credential
+  masking on HTTP error bodies.
 - :mod:`app_spark_agent.server.lifecycle` -- idle timeout and SIGTERM child-process registry.
 - :mod:`app_spark_agent.server.app` -- assembles the two halves into a FastAPI application.
 - :mod:`app_spark_agent.server.asgi` -- the module an external ASGI server is pointed at.

--- a/app-spark/agent/app_spark_agent/server/app.py
+++ b/app-spark/agent/app_spark_agent/server/app.py
@@ -1,7 +1,5 @@
 """Assembly of the Runtime application from its runtime state and its views."""
 
-from __future__ import annotations
-
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
@@ -12,9 +10,10 @@ from fastapi import FastAPI
 from pydantic_ai import Agent
 
 from app_spark_agent import VERSION, settings
+from app_spark_agent.server.errors import install_error_handlers
 from app_spark_agent.server.lifecycle import RuntimeLifecycle
-from app_spark_agent.server.routes import attach_runtime, busy_conflict_handler, router
-from app_spark_agent.server.runtime import ConversationRuntime, RuntimeBusyError
+from app_spark_agent.server.routes import attach_runtime, router
+from app_spark_agent.server.runtime import ConversationRuntime
 
 
 def create_runtime_app(
@@ -59,7 +58,7 @@ def create_runtime_app(
     # The views read the runtime back through a dependency, which is what keeps them plain
     # module-level functions instead of closures over this factory.
     attach_runtime(app, runtime)
-    app.add_exception_handler(RuntimeBusyError, busy_conflict_handler)
+    install_error_handlers(app)
     app.include_router(router)
     return app
 
@@ -68,7 +67,7 @@ def create_app_from_settings() -> FastAPI:
     """Create the application described entirely by the environment.
 
     When `APP_SPARK_AGENT_WORKSPACE` / `APP_SPARK_AGENT_STATE_DIR` are unset, fall
-    back to `/workspace` and `/state`.
+    back to `/data/workspace` and `/data/state`.
 
     :return: A FastAPI application for the configured workspace and state directory.
     """

--- a/app-spark/agent/app_spark_agent/server/errors.py
+++ b/app-spark/agent/app_spark_agent/server/errors.py
@@ -1,0 +1,54 @@
+"""Application error handlers: 409 mapping, and credential masking on HTTP error bodies."""
+
+from typing import cast
+
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from starlette.responses import JSONResponse, Response
+
+from app_spark_agent.masking import mask_payload, mask_text
+from app_spark_agent.server.runtime import RuntimeBusyError
+
+
+async def busy_conflict_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Answer a refused exclusive operation with a 409.
+
+    Registered on the application rather than repeated in every view.
+    """
+    return JSONResponse({"detail": mask_text(str(exc))}, status_code=status.HTTP_409_CONFLICT)
+
+
+async def masked_http_exception_handler(request: Request, exc: Exception) -> Response:
+    """Answer an ``HTTPException`` with its detail masked.
+
+    Several views build a detail out of an exception's own text, and an exception raised deep
+    in a library can quote whatever string it was handed. Masking here covers all of them at
+    once instead of asking every raise site to remember.
+    """
+    http_exc = cast(HTTPException, exc)
+    return JSONResponse(
+        {"detail": mask_payload(http_exc.detail)},
+        status_code=http_exc.status_code,
+        headers=http_exc.headers,
+    )
+
+
+async def masked_validation_exception_handler(request: Request, exc: Exception) -> Response:
+    """Answer a request-validation failure with the echoed input masked.
+
+    FastAPI's default reply quotes the rejected input, so a client that puts its token in the
+    body would get it back in the error -- and into whatever logs that response.
+    """
+    validation_exc = cast(RequestValidationError, exc)
+    return JSONResponse(
+        {"detail": mask_payload(jsonable_encoder(validation_exc.errors()))},
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+    )
+
+
+def install_error_handlers(app: FastAPI) -> None:
+    """Register handlers that map domain conflicts to 409 and mask credentials in HTTP error bodies."""
+    app.add_exception_handler(RuntimeBusyError, busy_conflict_handler)
+    app.add_exception_handler(HTTPException, masked_http_exception_handler)
+    app.add_exception_handler(RequestValidationError, masked_validation_exception_handler)

--- a/app-spark/agent/app_spark_agent/server/lifecycle.py
+++ b/app-spark/agent/app_spark_agent/server/lifecycle.py
@@ -1,7 +1,5 @@
 """Process lifecycle: idle-timeout exit, and stop registered app children on SIGTERM."""
 
-from __future__ import annotations
-
 import asyncio
 import os
 import subprocess

--- a/app-spark/agent/app_spark_agent/server/routes.py
+++ b/app-spark/agent/app_spark_agent/server/routes.py
@@ -1,10 +1,8 @@
-"""HTTP views: the only module that speaks in requests, responses, and status codes."""
-
-from __future__ import annotations
+"""HTTP views: health, drain, context, and the AG-UI run."""
 
 import json
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, Annotated, Any, cast
+from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request, status
 from fastapi.responses import StreamingResponse
@@ -12,7 +10,15 @@ from pydantic_ai.run import AgentRunResult
 from pydantic_ai.ui.ag_ui import AGUIAdapter
 from starlette.responses import JSONResponse, Response
 
+# Imported at runtime, not under TYPE_CHECKING: this module's annotations are read by tooling
+# and by the framework, and a name that only exists for a type checker turns any such read into
+# a NameError. ``starlette.types`` is a module of aliases, so importing it costs nothing.
+from starlette.types import Receive, Scope, Send
+
 from app_spark_agent import VERSION, settings
+
+# Imported under a different name: `log` already means "append-only channel" in this module.
+from app_spark_agent.observability import log as logger
 from app_spark_agent.recorder import TranscriptRecorder, record_messages
 from app_spark_agent.server.run_input import prepare_run, request_with_body
 from app_spark_agent.server.runtime import ConversationRuntime, RunLease, RuntimeBusyError
@@ -24,9 +30,6 @@ from app_spark_agent.state import (
     ConversationStateError,
 )
 from app_spark_agent.ui_events import record_ui_events
-
-if TYPE_CHECKING:
-    from starlette.types import Receive, Scope, Send
 
 router = APIRouter()
 
@@ -79,22 +82,9 @@ def require_bearer(request: Request) -> None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
 
 
-async def busy_conflict_handler(request: Request, exc: Exception) -> JSONResponse:
-    """Answer a refused exclusive operation with a 409.
-
-    Registered on the application rather than repeated in every view.
-    """
-    return JSONResponse({"detail": str(exc)}, status_code=status.HTTP_409_CONFLICT)
-
-
-@router.get("/health")
-async def health(
-    runtime: RuntimeDep,
-    token: str | None = Query(default=None),
-) -> dict[str, object]:
+@router.get("/health", dependencies=[Depends(require_bearer)])
+async def health(runtime: RuntimeDep) -> dict[str, object]:
     """Report the conversation's identity and the cursor of every stream."""
-    if not settings.matches_runtime_token(token or ""):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
     context = runtime.context_store.context
     return {
         "version": VERSION,
@@ -176,21 +166,29 @@ async def run(request: Request, runtime: RuntimeDep) -> Response:
         raise RuntimeBusyError("An Agent run is already in progress.")
 
     try:
-        response = await _start_run(runtime, request)
+        response, run_id = await _start_run(runtime, request)
     except Exception:
         lease.release()
         raise
-    return _hold_run_stream(response, lease)
+    return _hold_run_stream(response, lease, run_id=run_id)
 
 
-async def _start_run(runtime: ConversationRuntime, request: Request) -> Response:
+async def _start_run(runtime: ConversationRuntime, request: Request) -> tuple[Response, str]:
     """Validate one AG-UI run and return its streaming response.
 
     The caller owns the run guard: this only builds the response, and the stream it wraps is
     still running when it returns.
+
+    :return: ``(response, run_id)`` -- the open AG-UI stream, and the id later log lines quote.
     """
     context = runtime.context_store.context
     prepared = prepare_run(await request.body(), context, runtime.transcript)
+    logger.info(
+        "run started run_id=%s conversation_id=%s context_version=%s",
+        prepared.run_id,
+        prepared.conversation_id,
+        prepared.context_version,
+    )
     adapter = await AGUIAdapter.from_request(
         request_with_body(request, prepared.body),
         agent=runtime.agent,
@@ -234,10 +232,13 @@ async def _start_run(runtime: ConversationRuntime, request: Request) -> Response
         capabilities=[recorder],
         on_complete=commit_context,
     )
-    return adapter.streaming_response(record_ui_events(events, log=runtime.ui_events, run_id=prepared.run_id))
+    return (
+        adapter.streaming_response(record_ui_events(events, log=runtime.ui_events, run_id=prepared.run_id)),
+        prepared.run_id,
+    )
 
 
-def _hold_run_stream(response: Response, lease: RunLease) -> _HoldStreamingResponse:
+def _hold_run_stream(response: Response, lease: RunLease, *, run_id: str) -> _HoldStreamingResponse:
     """Wrap the AG-UI stream in a lease: release after enter, or at response end if never entered."""
     inner = cast(StreamingResponse, response)
 
@@ -248,6 +249,9 @@ def _hold_run_stream(response: Response, lease: RunLease) -> _HoldStreamingRespo
                 yield chunk
         finally:
             lease.release()
+            # Reached on a client disconnect as well as on a completed turn, so this says
+            # the stream is over and not that the run succeeded.
+            logger.info("run stream closed run_id=%s", run_id)
 
     headers = {**dict(inner.headers), **SSE_RESPONSE_HEADERS}
     return _HoldStreamingResponse(

--- a/app-spark/agent/app_spark_agent/server/run_input.py
+++ b/app-spark/agent/app_spark_agent/server/run_input.py
@@ -5,8 +5,6 @@ to act on: a single new user turn. The trusted history comes from the Runtime's 
 no display history, tool list, or system prompt submitted by the caller ever reaches the model.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import cast
 from uuid import UUID

--- a/app-spark/agent/app_spark_agent/server/runtime.py
+++ b/app-spark/agent/app_spark_agent/server/runtime.py
@@ -5,8 +5,6 @@ state channels, the agent, and the guard that keeps runs from overlapping -- so 
 in :mod:`app_spark_agent.server.routes` is left with nothing but request and response handling.
 """
 
-from __future__ import annotations
-
 import asyncio
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager

--- a/app-spark/agent/app_spark_agent/settings.py
+++ b/app-spark/agent/app_spark_agent/settings.py
@@ -7,16 +7,18 @@ import hmac
 from environs import Env, EnvError
 from marshmallow.validate import Length, Range
 
-# 所有配置项共用的环境变量前缀。
+# 所有配置项共用的环境变量前缀。接入层与本地开发都只下这一套。
 ENV_PREFIX = "APP_SPARK_AGENT_"
 
 DEFAULT_AGENT_PORT = 8090
-DEFAULT_WORKSPACE = "/workspace"
-DEFAULT_STATE_DIR = "/state"
+DEFAULT_APP_PORT = 8000
+DEFAULT_WORKSPACE = "/data/workspace"
+DEFAULT_STATE_DIR = "/data/state"
 DEFAULT_IDLE_TIMEOUT_SECONDS = 1800
 GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = 1
 
 env = Env(prefix=ENV_PREFIX)
+env.read_env(".env")
 
 # -----------------------------------------------------------------------
 # 运行目标
@@ -29,13 +31,23 @@ WORKSPACE = env.path("WORKSPACE", None)
 # Shell 工具读到、甚至改坏自己的历史。这一点在构建应用时强制检查。
 STATE_DIR = env.path("STATE_DIR", None)
 
-# GET /health 的 query token，以及 POST /runs 和控制面接口的 Bearer。
+# GET /health、POST /runs 和控制面接口共用的 Bearer。
 RUNTIME_TOKEN = env.str("RUNTIME_TOKEN", "")
 
 PORT = env.int("PORT", DEFAULT_AGENT_PORT)
 
+# 用户应用约定端口。本组件只读入并留给后续子进程，不拉起应用，也不因不是 8000
+# 而拒绝启动——数值由接入层锁定，端口是否在听属于应用管理。
+APP_PORT = env.int("APP_PORT", DEFAULT_APP_PORT)
+
 # 空闲秒数从进程启动起算，POST /runs 结束后重置。缺省 1800；<= 0 关闭空闲退出。
+# 从未收到 /runs 也会到期退出。
 IDLE_TIMEOUT_SECONDS = env.int("IDLE_TIMEOUT_SECONDS", DEFAULT_IDLE_TIMEOUT_SECONDS)
+
+# 只进日志与指标。不做业务分支：一个沙箱服务一个租户，这里按租户分流等于多造一套
+# 别处没有的策略。
+SESSION_ID = env.str("SESSION_ID", "")
+TENANT_ID = env.str("TENANT_ID", "")
 
 # -----------------------------------------------------------------------
 # 模型
@@ -45,7 +57,13 @@ IDLE_TIMEOUT_SECONDS = env.int("IDLE_TIMEOUT_SECONDS", DEFAULT_IDLE_TIMEOUT_SECO
 MODEL = env.str("MODEL", "deepseek:deepseek-v4-flash", validate=Length(min=1))
 
 # 模型密钥，同时交给 provider。缺失时 health 报 model_ready=false，POST /runs 返回 503。
+# 这是唯一的就绪门闩：模型名或网关地址缺失不让 Runtime 报未就绪。
 MODEL_API_KEY = env.str("MODEL_API_KEY", "") or None
+
+# 网关目标，读入是为了契约落在同一处。当前还不拿它们去拨号：模型客户端仍由
+# ``MODEL`` 与 ``MODEL_API_KEY`` 构造。
+MODEL_NAME = env.str("MODEL_NAME", "")
+MODEL_BASE_URL = env.str("MODEL_BASE_URL", "")
 
 # Agent 的系统提示词。它和 ``agent.py`` 里挂载的能力是配套的——提示词里提到的「file 工具」
 # 「shell 工具」「AGENTS.md」分别对应 FileSystem、Shell、RepoContext 三个能力。

--- a/app-spark/agent/app_spark_agent/state/context.py
+++ b/app-spark/agent/app_spark_agent/state/context.py
@@ -1,7 +1,5 @@
 """The mutable conversation context: the history actually sent to the model."""
 
-from __future__ import annotations
-
 import asyncio
 from collections.abc import Sequence
 from pathlib import Path

--- a/app-spark/agent/app_spark_agent/state/log.py
+++ b/app-spark/agent/app_spark_agent/state/log.py
@@ -6,8 +6,6 @@
 - event：AG-UI 协议的 UI 层 Client 对话
 """
 
-from __future__ import annotations
-
 import asyncio
 from collections.abc import Sequence
 from datetime import UTC, datetime

--- a/app-spark/agent/app_spark_agent/ui_events.py
+++ b/app-spark/agent/app_spark_agent/ui_events.py
@@ -1,6 +1,13 @@
-"""Persist the AG-UI event history the client actually saw."""
+"""Persist the AG-UI event history the client actually saw.
 
-from __future__ import annotations
+The stored copy is masked; the live stream is forwarded untouched. That split is deliberate.
+Masking each delta as it goes past would run on every streamed token to catch a value that can
+only be there if credential stripping had already failed, and it would still miss the value
+whenever the model happened to split it across two chunks. The stored copy is coalesced per
+message before it is masked, so it has the whole string to match against, and it is the copy an
+audit reads. A client that sees a credential in its own stream is a client that already holds
+one.
+"""
 
 from collections.abc import AsyncIterator, Sequence
 from enum import StrEnum
@@ -17,6 +24,7 @@ from ag_ui.core import (
     ToolCallEndEvent,
 )
 
+from app_spark_agent.masking import mask_payload
 from app_spark_agent.state import AppendLog
 
 
@@ -137,8 +145,10 @@ async def _persist(events: Sequence[BaseEvent], *, log: AppendLog, run_id: str) 
     if not events:
         return
     # Matches how the AG-UI encoder puts an event on the wire, so a stored event and a streamed
-    # one are the same JSON document.
+    # one are the same JSON document, apart from the masking. Masked whole rather than per
+    # field: by this point the deltas of one message are joined, so however the model chose to
+    # chunk a credential, it is a single string here.
     await log.append(
         run_id,
-        [event.model_dump(mode="json", by_alias=True, exclude_none=True) for event in events],
+        [mask_payload(event.model_dump(mode="json", by_alias=True, exclude_none=True)) for event in events],
     )

--- a/app-spark/agent/app_spark_agent/utils.py
+++ b/app-spark/agent/app_spark_agent/utils.py
@@ -4,8 +4,6 @@ Currently only crash-safe file writes: both state modules need them, and neither
 Every function here is blocking, so async callers must hand them to ``asyncio.to_thread``.
 """
 
-from __future__ import annotations
-
 import os
 from pathlib import Path
 

--- a/app-spark/agent/tests/api/conftest.py
+++ b/app-spark/agent/tests/api/conftest.py
@@ -1,7 +1,5 @@
 """Started Runtime clients supplied to the API tests as pytest fixtures."""
 
-from __future__ import annotations
-
 from collections.abc import Iterator, Sequence
 from contextlib import ExitStack
 from itertools import count
@@ -24,11 +22,18 @@ DEFAULT_REPLY: tuple[str, ...] = ("he", "llo")
 
 @pytest.fixture(autouse=True)
 def sandbox_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Give API tests a sandbox token and model key by default."""
+    """Give API tests the sandbox contract a real injection would provide."""
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", RUNTIME_TOKEN)
     monkeypatch.setattr(settings, "MODEL_API_KEY", MODEL_API_KEY)
-    # A short idle timeout in the environment must not os._exit during TestClient.
+    monkeypatch.setattr(settings, "MODEL_NAME", "test-model")
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "https://model-gateway.test/v1")
+    monkeypatch.setattr(settings, "APP_PORT", settings.DEFAULT_APP_PORT)
+    # A short idle timeout in a developer .env must not os._exit during TestClient.
     monkeypatch.setattr(settings, "IDLE_TIMEOUT_SECONDS", 0)
+    # Both labels are optional in the contract, so the default here is the unlabelled case a
+    # test must opt out of rather than the other way round.
+    monkeypatch.setattr(settings, "SESSION_ID", "")
+    monkeypatch.setattr(settings, "TENANT_ID", "")
 
 
 @pytest.fixture

--- a/app-spark/agent/tests/api/support.py
+++ b/app-spark/agent/tests/api/support.py
@@ -3,8 +3,6 @@
 This module owns everything that drives the test application over HTTP.
 """
 
-from __future__ import annotations
-
 import asyncio
 import time
 from collections.abc import AsyncGenerator, Sequence
@@ -24,10 +22,11 @@ from app_spark_agent.server import create_runtime_app
 from tests.support.ag_ui import SSE_HEADERS, assistant_text, run_body, sse_events
 from tests.support.fake_models import gated_model
 
+# Both are at least sixteen characters and share no substring, so a leak test can search for
+# one without matching the other or matching ordinary output.
 RUNTIME_TOKEN = "test-runtime-token"
-MODEL_API_KEY = "test-model-key"
+MODEL_API_KEY = "test-model-api-key"
 AUTH_HEADERS = {"Authorization": f"Bearer {RUNTIME_TOKEN}"}
-HEALTH_PARAMS = {"token": RUNTIME_TOKEN}
 HEALTH_FIELDS = {"version", "model_ready", "running", "app_status"}
 
 # `ASGITransport` never opens a socket, so this only has to be an absolute URL httpx can build
@@ -36,7 +35,7 @@ ASGI_BASE_URL = "http://runtime.test"
 
 
 class AuthedTestClient(TestClient):
-    """TestClient that attaches the runtime Bearer and health query token."""
+    """TestClient that attaches the runtime Bearer."""
 
     def request(self, method: str, url: str, **kwargs: Any) -> Any:  # type: ignore[override]
         headers = {str(key): str(value) for key, value in dict(kwargs.get("headers") or {}).items()}
@@ -44,16 +43,6 @@ class AuthedTestClient(TestClient):
         if not any(key.lower() == "authorization" for key in headers):
             headers["Authorization"] = AUTH_HEADERS["Authorization"]
         kwargs["headers"] = headers
-
-        # /health uses a query token, not Bearer. Use a bare TestClient for missing/wrong token.
-        path = str(url).split("?", 1)[0].rstrip("/")
-        if path.endswith("/health"):
-            params = kwargs.get("params")
-            if params is None:
-                kwargs["params"] = dict(HEALTH_PARAMS)
-            elif isinstance(params, dict) and "token" not in params:
-                kwargs["params"] = {**params, **HEALTH_PARAMS}
-
         return super().request(method, url, **kwargs)
 
 
@@ -214,7 +203,6 @@ async def http_client(test_client: TestClient) -> AsyncGenerator[httpx.AsyncClie
         transport=transport,
         base_url=ASGI_BASE_URL,
         headers=AUTH_HEADERS,
-        params=HEALTH_PARAMS,
     ) as client:
         yield client
 

--- a/app-spark/agent/tests/api/test_compaction.py
+++ b/app-spark/agent/tests/api/test_compaction.py
@@ -1,7 +1,5 @@
 """Compaction must never reach the raw transcript, only the context."""
 
-from __future__ import annotations
-
 from pathlib import Path
 from typing import Any
 from uuid import uuid4

--- a/app-spark/agent/tests/api/test_context.py
+++ b/app-spark/agent/tests/api/test_context.py
@@ -5,8 +5,6 @@ guarded: the export is tagged with the version it was taken at, and the import r
 that would overwrite a Runtime already holding a conversation of its own.
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 from typing import Any
 from uuid import uuid4

--- a/app-spark/agent/tests/api/test_health.py
+++ b/app-spark/agent/tests/api/test_health.py
@@ -5,8 +5,6 @@ interesting assertion is not the shape of the document but that its numbers agre
 endpoints they point at.
 """
 
-from __future__ import annotations
-
 from typing import Any
 from uuid import uuid4
 
@@ -14,7 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app_spark_agent import VERSION, settings
-from tests.api.support import HEALTH_FIELDS, drain_channel, run_turn
+from tests.api.support import HEALTH_FIELDS, RUNTIME_TOKEN, drain_channel, run_turn
 
 
 def test_an_empty_runtime_reports_no_conversation(api: TestClient) -> None:
@@ -49,9 +47,46 @@ def test_every_reported_cursor_matches_the_endpoint_it_points_at(api: TestClient
     assert reported["running"] is False
 
 
-@pytest.mark.parametrize("params", [None, {"token": ""}, {"token": "wrong"}, {"token": "short"}])
-def test_health_rejects_bad_token(api: TestClient, params: dict[str, str] | None) -> None:
+@pytest.mark.parametrize("missing", ["MODEL_NAME", "MODEL_BASE_URL"])
+def test_readiness_is_latched_only_by_the_api_key(
+    api: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    missing: str,
+) -> None:
+    """The model name and base URL are carried for a later caller, not gates on serving a run.
+
+    Reporting the Runtime unready for a missing name would stall the sandbox on a condition it
+    cannot fix and that stops nothing it currently does.
+    """
+    monkeypatch.setattr(settings, missing, "")
+
+    reported: dict[str, Any] = api.get("/health").json()
+
+    assert reported["model_ready"] is True
+
+
+def test_a_missing_api_key_is_reported_as_unready(api: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The one condition that must never be reported as ready."""
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+
+    reported: dict[str, Any] = api.get("/health").json()
+
+    assert reported["model_ready"] is False
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [None, {"Authorization": "Bearer "}, {"Authorization": "Bearer wrong"}, {"Authorization": "Bearer short"}],
+)
+def test_health_rejects_bad_token(api: TestClient, headers: dict[str, str] | None) -> None:
     # Skip AuthedTestClient so a missing token is not filled in.
-    resp = TestClient(api.app).get("/health", params=params)
+    resp = TestClient(api.app).get("/health", headers=headers)
+    assert resp.status_code == 401
+    assert HEALTH_FIELDS.isdisjoint(resp.json())
+
+
+def test_health_rejects_query_token(api: TestClient) -> None:
+    """A query token is not an alternative to Bearer."""
+    resp = TestClient(api.app).get("/health", params={"token": RUNTIME_TOKEN})
     assert resp.status_code == 401
     assert HEALTH_FIELDS.isdisjoint(resp.json())

--- a/app-spark/agent/tests/api/test_lifecycle.py
+++ b/app-spark/agent/tests/api/test_lifecycle.py
@@ -1,7 +1,5 @@
 """Idle clock on HTTP: reset only when a run ends; ``/health`` does not extend life."""
 
-from __future__ import annotations
-
 from uuid import uuid4
 
 from fastapi.testclient import TestClient

--- a/app-spark/agent/tests/api/test_log.py
+++ b/app-spark/agent/tests/api/test_log.py
@@ -6,8 +6,6 @@ What the AG-UI channel stores is its own question and lives in
 :mod:`tests.api.test_ui_events`.
 """
 
-from __future__ import annotations
-
 from typing import Any
 from uuid import uuid4
 

--- a/app-spark/agent/tests/api/test_persist.py
+++ b/app-spark/agent/tests/api/test_persist.py
@@ -1,6 +1,5 @@
-"""Authoritative state is the AG-1 trio: failure is not persisted as success, and no messages.json."""
-
-from __future__ import annotations
+"""Authoritative state is the three durable files: failure is not persisted as success, and no
+messages.json."""
 
 from pathlib import Path
 from typing import Any, cast

--- a/app-spark/agent/tests/api/test_run.py
+++ b/app-spark/agent/tests/api/test_run.py
@@ -5,8 +5,6 @@ Runtime streams back, and what happens to a second caller who arrives while a ru
 flight.
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 from typing import Any
 from uuid import uuid4

--- a/app-spark/agent/tests/api/test_runtime.py
+++ b/app-spark/agent/tests/api/test_runtime.py
@@ -1,7 +1,5 @@
 """RunLease: releasing a never-started generator must not drop the next run."""
 
-from __future__ import annotations
-
 from app_spark_agent.server.runtime import RunGuard
 
 

--- a/app-spark/agent/tests/api/test_secret_masking.py
+++ b/app-spark/agent/tests/api/test_secret_masking.py
@@ -1,0 +1,157 @@
+"""Credentials must not leave the process through anything a caller or an auditor reads.
+
+Here: HTTP error bodies, the live AG-UI stream and its persisted copy, the process log. The
+subprocess-environment layer is in :mod:`tests.test_agent`. The values searched for are the
+ones the whole suite authenticates with, so requests still succeed while carrying them.
+"""
+
+import logging
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app_spark_agent import settings
+from app_spark_agent.masking import SECRET_PLACEHOLDER
+from app_spark_agent.observability import LOGGER_NAME
+from tests.api.support import (
+    MODEL_API_KEY,
+    RUNTIME_TOKEN,
+    ApiFactory,
+    drain_channel,
+    run_request,
+    run_turn,
+)
+from tests.support.ag_ui import SSE_HEADERS, assistant_text, run_body
+from tests.support.fake_models import text_model
+
+ALL_CREDENTIALS = (RUNTIME_TOKEN, MODEL_API_KEY)
+
+
+def assert_no_credentials(text: str) -> None:
+    """Fail with the offending value named, rather than with a bare False."""
+    for credential in ALL_CREDENTIALS:
+        assert credential not in text, f"{credential} leaked into: {text}"
+
+
+def test_an_unauthorized_reply_does_not_name_the_expected_value(api: TestClient) -> None:
+    """A 401 says the caller failed, not what would have worked."""
+    # Bare client: the suite's auto-authentication would put the real token back on the request.
+    raw = TestClient(api.app)
+    body = run_body(conversation_id=str(uuid4()), run_id=str(uuid4()), context_version=0)
+
+    refused = [
+        raw.get("/health", headers={"Authorization": "Bearer wrong"}),
+        raw.post("/runs", headers={"Authorization": "Bearer wrong"}, json=body),
+    ]
+
+    for resp in refused:
+        assert resp.status_code == 401, resp.text
+        assert_no_credentials(resp.text)
+
+
+def test_a_rejected_query_value_is_masked_before_it_is_echoed(api: TestClient) -> None:
+    """A validation error quotes the input it refused, and that input is the caller's.
+
+    A declared query parameter on purpose: ``POST /runs`` parses the AG-UI document itself, so
+    its 422 is a fixed string that echoes nothing and would pass this without any masking.
+    """
+    resp = api.get("/log", params={"since": RUNTIME_TOKEN})
+
+    assert resp.status_code == 422
+    # Proves the value reached the reply and was replaced, rather than never arriving.
+    assert SECRET_PLACEHOLDER in resp.text
+    assert_no_credentials(resp.text)
+
+
+def test_a_refused_run_names_no_credential(api: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The 409 is built out of an exception's own text; the 503 is a fixed one.
+
+    Sequenced, not split: the conflict needs a conversation to exist first, and dropping the
+    key for the 503 is what stops any further run from starting.
+    """
+    run_turn(api, conversation_id=str(uuid4()))
+    conflict = run_request(api, conversation_id=str(uuid4()), context_version=0)
+
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    unready = run_request(api, conversation_id=str(uuid4()), context_version=0)
+
+    assert conflict.status_code == 409, conflict.text
+    assert unready.status_code == 503, unready.text
+    assert_no_credentials(conflict.text)
+    assert_no_credentials(unready.text)
+
+
+_HALF = len(MODEL_API_KEY) // 2
+
+
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        pytest.param((f"the key is {MODEL_API_KEY}",), id="whole-in-one-chunk"),
+        pytest.param((MODEL_API_KEY[:_HALF], MODEL_API_KEY[_HALF:]), id="split-across-chunks"),
+    ],
+)
+def test_the_stored_events_are_masked_however_the_model_chunked_the_value(
+    make_api: ApiFactory,
+    chunks: tuple[str, ...],
+) -> None:
+    """The stored copy is masked whether or not the value survived streaming in one piece.
+
+    The model here does what a compromised or merely careless one would: repeats a credential
+    verbatim. This is the case environment stripping cannot cover, because by then the value is
+    model output. Both chunkings are covered because masking happens after the deltas of one
+    message are joined, so the split is not a case the stored copy can fail on.
+    """
+    api = make_api(model=text_model(chunks))
+
+    outcome = run_turn(api, conversation_id=str(uuid4()))
+
+    # The live stream is forwarded untouched by design, so the client does see the value.
+    assert MODEL_API_KEY in assistant_text(outcome.events)
+    stored = drain_channel(api, "/ui-events")
+    assert stored, "the run stored no events"
+    assert_no_credentials(str(stored))
+    # Proves the value reached the events and was replaced, rather than never arriving.
+    assert SECRET_PLACEHOLDER in str(stored)
+
+
+def test_the_tenant_label_changes_no_behaviour(api: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The label is for finding a sandbox's output, never for branching on."""
+    observed: list[tuple[int, object, object]] = []
+    for tenant in ("tenant-a", "tenant-b"):
+        monkeypatch.setattr(settings, "TENANT_ID", tenant)
+
+        health = api.get("/health").json()
+        rejected = api.post("/runs", headers=SSE_HEADERS, json={"threadId": ""})
+
+        observed.append((rejected.status_code, health["model_ready"], health["running"]))
+
+    assert observed[0] == observed[1]
+
+
+def test_a_run_is_logged_with_labels_and_without_credentials(
+    api: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A run must be findable by session and tenant, and quote no credential doing it.
+
+    The conversation id is caller-supplied, so it is the part of a log line that can carry
+    anything -- the token included.
+    """
+    monkeypatch.setattr(settings, "SESSION_ID", "sess-demo")
+    monkeypatch.setattr(settings, "TENANT_ID", "tenant-demo")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        run_turn(api, conversation_id=f"conversation-{RUNTIME_TOKEN}")
+
+    records = [record for record in caplog.records if record.name == LOGGER_NAME]
+    assert records, "the run logged nothing"
+    for record in records:
+        assert record.session_id == "sess-demo"
+        assert record.tenant_id == "tenant-demo"
+        assert_no_credentials(record.getMessage())
+    messages = [record.getMessage() for record in records]
+    assert any("run started" in message for message in messages)
+    assert any("run stream closed" in message for message in messages)

--- a/app-spark/agent/tests/api/test_ui_events.py
+++ b/app-spark/agent/tests/api/test_ui_events.py
@@ -1,7 +1,5 @@
 """``GET /ui-events``: the stored, replayable copy of what the client saw."""
 
-from __future__ import annotations
-
 import json
 from typing import Any
 from uuid import uuid4

--- a/app-spark/agent/tests/e2e/conftest.py
+++ b/app-spark/agent/tests/e2e/conftest.py
@@ -5,8 +5,6 @@ starts for itself: the restart and cold-restore stories run two and three proces
 scenario that fails halfway must not leave any of them behind.
 """
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 from contextlib import ExitStack
 from pathlib import Path

--- a/app-spark/agent/tests/e2e/console.py
+++ b/app-spark/agent/tests/e2e/console.py
@@ -9,8 +9,6 @@ The direction of every line is readable at a glance: ``>`` is what the client se
 what the Runtime sent back. Nothing in this module ever fails a test; it only reports.
 """
 
-from __future__ import annotations
-
 import sys
 from typing import Any
 

--- a/app-spark/agent/tests/e2e/live.py
+++ b/app-spark/agent/tests/e2e/live.py
@@ -9,8 +9,6 @@ is only ever read through the endpoints that serve it.
 Every call narrates itself through :mod:`tests.e2e.console`, which makes ``-s`` worth passing.
 """
 
-from __future__ import annotations
-
 import json
 import os
 import socket
@@ -234,7 +232,9 @@ def serve(
     url = f"http://127.0.0.1:{port}"
     log_path = state_dir.parent / f"{label}-uvicorn.log"
     runtime_token = os.environ.get(f"{ENV_PREFIX}RUNTIME_TOKEN") or E2E_RUNTIME_TOKEN
-    model_api_key = os.environ.get(f"{ENV_PREFIX}MODEL_API_KEY") or settings.MODEL_API_KEY or ""
+    # Prefer the already-resolved setting (including `.env`) over `os.environ`: injecting an
+    # empty string would block the child from reading its own `.env` and leave it unready.
+    model_api_key = settings.MODEL_API_KEY or ""
 
     console.banner(f"{label}: uvicorn {ASGI_TARGET} on {url}")
     console.note(f"workspace={workspace}")
@@ -291,7 +291,6 @@ def serve(
             base_url=url,
             timeout=REQUEST_TIMEOUT_SECONDS,
             headers={"Authorization": f"Bearer {runtime_token}"},
-            params={"token": runtime_token},
         ),
         log_path=log_path,
     )
@@ -319,7 +318,7 @@ def wait_until_healthy(
             if (
                 httpx.get(
                     f"{url}/health",
-                    params={"token": runtime_token},
+                    headers={"Authorization": f"Bearer {runtime_token}"},
                     timeout=0.5,
                 ).status_code
                 == 200

--- a/app-spark/agent/tests/e2e/test_coding_session.py
+++ b/app-spark/agent/tests/e2e/test_coding_session.py
@@ -6,8 +6,6 @@ Runtime holds rather than from anything the client resent, and afterwards the th
 channels have to agree with the cursors ``/health`` reports.
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import pytest

--- a/app-spark/agent/tests/e2e/test_compaction.py
+++ b/app-spark/agent/tests/e2e/test_compaction.py
@@ -10,8 +10,6 @@ discarded on the request after the one that paid for it and the history re-summa
 Only a real model can produce a real summary, so this is the only place that regression shows.
 """
 
-from __future__ import annotations
-
 from typing import Any
 
 import pytest

--- a/app-spark/agent/tests/e2e/test_restore.py
+++ b/app-spark/agent/tests/e2e/test_restore.py
@@ -9,8 +9,6 @@ Both are driven here in one chain, because the second only means anything if the
 a conversation worth moving.
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import pytest

--- a/app-spark/agent/tests/server/test_lifecycle.py
+++ b/app-spark/agent/tests/server/test_lifecycle.py
@@ -1,7 +1,5 @@
 """Idle clock and app-child registry: fake clock plus real subprocesses."""
 
-from __future__ import annotations
-
 import subprocess
 import sys
 

--- a/app-spark/agent/tests/server/test_paths.py
+++ b/app-spark/agent/tests/server/test_paths.py
@@ -1,7 +1,5 @@
 """Container path lock: workspace and state stay distinct; overlap refuses to start."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from pathlib import Path
 
@@ -14,8 +12,8 @@ from app_spark_agent.server.runtime import ConversationRuntime
 
 
 def test_container_default_paths_are_locked_siblings() -> None:
-    assert settings.DEFAULT_WORKSPACE == "/workspace"
-    assert settings.DEFAULT_STATE_DIR == "/state"
+    assert settings.DEFAULT_WORKSPACE == "/data/workspace"
+    assert settings.DEFAULT_STATE_DIR == "/data/state"
     assert settings.DEFAULT_WORKSPACE != settings.DEFAULT_STATE_DIR
 
 

--- a/app-spark/agent/tests/state/test_context.py
+++ b/app-spark/agent/tests/state/test_context.py
@@ -1,7 +1,5 @@
 """Conversation context: validation, monotonic versioning, and atomic replacement."""
 
-from __future__ import annotations
-
 import json
 from pathlib import Path
 from uuid import uuid4

--- a/app-spark/agent/tests/state/test_log.py
+++ b/app-spark/agent/tests/state/test_log.py
@@ -1,7 +1,5 @@
 """Append-only channel behavior: contiguity, cursors, and crash recovery."""
 
-from __future__ import annotations
-
 import json
 from pathlib import Path
 
@@ -106,8 +104,7 @@ async def test_appending_after_recovery_stays_contiguous(tmp_path: Path) -> None
 def test_a_gap_in_the_sequence_is_rejected(tmp_path: Path) -> None:
     path = tmp_path / "channel.jsonl"
     path.write_text(
-        '{"seq":1,"run_id":"a","timestamp":"t","message":{}}\n'
-        '{"seq":3,"run_id":"a","timestamp":"t","message":{}}\n'
+        '{"seq":1,"run_id":"a","timestamp":"t","message":{}}\n{"seq":3,"run_id":"a","timestamp":"t","message":{}}\n'
     )
 
     with pytest.raises(AppendLogError, match="not contiguous"):

--- a/app-spark/agent/tests/support/ag_ui.py
+++ b/app-spark/agent/tests/support/ag_ui.py
@@ -1,7 +1,5 @@
 """Pure AG-UI request and event helpers shared by in-process and live tests."""
 
-from __future__ import annotations
-
 import json
 from collections.abc import Sequence
 from typing import Any, cast
@@ -44,9 +42,7 @@ def sse_events(body: str) -> list[dict[str, Any]]:
     events: list[dict[str, Any]] = []
     for frame in body.replace("\r\n", "\n").split("\n\n"):
         data = "\n".join(
-            line.removeprefix("data:").lstrip()
-            for line in frame.splitlines()
-            if line.startswith("data:")
+            line.removeprefix("data:").lstrip() for line in frame.splitlines() if line.startswith("data:")
         )
         if data:
             events.append(cast(dict[str, Any], json.loads(data)))

--- a/app-spark/agent/tests/support/fake_models.py
+++ b/app-spark/agent/tests/support/fake_models.py
@@ -1,7 +1,5 @@
 """Deterministic models and tools shared by Runtime tests."""
 
-from __future__ import annotations
-
 import asyncio
 import json
 from collections.abc import AsyncIterator, Sequence

--- a/app-spark/agent/tests/test_agent.py
+++ b/app-spark/agent/tests/test_agent.py
@@ -1,7 +1,10 @@
+import fnmatch
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from pydantic_ai import Agent
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import ToolCallPart
 from pydantic_ai.models.openai import OpenAIChatModel
@@ -55,7 +58,55 @@ def test_create_agent_scopes_tools_to_workspace(
     assert any(isinstance(item, TieredCompaction) for item in capabilities)
 
 
-def test_the_configured_api_key_reaches_the_provider(monkeypatch: MonkeyPatch) -> None:
+def denied(name: str, patterns: Sequence[str]) -> bool:
+    """Whether a subprocess would inherit ``name``, decided the way the harness decides it."""
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
+
+
+def shell_of(agent: Agent[None, str]) -> Shell:
+    return next(item for item in agent.root_capability.capabilities if isinstance(item, Shell))
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "APP_SPARK_AGENT_MODEL_API_KEY",
+        "APP_SPARK_AGENT_RUNTIME_TOKEN",
+    ],
+)
+def test_a_credential_is_stripped_from_the_environment_a_subprocess_inherits(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    name: str,
+) -> None:
+    """The first layer of credential protection: the model's shell never sees the value.
+
+    Asserted against `fnmatch`, the matcher the harness itself uses, rather than against the
+    literal pattern list -- what matters is whether the name is excluded, not how it is spelled.
+    """
+    monkeypatch.setattr(settings, "MODEL_API_KEY", "not-used-by-this-test")
+
+    patterns = shell_of(create_agent(tmp_path)).denied_env_patterns
+
+    assert denied(name, patterns)
+
+
+def provider_key_of(model: Any) -> str:
+    """Return the credential the built model's provider client will authenticate with."""
+    assert isinstance(model, OpenAIChatModel)
+    return cast(str, cast(Any, model.client).api_key)
+
+
+def test_the_injected_contract_key_reaches_the_provider(monkeypatch: MonkeyPatch) -> None:
+    """`APP_SPARK_AGENT_MODEL_API_KEY` alone must be enough to start the provider."""
+    monkeypatch.setattr(settings, "MODEL_API_KEY", "injected-contract-key")
+
+    assert provider_key_of(build_model()) == "injected-contract-key"
+
+
+def test_the_settings_key_reaches_the_provider_when_it_is_not_in_the_environment(
+    monkeypatch: MonkeyPatch,
+) -> None:
     """A key that only exists in the settings must still authenticate the provider.
 
     The value never enters ``os.environ``, so a provider left to read the environment
@@ -63,11 +114,7 @@ def test_the_configured_api_key_reaches_the_provider(monkeypatch: MonkeyPatch) -
     """
     monkeypatch.setattr(settings, "MODEL_API_KEY", "key-only-in-settings")
 
-    model = build_model()
-
-    assert isinstance(model, OpenAIChatModel)
-    client = cast(Any, model.client)
-    assert client.api_key == "key-only-in-settings"
+    assert provider_key_of(build_model()) == "key-only-in-settings"
 
 
 def test_compaction_escalates_from_cheap_to_expensive() -> None:
@@ -80,7 +127,7 @@ def test_compaction_escalates_from_cheap_to_expensive() -> None:
         ClearToolResults,
         SummarizingCompaction,
     ]
-    # An absolute budget rather than a fraction of the window; `test_settings.py` pins why that
+    # An absolute budget rather than a fraction of the window; `settings.py` pins why that
     # number is what it is.
     assert compaction.target_tokens == settings.COMPACTION_TARGET_TOKENS
 

--- a/app-spark/agent/tests/test_masking.py
+++ b/app-spark/agent/tests/test_masking.py
@@ -1,0 +1,101 @@
+"""Credential masking: what counts as a secret, and what a masked document looks like."""
+
+from typing import Any
+
+import pytest
+
+from app_spark_agent import settings
+from app_spark_agent.masking import SECRET_PLACEHOLDER, mask_payload, mask_text, secret_values
+
+RUNTIME_TOKEN = "runtime-token-0123456789"
+MODEL_API_KEY = "model-api-key-0123456789"
+
+
+@pytest.fixture
+def credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure both credentials with distinct values."""
+    monkeypatch.setattr(settings, "RUNTIME_TOKEN", RUNTIME_TOKEN)
+    monkeypatch.setattr(settings, "MODEL_API_KEY", MODEL_API_KEY)
+
+
+def test_every_configured_credential_is_masked(credentials: None) -> None:
+    text = f"token={RUNTIME_TOKEN} key={MODEL_API_KEY}"
+
+    masked = mask_text(text)
+
+    assert RUNTIME_TOKEN not in masked
+    assert MODEL_API_KEY not in masked
+    assert masked == f"token={SECRET_PLACEHOLDER} key={SECRET_PLACEHOLDER}"
+
+
+def test_key_names_survive_masking(credentials: None) -> None:
+    """Names are what makes a log line or a settings table readable; only values are secret."""
+    text = "APP_SPARK_AGENT_RUNTIME_TOKEN and APP_SPARK_AGENT_MODEL_API_KEY are set"
+
+    assert mask_text(text) == text
+
+
+def test_an_unset_credential_masks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty value must not turn into a match against every string in sight."""
+    monkeypatch.setattr(settings, "RUNTIME_TOKEN", "")
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+
+    assert secret_values() == ()
+    assert mask_text("nothing to hide") == "nothing to hide"
+
+
+def test_the_longest_credential_is_masked_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One credential containing another must not leave the remainder of the longer one behind.
+
+    Masking the short value first would rewrite the middle of the long one and let its head and
+    tail through, which reads as a partial leak rather than as a masked value.
+    """
+    short = "secret"
+    long = f"prefix-{short}-suffix"
+    monkeypatch.setattr(settings, "RUNTIME_TOKEN", short)
+    monkeypatch.setattr(settings, "MODEL_API_KEY", long)
+
+    assert secret_values() == (long, short)
+    assert mask_text(f"value={long}") == f"value={SECRET_PLACEHOLDER}"
+
+
+def test_credentials_are_read_per_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A value captured at import would keep masking whatever the environment held back then."""
+    monkeypatch.setattr(settings, "RUNTIME_TOKEN", "first")
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    assert mask_text("first") == SECRET_PLACEHOLDER
+
+    monkeypatch.setattr(settings, "RUNTIME_TOKEN", "second")
+
+    assert mask_text("first") == "first"
+    assert mask_text("second") == SECRET_PLACEHOLDER
+
+
+def test_a_whole_document_is_walked(credentials: None) -> None:
+    payload: dict[str, Any] = {
+        "type": "TEXT_MESSAGE_CONTENT",
+        "delta": f"the key is {MODEL_API_KEY}",
+        "nested": {"headers": [f"Bearer {RUNTIME_TOKEN}", "Accept: text/event-stream"]},
+        "seq": 7,
+        "done": False,
+        "missing": None,
+    }
+
+    masked = mask_payload(payload)
+
+    assert masked == {
+        "type": "TEXT_MESSAGE_CONTENT",
+        "delta": f"the key is {SECRET_PLACEHOLDER}",
+        "nested": {"headers": [f"Bearer {SECRET_PLACEHOLDER}", "Accept: text/event-stream"]},
+        "seq": 7,
+        "done": False,
+        "missing": None,
+    }
+
+
+def test_tuples_keep_their_shape(credentials: None) -> None:
+    """Log record arguments arrive as a tuple, and `%`-formatting rejects a list."""
+    masked = mask_payload((f"Bearer {RUNTIME_TOKEN}", 3))
+
+    assert masked == (f"Bearer {SECRET_PLACEHOLDER}", 3)
+    assert isinstance(masked, tuple)

--- a/app-spark/agent/tests/test_observability.py
+++ b/app-spark/agent/tests/test_observability.py
@@ -1,0 +1,189 @@
+"""Process logging: sandbox labels arrive on records, credentials do not."""
+
+import logging
+
+import pytest
+
+from app_spark_agent import settings
+from app_spark_agent.masking import SECRET_PLACEHOLDER
+from app_spark_agent.observability import (
+    LOG_FORMAT,
+    LOGGER_NAME,
+    UNLABELLED,
+    SandboxLabelFilter,
+    SecretMaskingFilter,
+    configure_logging,
+    log,
+)
+
+RUNTIME_TOKEN = "runtime-token-0123456789"
+
+
+@pytest.fixture
+def labelled_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SESSION_ID", "sess-demo")
+    monkeypatch.setattr(settings, "TENANT_ID", "tenant-demo")
+
+
+def make_record(message: str, args: object = ()) -> logging.LogRecord:
+    return logging.LogRecord(
+        name=LOGGER_NAME,
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=args,
+        exc_info=None,
+    )
+
+
+def test_a_record_carries_the_sandbox_labels(
+    labelled_sandbox: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Session and tenant must be searchable, so they ride on the record itself."""
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        log.info("something happened")
+
+    record = caplog.records[-1]
+    assert record.session_id == "sess-demo"
+    assert record.tenant_id == "tenant-demo"
+
+
+def test_an_unlabelled_sandbox_still_formats(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Both labels are optional in the contract, and a blank field reads as a bug downstream."""
+    monkeypatch.setattr(settings, "SESSION_ID", "")
+    monkeypatch.setattr(settings, "TENANT_ID", "")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        log.info("something happened")
+
+    record = caplog.records[-1]
+    assert record.session_id == UNLABELLED
+    assert record.tenant_id == UNLABELLED
+    assert logging.Formatter(LOG_FORMAT).format(record).count(UNLABELLED) >= 2
+
+
+def test_labels_are_read_when_the_record_is_made(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The adapter is built at import, long before the sandbox labels are known."""
+    monkeypatch.setattr(settings, "SESSION_ID", "sess-late")
+    monkeypatch.setattr(settings, "TENANT_ID", "tenant-late")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        log.info("late binding")
+
+    assert caplog.records[-1].session_id == "sess-late"
+
+
+def test_a_caller_can_override_a_label(labelled_sandbox: None, caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        log.info("explicit", extra={"session_id": "sess-explicit"})
+
+    record = caplog.records[-1]
+    assert record.session_id == "sess-explicit"
+    assert record.tenant_id == "tenant-demo"
+
+
+def test_this_logger_masks_before_any_handler_sees_the_record(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Masking only at the configured handler would leave the value on the record.
+
+    Anything else holding a handler -- a host application, a test's capture, an exporter added
+    later -- reads the record, not the line this module's handler printed.
+    """
+    monkeypatch.setattr(settings, "RUNTIME_TOKEN", RUNTIME_TOKEN)
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        log.info("conversation_id=%s", f"conversation-{RUNTIME_TOKEN}")
+
+    message = caplog.records[-1].getMessage()
+    assert RUNTIME_TOKEN not in message
+    assert SECRET_PLACEHOLDER in message
+
+
+def test_the_masking_filter_hides_a_credential_in_the_template(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "RUNTIME_TOKEN", RUNTIME_TOKEN)
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    record = make_record(f"token is {RUNTIME_TOKEN}")
+
+    assert SecretMaskingFilter().filter(record) is True
+    assert record.getMessage() == f"token is {SECRET_PLACEHOLDER}"
+
+
+def test_the_masking_filter_hides_a_credential_in_the_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Masking the formatted line instead would run after the handler already has the values."""
+    monkeypatch.setattr(settings, "RUNTIME_TOKEN", RUNTIME_TOKEN)
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    record = make_record("token is %s and count is %s", (RUNTIME_TOKEN, 3))
+
+    SecretMaskingFilter().filter(record)
+
+    assert record.getMessage() == f"token is {SECRET_PLACEHOLDER} and count is 3"
+
+
+def test_a_foreign_record_gets_the_labels_it_lacks(labelled_sandbox: None) -> None:
+    """Uvicorn's records never pass through the adapter, and the formatter needs both fields."""
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="GET /health 200",
+        args=(),
+        exc_info=None,
+    )
+
+    assert SandboxLabelFilter().filter(record) is True
+    assert logging.Formatter(LOG_FORMAT).format(record).endswith("GET /health 200")
+    assert record.session_id == "sess-demo"
+
+
+def test_configuring_twice_does_not_duplicate_output() -> None:
+    """A repeated call must replace its own handler, and leave the host application's alone."""
+    root = logging.getLogger()
+    foreign = logging.NullHandler()
+    original_handlers = list(root.handlers)
+    original_level = root.level
+    root.addHandler(foreign)
+    try:
+        configure_logging()
+        after_first = list(root.handlers)
+        configure_logging()
+        after_second = list(root.handlers)
+
+        assert len(after_second) == len(after_first)
+        assert foreign in after_second
+        assert sum(handler.name == LOGGER_NAME for handler in after_second) == 1
+    finally:
+        root.handlers = original_handlers
+        root.setLevel(original_level)
+
+
+def test_uvicorn_logs_are_routed_through_the_masking_handler() -> None:
+    """Uvicorn's own handlers would print an unmasked second copy of every line."""
+    root = logging.getLogger()
+    original_handlers = list(root.handlers)
+    original_level = root.level
+    uvicorn_logger = logging.getLogger("uvicorn.access")
+    original_uvicorn = list(uvicorn_logger.handlers)
+    original_propagate = uvicorn_logger.propagate
+    uvicorn_logger.addHandler(logging.NullHandler())
+    try:
+        configure_logging()
+
+        assert uvicorn_logger.handlers == []
+        assert uvicorn_logger.propagate is True
+    finally:
+        root.handlers = original_handlers
+        root.setLevel(original_level)
+        uvicorn_logger.handlers = original_uvicorn
+        uvicorn_logger.propagate = original_propagate

--- a/app-spark/agent/tests/test_recorder.py
+++ b/app-spark/agent/tests/test_recorder.py
@@ -1,7 +1,5 @@
 """Raw transcript capture: record before compaction, persist when it rewrites history."""
 
-from __future__ import annotations
-
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, cast
@@ -70,9 +68,7 @@ def assistant_turn(content: str) -> ModelResponse:
 
 
 def recorded(log: AppendLog) -> list[ModelMessage]:
-    return ModelMessagesTypeAdapter.validate_python(
-        [record.payload for record in log.read_since(0, 1_000)]
-    )
+    return ModelMessagesTypeAdapter.validate_python([record.payload for record in log.read_since(0, 1_000)])
 
 
 async def test_record_messages_skips_an_empty_sequence(tmp_path: Path) -> None:

--- a/app-spark/agent/tests/test_ui_events.py
+++ b/app-spark/agent/tests/test_ui_events.py
@@ -1,7 +1,5 @@
 """AG-UI event logging: forward the live stream, persist a coalesced replayable copy."""
 
-from __future__ import annotations
-
 from collections.abc import AsyncIterator, Sequence
 from pathlib import Path
 


### PR DESCRIPTION
- extract error handlers into server.errors with credential masking for HTTP error bodies
- add masking module that replaces configured credential values in logs, stored events, and error responses
- add observability module with sandbox labels and secret masking on all log records
- log run start and stream close with run_id
- configure uvicorn logging to use the root masked handler
- read APP_PORT, SESSION_ID, TENANT_ID, MODEL_NAME, and MODEL_BASE_URL settings
- remove `from __future__ import annotations` where runtime annotation reads are needed