### PR TITLE
feat: add gateway client and session middleware --story=137664841

### DIFF
--- a/app-spark/agent/AGENTS.md
+++ b/app-spark/agent/AGENTS.md
@@ -12,6 +12,9 @@ After editing Python files, run `uv run ruff format {filename}` and `uv run mypy
 
 * For Python files, follow PEP-8.
 * Do not introduce Django. HTTP is FastAPI.
+* Python comments and docstrings are not rendered. Write identifiers as-is
+  (`fake_model.py`); do not wrap them in RST/Markdown double backticks
+  (``fake_model.py``).
 
 ## Spike vs formal work
 

--- a/app-spark/agent/README.md
+++ b/app-spark/agent/README.md
@@ -24,7 +24,7 @@ uv sync
 | 变量 | 必需 | 说明 |
 |------|------|------|
 | `APP_SPARK_AGENT_RUNTIME_TOKEN` | 是 | 所有 HTTP 接口的 Bearer（含 `GET /health`、`POST /runs`、控制面） |
-| `APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN` | 调用真实模型时是 | 用户态 access_token。app-spark 创建 bkaidev 空间和单个智能体后注入；出站只放进 `X-Bkapi-Authorization`。`fake:*` 不需要 |
+| `APP_SPARK_AGENT_BK_AIDEV_ACCESS_TOKEN` | 调用真实模型时是 | 用户态 access_token。app-spark 创建 bkaidev 空间和单个智能体后注入；出站只放进 `X-Bkapi-Authorization`。`fake:*` 不需要 |
 | `APP_SPARK_AGENT_MODEL_API_KEY` | 调用真实模型时是 | 兼容回落。未注入上面的 token 时当作 access_token 用。`fake:*` 不需要 |
 | `APP_SPARK_AGENT_MODEL_NAME` | 调用真实模型时是 | 不带 vendor 前缀，必须落在对照表（本期 `deepseek-v4-flash`） |
 | `APP_SPARK_AGENT_MODEL_BASE_URL` | 调用真实模型时是 | bkaidev LLM 网关 v1 入口，不要带 `/chat/completions` |
@@ -39,7 +39,7 @@ uv sync
 | `APP_SPARK_AGENT_MODEL` | 否 | 缺省 `deepseek:deepseek-v4-flash` |
 
 就绪门闩：`fake:*` 直接就绪；真实模型要 access_token 非空 **且** `MODEL_BASE_URL` 非空 **且** `MODEL_NAME` 在对照表。
-access_token 取值：`APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN` → `APP_SPARK_AGENT_MODEL_API_KEY`。
+access_token 取值：`APP_SPARK_AGENT_BK_AIDEV_ACCESS_TOKEN` → `APP_SPARK_AGENT_MODEL_API_KEY`。
 bkaidev 鉴权是 `X-Bkapi-Authorization: {"access_token":"..."}`，不是 `Authorization: Bearer`。
 沙箱不注入 `bk_app_code` / `bk_app_secret`。
 
@@ -47,7 +47,7 @@ bkaidev 鉴权是 `X-Bkapi-Authorization: {"access_token":"..."}`，不是 `Auth
 
 ```bash
 export APP_SPARK_AGENT_RUNTIME_TOKEN=replace-me
-export APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN=replace-me
+export APP_SPARK_AGENT_BK_AIDEV_ACCESS_TOKEN=replace-me
 export APP_SPARK_AGENT_MODEL_NAME=deepseek-v4-flash
 export APP_SPARK_AGENT_MODEL_BASE_URL=https://bkaidev.apigw.example.com/prod/openapi/aidev/gateway/llm/v1
 export APP_SPARK_AGENT_WORKSPACE=/tmp/app-spark-workspace
@@ -192,7 +192,7 @@ curl -sS -N -H "Authorization: Bearer ${APP_SPARK_AGENT_RUNTIME_TOKEN}" \
 make docker-build
 docker run --rm -p 8090:8090 \
   -e APP_SPARK_AGENT_RUNTIME_TOKEN=replace-me \
-  -e APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN=replace-me \
+  -e APP_SPARK_AGENT_BK_AIDEV_ACCESS_TOKEN=replace-me \
   -e APP_SPARK_AGENT_MODEL_NAME=deepseek-v4-flash \
   -e APP_SPARK_AGENT_MODEL_BASE_URL=https://bkaidev.apigw.example.com/prod/openapi/aidev/gateway/llm/v1 \
   app-spark-agent:dev
@@ -227,7 +227,7 @@ make test
 都走 HTTP。设置好有效配置后：
 
 ```bash
-export APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN=replace-me
+export APP_SPARK_AGENT_BK_AIDEV_ACCESS_TOKEN=replace-me
 export APP_SPARK_AGENT_MODEL_NAME=deepseek-v4-flash
 export APP_SPARK_AGENT_MODEL_BASE_URL=https://bkaidev.apigw.example.com/prod/openapi/aidev/gateway/llm/v1
 export APP_SPARK_AGENT_RUNTIME_TOKEN=replace-me

--- a/app-spark/agent/README.md
+++ b/app-spark/agent/README.md
@@ -24,9 +24,10 @@ uv sync
 | 变量 | 必需 | 说明 |
 |------|------|------|
 | `APP_SPARK_AGENT_RUNTIME_TOKEN` | 是 | 所有 HTTP 接口的 Bearer（含 `GET /health`、`POST /runs`、控制面） |
-| `APP_SPARK_AGENT_MODEL_API_KEY` | 调用真实模型时是 | 模型密钥。真实模型缺失时 `model_ready=false`，`POST /runs` 返回 503；`fake:*` 不需要 |
-| `APP_SPARK_AGENT_MODEL_NAME` | 是 | 不带 vendor 前缀。当前只读入，尚未用于构造模型客户端 |
-| `APP_SPARK_AGENT_MODEL_BASE_URL` | 是 | 自研网关 OpenAI 兼容入口。同上，当前只读入 |
+| `APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN` | 调用真实模型时是 | 用户态 access_token。app-spark 创建 bkaidev 空间和单个智能体后注入；出站只放进 `X-Bkapi-Authorization`。`fake:*` 不需要 |
+| `APP_SPARK_AGENT_MODEL_API_KEY` | 调用真实模型时是 | 兼容回落。未注入上面的 token 时当作 access_token 用。`fake:*` 不需要 |
+| `APP_SPARK_AGENT_MODEL_NAME` | 调用真实模型时是 | 不带 vendor 前缀，必须落在对照表（本期 `deepseek-v4-flash`） |
+| `APP_SPARK_AGENT_MODEL_BASE_URL` | 调用真实模型时是 | bkaidev LLM 网关 v1 入口，不要带 `/chat/completions` |
 | `APP_SPARK_AGENT_APP_PORT` | 是 | 用户应用约定端口，锁定 `8000`；本组件只读入，不拉起应用也不校验 |
 | `APP_SPARK_AGENT_PORT` | 否 | 监听端口，缺省 `8090` |
 | `APP_SPARK_AGENT_IDLE_TIMEOUT_SECONDS` | 否 | 空闲秒数，从进程启动起算，每次 `POST /runs` 结束后重置；从未收到 `/runs` 也会到期退出。缺省 `1800`，到期以退出码 0 退出。`GET /health` 不续命。`<= 0` 关闭空闲退出 |
@@ -34,22 +35,27 @@ uv sync
 | `APP_SPARK_AGENT_TENANT_ID` | 否 | 只进日志与指标，不做业务分支 |
 | `APP_SPARK_AGENT_WORKSPACE` | 本地是；容器缺省 `/data/workspace` | Agent 工具可见目录 |
 | `APP_SPARK_AGENT_STATE_DIR` | 本地是；容器缺省 `/data/state` | 必须在 workspace 外 |
+| `APP_SPARK_AGENT_APP_LOG_PATH` | 否 | 本会话约定应用日志，缺省 `/data/app.log`。必须在 workspace / state 外；日志工具只读这一条 |
 | `APP_SPARK_AGENT_MODEL` | 否 | 缺省 `deepseek:deepseek-v4-flash` |
 
-模型凭据取值顺序：`APP_SPARK_AGENT_MODEL_API_KEY` → provider 自有环境变量。
-只注入契约键即可启动并调通。
+就绪门闩：`fake:*` 直接就绪；真实模型要 access_token 非空 **且** `MODEL_BASE_URL` 非空 **且** `MODEL_NAME` 在对照表。
+access_token 取值：`APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN` → `APP_SPARK_AGENT_MODEL_API_KEY`。
+bkaidev 鉴权是 `X-Bkapi-Authorization: {"access_token":"..."}`，不是 `Authorization: Bearer`。
+沙箱不注入 `bk_app_code` / `bk_app_secret`。
 
 示例：
 
 ```bash
 export APP_SPARK_AGENT_RUNTIME_TOKEN=replace-me
-export APP_SPARK_AGENT_MODEL_API_KEY=replace-me
+export APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN=replace-me
+export APP_SPARK_AGENT_MODEL_NAME=deepseek-v4-flash
+export APP_SPARK_AGENT_MODEL_BASE_URL=https://bkaidev.apigw.example.com/prod/openapi/aidev/gateway/llm/v1
 export APP_SPARK_AGENT_WORKSPACE=/tmp/app-spark-workspace
 export APP_SPARK_AGENT_STATE_DIR=/tmp/app-spark-state
 make run
 ```
 
-其余压缩策略、游标 limit 等配置见 `app_spark_agent/settings.py`（`APP_SPARK_AGENT_*`，`.env` 也会自动读取）。
+其余压缩策略、游标 limit 等配置见 `app_spark_agent/settings.py`（`APP_SPARK_AGENT_*`）。
 
 ## 假模型
 
@@ -151,6 +157,10 @@ curl -sS -N -H "Authorization: Bearer ${APP_SPARK_AGENT_RUNTIME_TOKEN}" \
 - `context_version` 不等于轮次：一轮里压缩触发几次就提交几次，控制面不要假设两者同步。
 - `SummarizingCompaction` 是一次不可重放的真实 LLM 调用，冷启动重建上下文的唯一来源是
   `context.json`，绝不能从 `log.jsonl` 拼出来。
+- bkaidev 对话中间层（`app_spark_agent/bkaidev/session.py`）只从 `context.json` 取发给
+  网关的历史，并读取三份游标；不改写 context，也不往 transcript 写 OpenAI 原始报文。
+- `read_app_log` 只读 `APP_LOG_PATH`（缺省 `/data/app.log`），不接受路径，单次最多尾部
+  8192 字节；文件工具看不见它。
 
 ## 远程持久化
 
@@ -182,7 +192,9 @@ curl -sS -N -H "Authorization: Bearer ${APP_SPARK_AGENT_RUNTIME_TOKEN}" \
 make docker-build
 docker run --rm -p 8090:8090 \
   -e APP_SPARK_AGENT_RUNTIME_TOKEN=replace-me \
-  -e APP_SPARK_AGENT_MODEL_API_KEY=replace-me \
+  -e APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN=replace-me \
+  -e APP_SPARK_AGENT_MODEL_NAME=deepseek-v4-flash \
+  -e APP_SPARK_AGENT_MODEL_BASE_URL=https://bkaidev.apigw.example.com/prod/openapi/aidev/gateway/llm/v1 \
   app-spark-agent:dev
 ```
 
@@ -215,7 +227,9 @@ make test
 都走 HTTP。设置好有效配置后：
 
 ```bash
-export APP_SPARK_AGENT_MODEL_API_KEY=sk-...
+export APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN=replace-me
+export APP_SPARK_AGENT_MODEL_NAME=deepseek-v4-flash
+export APP_SPARK_AGENT_MODEL_BASE_URL=https://bkaidev.apigw.example.com/prod/openapi/aidev/gateway/llm/v1
 export APP_SPARK_AGENT_RUNTIME_TOKEN=replace-me
 uv run pytest tests/e2e -s
 ```

--- a/app-spark/agent/app_spark_agent/agent.py
+++ b/app-spark/agent/app_spark_agent/agent.py
@@ -1,13 +1,20 @@
 """Construction of the workspace-scoped coding agent."""
 
+from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any, Protocol, cast
 
+import httpx2
+from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import AbstractCapability
-from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.messages import ModelMessage, ToolCallPart
 from pydantic_ai.models import Model, infer_model
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.profiles.openai import OpenAIModelProfile
 from pydantic_ai.providers import Provider, infer_provider_class
+from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai_harness import (
     ClampOversizedMessages,
     ClearToolResults,
@@ -21,6 +28,12 @@ from pydantic_ai_harness.repo_context import RepoContext
 from pydantic_ai_harness.shell import LLM_API_KEY_ENV_PATTERNS
 
 from app_spark_agent import settings
+from app_spark_agent.app_log import AppLogReader, AppLogReadResult
+from app_spark_agent.bkaidev.auth import (
+    OPENAI_API_KEY_PLACEHOLDER,
+    WithoutAuthorization,
+    authorization_headers,
+)
 from app_spark_agent.fake_model import FAKE_MODEL_PREFIX, build_fake_model
 
 
@@ -31,13 +44,69 @@ class ApiKeyProvider(Protocol):
 
 
 def build_model() -> Model:
-    """Build the model named by :data:`app_spark_agent.settings.MODEL`.
+    """Build the chat model the agent will call."""
 
-    A ``fake:`` name is intercepted here rather than handed to ``infer_model``, which only
-    special-cases ``"test"`` and rejects any other unknown provider outright.
-    """
+    # fake: 不发起网络请求。infer_model 只特殊处理 "test"，其它未知前缀会直接拒。
     if settings.MODEL.startswith(FAKE_MODEL_PREFIX):
         return build_fake_model(settings.MODEL.removeprefix(FAKE_MODEL_PREFIX))
+
+    token = settings.gateway_access_token()
+    base_url = settings.MODEL_BASE_URL.strip()
+    model_name = settings.resolved_model_name()
+    profile = settings.openai_capability_profile(model_name)
+
+    # 网关三件套：token + 地址 + 对照表内模型。协议仍是 Chat Completions，鉴权换头。
+    if token and base_url and profile is not None:
+        return _build_gateway_model(model_name, base_url, token, profile=profile)
+
+    # 没有网关意图、只注入了 MODEL_API_KEY：官网 / 单测直连。
+    if settings.uses_direct_provider():
+        return _build_inferred_model()
+
+    # 缺项不推断、也不发往公网；占位模型让进程能起来、/health 能答。
+    return _build_unready_model()
+
+
+def _build_gateway_model(
+    model_name: str,
+    base_url: str,
+    access_token: str,
+    *,
+    profile: OpenAIModelProfile,
+    transport: httpx2.AsyncBaseTransport | None = None,
+) -> OpenAIChatModel:
+    """用 OpenAI 兼容客户端拨 bkaidev。
+
+    api_key 只填占位 empty，过网关靠 X-Bkapi-Authorization。profile 必须由调用方
+    传入（对照表里那份打开了 tools / JSON 输出的档），不能交给 pydantic-ai 按名字
+    猜——表外或保守推断会把工具调用静默关掉，进程看起来正常，模型却调不了工具。
+    """
+    client = AsyncOpenAI(
+        base_url=base_url,
+        api_key=OPENAI_API_KEY_PLACEHOLDER,
+        default_headers=authorization_headers(access_token),
+        http_client=DefaultAsyncHttpxClient(transport=WithoutAuthorization(transport)),
+    )
+    return OpenAIChatModel(
+        model_name,
+        provider=OpenAIProvider(openai_client=client),
+        profile=profile,
+    )
+
+
+async def _unready_stream(_messages: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+    """未就绪占位：被调用说明门闩被绕过了。"""
+    raise RuntimeError("model is not ready: need access_token, MODEL_BASE_URL, and a listed MODEL_NAME")
+    yield ""
+
+
+def _build_unready_model() -> FunctionModel:
+    """让 create_agent 在未就绪时仍能构造，避免进程起不来、/health 答不上。"""
+    return FunctionModel(stream_function=_unready_stream, model_name="unready")
+
+
+def _build_inferred_model() -> Model:
+    """<provider>:<model> 推断路径，单测和官网直连预留。"""
 
     def provider_factory(provider_name: str) -> Provider[Any]:
         provider_class = infer_provider_class(provider_name)
@@ -51,11 +120,11 @@ def build_model() -> Model:
 
 
 def file_read_key(call: ToolCallPart) -> str | None:
-    """Return the path a file-read tool call refers to, or ``None`` for any other call.
+    """Return the path a file-read tool call refers to, or None for any other call.
 
-    ``DeduplicateFileReads`` ships no default because a wrong guess would blank live data, so
-    this maps the harness ``FileSystem`` read tool explicitly. Clamped arguments carry no
-    ``path``, which correctly reads as "not a file read" rather than as a read of nothing.
+    DeduplicateFileReads ships no default because a wrong guess would blank live data, so
+    this maps the harness FileSystem read tool explicitly. Clamped arguments carry no
+    path, which correctly reads as "not a file read" rather than as a read of nothing.
     """
     if call.tool_name != "read_file":
         return None
@@ -69,7 +138,7 @@ def build_compaction() -> TieredCompaction[object]:
     Tiers run cheap-to-expensive and stop as soon as the history fits the target, so the
     summarizing tier -- the only one that spends a model call -- is reached only when blanking
     and deduplicating cannot reclaim enough. Each tier's own trigger is ignored inside
-    ``TieredCompaction``, which drives them directly.
+    TieredCompaction, which drives them directly.
 
     :return: The tiered compaction capability the agent is built with.
     """
@@ -91,20 +160,33 @@ def build_compaction() -> TieredCompaction[object]:
     )
 
 
-def create_agent(workspace: str | Path) -> Agent[None, str]:
-    """Create the coding agent scoped to ``workspace``.
+def create_agent(workspace: str | Path, *, state_dir: Path | None = None) -> Agent[None, str]:
+    """Create the coding agent scoped to workspace.
 
     The harness file tools enforce a workspace root and protect common secrets. Shell commands
     are useful for development but are not an operating-system sandbox, so this runtime must only
-    be used with trusted users and workspaces.
+    be used with trusted users and workspaces. The application log tool reads one path outside
+    both workspace and state_dir.
 
     :param workspace: Existing directory the agent may inspect and modify.
+    :param state_dir: Conversation state directory; the log tool must not point inside it.
     :return: A configured Pydantic AI coding agent.
-    :raises NotADirectoryError: If ``workspace`` is not an existing directory.
+    :raises NotADirectoryError: If workspace is not an existing directory.
     """
     workspace_path = Path(workspace).expanduser().resolve(strict=True)
     if not workspace_path.is_dir():
         raise NotADirectoryError(f"Workspace is not a directory: {workspace_path}")
+
+    resolved_state = state_dir.expanduser().resolve() if state_dir is not None else None
+    reader = AppLogReader(
+        Path(settings.APP_LOG_PATH),
+        workspace=workspace_path,
+        state_dir=resolved_state,
+    )
+
+    def read_app_log() -> AppLogReadResult:
+        """Read this session's application log. The path is not a parameter."""
+        return reader.read()
 
     capabilities: list[AbstractCapability[object]] = [
         FileSystem(root_dir=workspace_path),
@@ -122,4 +204,9 @@ def create_agent(workspace: str | Path) -> Agent[None, str]:
         ),
         build_compaction(),
     ]
-    return Agent(build_model(), instructions=settings.INSTRUCTIONS, capabilities=capabilities)
+    return Agent(
+        build_model(),
+        instructions=settings.INSTRUCTIONS,
+        capabilities=capabilities,
+        tools=[read_app_log],
+    )

--- a/app-spark/agent/app_spark_agent/app_log.py
+++ b/app-spark/agent/app_spark_agent/app_log.py
@@ -1,0 +1,122 @@
+"""受控应用日志读取：只读一条约定文件，不接受路径，单次不超过尾部 8KB。"""
+
+import os
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from app_spark_agent import settings
+from app_spark_agent.masking import mask_text
+
+NO_LOG_MESSAGE = "无日志"
+READ_ERROR_PREFIX = "读取失败"
+
+
+class AppLogReadResult(BaseModel):
+    """日志工具返回给模型的结构，方便按字段消费而不是猜一段纯文本。
+
+    :param status: ok 读到了正文；empty 文件不存在或长度为 0；error 读失败。
+    :param content: 正文，或「无日志」/「读取失败: …」。
+    :param truncated: 是否只保留了文件尾部。
+    :param byte_length: 从文件取出的字节数，保证 <= APP_LOG_MAX_BYTES。
+    """
+
+    status: Literal["ok", "empty", "error"]
+    content: str
+    truncated: bool = False
+    byte_length: int = Field(default=0, ge=0)
+
+
+class AppLogReader:
+    """只读 APP_LOG_PATH。构造时就拒绝落在 workspace / state 里的路径。"""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        max_bytes: int = settings.APP_LOG_MAX_BYTES,
+        workspace: Path | None = None,
+        state_dir: Path | None = None,
+    ) -> None:
+        if max_bytes <= 0:
+            raise ValueError("max_bytes must be positive")
+        self._configured = path.expanduser()
+        self.path = self._configured.resolve()
+        self.max_bytes = max_bytes
+        self._workspace = workspace.expanduser().resolve() if workspace is not None else None
+        self._state_dir = state_dir.expanduser().resolve() if state_dir is not None else None
+        self._reject_if_inside_protected(self.path)
+
+    def read(self) -> AppLogReadResult:
+        """读约定文件的尾部。任何失败都折成结构体，不向上抛。"""
+        try:
+            # 每次读都重新解析：构造后路径被换成软链时，不能沿用当时的目标。
+            resolved = self._configured.resolve()
+            self._reject_if_inside_protected(resolved)
+            if resolved != self.path:
+                return self._error("APP_LOG_PATH resolved to a different file")
+
+            # 缺文件当无日志；存在但不是普通文件才报错。
+            if not self.path.exists() or not self.path.is_file():
+                if self.path.exists() and not self.path.is_file():
+                    return self._error(f"{self.path.name} is not a regular file")
+                return AppLogReadResult(status="empty", content=NO_LOG_MESSAGE)
+
+            size = self.path.stat().st_size
+            if size == 0:
+                return AppLogReadResult(status="empty", content=NO_LOG_MESSAGE)
+
+            truncated = size > self.max_bytes
+            take = min(size, self.max_bytes)
+            raw = self._read_tail(take, truncated)
+        except (OSError, ValueError) as exc:
+            return self._error(str(exc))
+
+        return AppLogReadResult(
+            status="ok",
+            content=mask_text(raw.decode("utf-8", errors="replace")),
+            truncated=truncated,
+            byte_length=len(raw),
+        )
+
+    def _read_tail(self, take: int, truncated: bool) -> bytes:
+        """打开约定路径，读尾部 take 字节。"""
+
+        # resolve 之后、open 之前被换成软链时，O_NOFOLLOW 不跟着走。
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+
+        fd = os.open(self.path, flags)
+        with os.fdopen(fd, "rb") as handle:
+            if truncated:
+                handle.seek(-take, 2)
+            return handle.read(take)
+
+    def _reject_if_inside_protected(self, path: Path) -> None:
+        """拒绝落在 workspace / state 里的路径。"""
+        if self._workspace is not None and _is_inside(path, self._workspace):
+            raise ValueError("APP_LOG_PATH must be outside the workspace")
+
+        if self._state_dir is not None and _is_inside(path, self._state_dir):
+            raise ValueError("APP_LOG_PATH must be outside the state directory")
+
+    def _error(self, reason: str) -> AppLogReadResult:
+        """把失败折成 error 结构体。"""
+        return AppLogReadResult(status="error", content=f"{READ_ERROR_PREFIX}: {reason}")
+
+
+def resolve_app_log_path(*, workspace: Path, state_dir: Path | None = None) -> Path:
+    """把当前配置的约定路径解析成绝对路径，并拒绝落在 workspace / state 内。"""
+    return AppLogReader(
+        Path(settings.APP_LOG_PATH),
+        workspace=workspace,
+        state_dir=state_dir,
+    ).path
+
+
+def _is_inside(path: Path, directory: Path) -> bool:
+    resolved = path.expanduser().resolve()
+    root = directory.expanduser().resolve()
+    return resolved == root or root in resolved.parents

--- a/app-spark/agent/app_spark_agent/app_log.py
+++ b/app-spark/agent/app_spark_agent/app_log.py
@@ -1,4 +1,9 @@
-"""受控应用日志读取：只读一条约定文件，不接受路径，单次不超过尾部 8KB。"""
+"""读用户应用的约定日志。
+
+这里的应用是用户用自然语言编出来、跑在沙箱里的那个服务，不是 Agent 进程。
+只读 APP_LOG_PATH 这一条，不接受路径参数，单次不超过尾部 8KB。
+后续会把该服务的 stdout/stderr 接到同一文件。
+"""
 
 import os
 from pathlib import Path
@@ -29,7 +34,7 @@ class AppLogReadResult(BaseModel):
 
 
 class AppLogReader:
-    """只读 APP_LOG_PATH。构造时就拒绝落在 workspace / state 里的路径。"""
+    """只读用户应用的约定日志文件。构造时就拒绝落在 workspace / state 里的路径。"""
 
     def __init__(
         self,

--- a/app-spark/agent/app_spark_agent/bkaidev/__init__.py
+++ b/app-spark/agent/app_spark_agent/bkaidev/__init__.py
@@ -1,0 +1,33 @@
+"""bkaidev LLM 网关：鉴权、类型化客户端、挂在已有持久化上的对话中间层。"""
+
+from app_spark_agent.bkaidev.auth import (
+    BKAPI_AUTHORIZATION_HEADER,
+    OPENAI_API_KEY_PLACEHOLDER,
+    authorization_headers,
+    authorization_payload,
+)
+from app_spark_agent.bkaidev.client import AidevApiClient, AidevApiError
+from app_spark_agent.bkaidev.session import ConversationSession, SessionCursors
+from app_spark_agent.bkaidev.types import (
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    FunctionTool,
+    ModelList,
+)
+
+__all__ = [
+    "BKAPI_AUTHORIZATION_HEADER",
+    "OPENAI_API_KEY_PLACEHOLDER",
+    "AidevApiClient",
+    "AidevApiError",
+    "ChatCompletionMessage",
+    "ChatCompletionRequest",
+    "ChatCompletionResponse",
+    "ConversationSession",
+    "FunctionTool",
+    "ModelList",
+    "SessionCursors",
+    "authorization_headers",
+    "authorization_payload",
+]

--- a/app-spark/agent/app_spark_agent/bkaidev/auth.py
+++ b/app-spark/agent/app_spark_agent/bkaidev/auth.py
@@ -44,7 +44,7 @@ class WithoutAuthorization(httpx2.AsyncBaseTransport):
     """剥掉 OpenAI SDK 自动加上的 Authorization: Bearer <api_key>。
 
     api_key 必须填占位才能构造客户端，但出站只允许 X-Bkapi-Authorization。
-    OpenAI 1.x 用的是 httpx2，不是项目里其它地方的 httpx。
+    锁定的 openai v3.x 依赖 httpx2；AidevApiClient 用的是 httpx，两个包不能通用。
     """
 
     def __init__(self, wrapped: httpx2.AsyncBaseTransport | None = None) -> None:

--- a/app-spark/agent/app_spark_agent/bkaidev/auth.py
+++ b/app-spark/agent/app_spark_agent/bkaidev/auth.py
@@ -1,0 +1,57 @@
+"""bkaidev 网关鉴权：只允许用户态 access_token。
+
+对话协议与 OpenAI 兼容客户端共用；鉴权不能共用。bkaidev 走
+X-Bkapi-Authorization（JSON 字符串），不是 Authorization: Bearer。
+
+空间和智能体由 app-spark 在接入层创建，本组件只消费注入的 token。
+禁止把 bk_app_code / bk_app_secret 写进请求头或交给模型。
+"""
+
+import json
+
+import httpx2
+
+# 蓝鲸网关公共鉴权头。值为 JSON 字符串，本期只放 access_token。
+BKAPI_AUTHORIZATION_HEADER = "X-Bkapi-Authorization"
+
+# bkaidev 自己的 OpenAI 客户端把 api_key 填成这个占位；真正过网关靠上面那个头。
+OPENAI_API_KEY_PLACEHOLDER = "empty"
+
+
+def authorization_payload(access_token: str) -> dict[str, str]:
+    """构造 X-Bkapi-Authorization 的 JSON 对象，只含 access_token。
+
+    :param access_token: 注入到沙箱的用户态 token。
+    :raises ValueError: token 为空。
+    """
+    token = access_token.strip()
+    if not token:
+        raise ValueError("access_token is required")
+    return {"access_token": token}
+
+
+def authorization_headers(access_token: str) -> dict[str, str]:
+    """返回出站 HTTP 头。JSON 用紧凑分隔符，避免空白差异干扰对照。"""
+    return {
+        BKAPI_AUTHORIZATION_HEADER: json.dumps(
+            authorization_payload(access_token),
+            separators=(",", ":"),
+        )
+    }
+
+
+class WithoutAuthorization(httpx2.AsyncBaseTransport):
+    """剥掉 OpenAI SDK 自动加上的 Authorization: Bearer <api_key>。
+
+    api_key 必须填占位才能构造客户端，但出站只允许 X-Bkapi-Authorization。
+    OpenAI 1.x 用的是 httpx2，不是项目里其它地方的 httpx。
+    """
+
+    def __init__(self, wrapped: httpx2.AsyncBaseTransport | None = None) -> None:
+        self._wrapped = wrapped or httpx2.AsyncHTTPTransport()
+
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+        headers = httpx2.Headers(request.headers)
+        headers.pop("Authorization", None)
+        request.headers = headers
+        return await self._wrapped.handle_async_request(request)

--- a/app-spark/agent/app_spark_agent/bkaidev/client.py
+++ b/app-spark/agent/app_spark_agent/bkaidev/client.py
@@ -1,0 +1,102 @@
+"""bkaidev LLM 网关的类型化 HTTP 客户端。
+
+只调本期需要的两条 OpenAPI 资源：GET {BASE_URL}/models，以及
+POST {BASE_URL}/chat/completions。鉴权只用用户态 access_token。
+空间 / 智能体的创建不在本组件。
+"""
+
+from typing import Self
+
+import httpx
+from pydantic import ValidationError
+
+from app_spark_agent import settings
+from app_spark_agent.bkaidev.auth import authorization_headers
+from app_spark_agent.bkaidev.types import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ErrorResponse,
+    ModelList,
+)
+
+
+class AidevApiError(RuntimeError):
+    """网关返回了非 2xx。status_code 留给调用方区分 4xx / 5xx。"""
+
+    def __init__(self, status_code: int, message: str, body: str = "") -> None:
+        self.status_code = status_code
+        self.body = body
+        super().__init__(f"bkaidev gateway {status_code}: {message}")
+
+
+class AidevApiClient:
+    """对 MODEL_BASE_URL 指向的 LLM 网关发 OpenAI 兼容请求。
+
+    :param base_url: v1 层地址，不要带 /chat/completions。
+    :param access_token: 用户态 token，只进 X-Bkapi-Authorization。
+    :param timeout: 单次请求超时秒数。
+    :param transport: 测试注入的 httpx transport。
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        access_token: str,
+        timeout: float = 60.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._client = httpx.AsyncClient(
+            base_url=self.base_url,
+            headers=authorization_headers(access_token),
+            timeout=timeout,
+            transport=transport,
+        )
+
+    @classmethod
+    def from_settings(cls) -> AidevApiClient:
+        """用当前进程注入的 token 和网关地址构造客户端。"""
+        token = settings.gateway_access_token()
+        if token is None:
+            raise ValueError("AIDEV_ACCESS_TOKEN or MODEL_API_KEY is required")
+
+        base_url = settings.MODEL_BASE_URL.strip()
+        if not base_url:
+            raise ValueError("MODEL_BASE_URL is required")
+
+        return cls(base_url=base_url, access_token=token)
+
+    async def aclose(self) -> None:
+        """关闭底层 HTTP 连接池。"""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.aclose()
+
+    async def list_models(self) -> ModelList:
+        """GET /models：当前 access_token 能用的 llm_code 列表。"""
+        response = await self._client.get("/models")
+        return ModelList.model_validate(self._json(response))
+
+    async def create_chat_completion(self, request: ChatCompletionRequest) -> ChatCompletionResponse:
+        """POST /chat/completions：一次非流式对话。"""
+        payload = request.model_dump(mode="json", exclude_none=True, by_alias=True)
+        response = await self._client.post("/chat/completions", json=payload)
+        return ChatCompletionResponse.model_validate(self._json(response))
+
+    def _json(self, response: httpx.Response) -> object:
+        """把响应校验成 JSON；非 2xx 抽错误信息，正文不含鉴权头。"""
+        if response.is_success:
+            return response.json()
+
+        try:
+            parsed = ErrorResponse.model_validate_json(response.text)
+        except ValidationError, ValueError:
+            message = response.text or response.reason_phrase
+        else:
+            message = parsed.error.message
+        raise AidevApiError(response.status_code, message, body=response.text)

--- a/app-spark/agent/app_spark_agent/bkaidev/client.py
+++ b/app-spark/agent/app_spark_agent/bkaidev/client.py
@@ -55,11 +55,11 @@ class AidevApiClient:
         )
 
     @classmethod
-    def from_settings(cls) -> AidevApiClient:
+    def from_settings(cls) -> "AidevApiClient":
         """用当前进程注入的 token 和网关地址构造客户端。"""
         token = settings.gateway_access_token()
         if token is None:
-            raise ValueError("AIDEV_ACCESS_TOKEN or MODEL_API_KEY is required")
+            raise ValueError("BK_AIDEV_ACCESS_TOKEN or MODEL_API_KEY is required")
 
         base_url = settings.MODEL_BASE_URL.strip()
         if not base_url:

--- a/app-spark/agent/app_spark_agent/bkaidev/messages.py
+++ b/app-spark/agent/app_spark_agent/bkaidev/messages.py
@@ -1,0 +1,111 @@
+"""把 Runtime 可信历史（pydantic-ai ModelMessage）转成网关 messages。
+
+context.json 存的是压缩后仍会发给模型的历史，不能从 log.jsonl 拼回来。
+本模块只做协议映射，不读写磁盘。
+"""
+
+from collections.abc import Sequence
+
+from pydantic_ai import ModelMessage
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    RetryPromptPart,
+    SystemPromptPart,
+    TextPart,
+    ThinkingPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from app_spark_agent.bkaidev.types import ChatCompletionMessage, ChatMessageToolCall, FunctionCall
+
+
+def openai_messages_from_model_messages(
+    messages: Sequence[ModelMessage],
+) -> list[ChatCompletionMessage]:
+    """把 ConversationContext.messages 转成 Chat Completions 的 messages。"""
+    converted: list[ChatCompletionMessage] = []
+    for message in messages:
+        if isinstance(message, ModelRequest):
+            converted.extend(_from_request(message))
+        elif isinstance(message, ModelResponse):
+            converted.append(_from_response(message))
+    return converted
+
+
+def _from_request(message: ModelRequest) -> list[ChatCompletionMessage]:
+    converted: list[ChatCompletionMessage] = []
+    for part in message.parts:
+        if isinstance(part, SystemPromptPart):
+            converted.append(ChatCompletionMessage(role="system", content=_text(part.content)))
+        elif isinstance(part, UserPromptPart):
+            converted.append(ChatCompletionMessage(role="user", content=_text(part.content)))
+        elif isinstance(part, ToolReturnPart):
+            converted.append(
+                ChatCompletionMessage(
+                    role="tool",
+                    content=_text(part.content),
+                    tool_call_id=part.tool_call_id,
+                    name=part.tool_name,
+                )
+            )
+        elif isinstance(part, RetryPromptPart):
+            converted.append(_from_retry(part))
+        else:
+            raise TypeError(f"unsupported model request part: {type(part).__name__}")
+    return converted
+
+
+def _from_retry(part: RetryPromptPart) -> ChatCompletionMessage:
+    """工具校验失败必须回一条配对的 role=tool，否则网关会 400。"""
+    if part.tool_name:
+        return ChatCompletionMessage(
+            role="tool",
+            content=part.model_response(),
+            tool_call_id=part.tool_call_id,
+            name=part.tool_name,
+        )
+    return ChatCompletionMessage(role="user", content=part.model_response())
+
+
+def _from_response(message: ModelResponse) -> ChatCompletionMessage:
+    """把一条模型回复折成网关的一条 role=assistant。
+
+    pydantic-ai 把回复拆成多种 part：TextPart 是给用户看的正文，
+    ThinkingPart 是思考链，ToolCallPart 是要执行的函数。Chat Completions
+    没有「一条回复拆成多条 message」的写法，只能塞进同一条 assistant：正文进
+    content，思考进 reasoning_content，函数调用进 tool_calls。
+    不认识的 part 直接报错，避免历史被悄悄丢掉、下一轮对不齐。
+    """
+    texts: list[str] = []
+    thinking: list[str] = []
+    tool_calls: list[ChatMessageToolCall] = []
+    for part in message.parts:
+        if isinstance(part, TextPart):
+            texts.append(part.content)
+        elif isinstance(part, ThinkingPart):
+            thinking.append(part.content)
+        elif isinstance(part, ToolCallPart):
+            tool_calls.append(
+                ChatMessageToolCall(
+                    tool_call_id=part.tool_call_id,
+                    function=FunctionCall(
+                        name=part.tool_name,
+                        arguments=part.args_as_json_str(),
+                    ),
+                )
+            )
+        else:
+            raise TypeError(f"unsupported model response part: {type(part).__name__}")
+    return ChatCompletionMessage(
+        role="assistant",
+        content="".join(texts) or None,
+        tool_calls=tool_calls or None,
+        reasoning_content="".join(thinking) or None,
+    )
+
+
+def _text(content: object) -> str:
+    return content if isinstance(content, str) else str(content)

--- a/app-spark/agent/app_spark_agent/bkaidev/session.py
+++ b/app-spark/agent/app_spark_agent/bkaidev/session.py
@@ -1,0 +1,94 @@
+"""对话中间层：用已有三份持久化，经 AidevApiClient 调 bkaidev。
+
+磁盘契约不变，文件名也不是配置项。context.json 是发给模型的可信历史
+（ContextStore），压缩会整体替换它。log.jsonl 是原始对话记录（AppendLog，
+payload_key=message）。ui_events.jsonl 是客户端看到的 AG-UI 事件（AppendLog，
+payload_key=event）。
+
+本层只读这三份来定位会话，不改写 context.json（压缩后的权威历史仍由
+Agent / TranscriptRecorder 提交），也不往 log.jsonl 写 OpenAI 原始报文——
+transcript 的 payload 形状是 pydantic-ai ModelMessage。
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from app_spark_agent import settings
+from app_spark_agent.bkaidev.client import AidevApiClient
+from app_spark_agent.bkaidev.messages import openai_messages_from_model_messages
+from app_spark_agent.bkaidev.types import (
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    FunctionTool,
+)
+from app_spark_agent.state import AppendLog, ContextStore, ConversationContext
+
+
+@dataclass(frozen=True)
+class SessionCursors:
+    """三份持久化当前能读到的游标，和 GET /health 对齐。"""
+
+    conversation_id: str | None
+    context_version: int
+    log_seq: int
+    ui_event_seq: int
+
+
+@dataclass(frozen=True)
+class ConversationSession:
+    """把一次网关调用接到当前 Runtime 的会话状态上。
+
+    :param client: 已带好 access_token 的网关客户端。
+    :param context_store: context.json。
+    :param transcript: log.jsonl。
+    :param ui_events: ui_events.jsonl。
+    """
+
+    client: AidevApiClient
+    context_store: ContextStore
+    transcript: AppendLog
+    ui_events: AppendLog
+
+    @property
+    def context(self) -> ConversationContext:
+        """当前已提交的可信历史。"""
+        return self.context_store.context
+
+    @property
+    def cursors(self) -> SessionCursors:
+        """三份持久化当前的游标，供控制面或排障对照 health。"""
+        context = self.context
+        return SessionCursors(
+            conversation_id=context.conversation_id,
+            context_version=context.context_version,
+            log_seq=self.transcript.last_seq,
+            ui_event_seq=self.ui_events.last_seq,
+        )
+
+    def history(self) -> list[ChatCompletionMessage]:
+        """从 context.json 取出将发给网关的消息，不读 log.jsonl。"""
+        return openai_messages_from_model_messages(self.context.messages)
+
+    async def create_completion(
+        self,
+        extra_messages: Sequence[ChatCompletionMessage] = (),
+        *,
+        model: str | None = None,
+        tools: Sequence[FunctionTool] | None = None,
+        temperature: float | None = None,
+    ) -> ChatCompletionResponse:
+        """用可信历史加上本轮增量，发一次非流式 chat/completions。
+
+        :param extra_messages: 尚未写入 context 的本轮消息（通常是最新 user）。
+        :param model: 覆盖 MODEL_NAME；默认用对照表里的注入名。
+        :param tools: 本轮可供调用的函数。
+        :param temperature: 覆盖协议默认温度。
+        """
+        request = ChatCompletionRequest(
+            model=model or settings.resolved_model_name(),
+            messages=[*self.history(), *extra_messages],
+            tools=list(tools) if tools is not None else None,
+            temperature=temperature,
+        )
+        return await self.client.create_chat_completion(request)

--- a/app-spark/agent/app_spark_agent/bkaidev/types.py
+++ b/app-spark/agent/app_spark_agent/bkaidev/types.py
@@ -1,0 +1,270 @@
+"""bkaidev LLM 网关 OpenAPI 结构体。
+
+字段对齐 bk-aidev 的 aidev_gateway/protocols/openai.py，以及网关资源
+POST {BASE_URL}/chat/completions（aidev_llm_gateway_chat_completion）和
+GET {BASE_URL}/models（aidev_llm_gateway_models）。
+
+BASE_URL 注入到 v1 层，例如
+https://bkaidev.apigw.example.com/prod/openapi/aidev/gateway/llm/v1。
+网关 resources.yaml 不展开请求体，所以字段以协议层为准。
+
+Python 属性避开 id / type / object / property 这些内置名，JSON 仍走协议字段。
+"""
+
+from typing import Any, Literal
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+
+
+def _wire(python_name: str, json_name: str, **kwargs: Any) -> Any:
+    """Python 属性避开内置名，出站 / 入站 JSON 仍用协议字段。"""
+    return Field(
+        validation_alias=AliasChoices(python_name, json_name),
+        serialization_alias=json_name,
+        **kwargs,
+    )
+
+
+class FunctionDefinition(BaseModel):
+    """OpenAI function 定义，挂在 tools[].function 上。
+
+    :param name: 函数名，模型回传的 tool_calls[].function.name 用这个。
+    :param description: 给模型看的说明，可空。
+    :param parameters: JSON Schema 对象；网关原样转给上游。
+    """
+
+    name: str
+    description: str | None = None
+    parameters: dict[str, object] | None = None
+
+
+class FunctionTool(BaseModel):
+    """Chat Completions 的 tools 数组元素。本期只发 type=function。"""
+
+    tool_type: Literal["function"] = _wire("tool_type", "type", default="function")
+    function: FunctionDefinition
+
+
+class FunctionCall(BaseModel):
+    """一次已选定的 function 调用。
+
+    :param name: 要调用的函数名。
+    :param arguments: 参数的 JSON 字符串（不是对象），与 OpenAI 一致。
+    """
+
+    name: str
+    arguments: str
+
+
+class ChatMessageToolCall(BaseModel):
+    """assistant 消息里的一条 tool call。
+
+    :param tool_call_id: 本次调用 id，后续 role=tool 的 tool_call_id 必须对上。
+    :param function: 函数名和参数。
+    :param tool_type: 固定 function。
+    """
+
+    tool_call_id: str = _wire("tool_call_id", "id")
+    function: FunctionCall
+    tool_type: Literal["function"] = _wire("tool_type", "type", default="function")
+
+
+class ChatCompletionMessage(BaseModel):
+    """Chat Completions 的一条 messages[] / 响应 choices[].message。
+
+    请求侧常见 role：system / user / assistant / tool。
+    响应侧可能多带 reasoning_content（思考模型）。
+
+    :param role: 说话角色。
+    :param content: 文本正文；纯 tool_calls 时可为 None。
+    :param name: 可选发言者名，OpenAI 兼容字段。
+    :param tool_call_id: role=tool 时对应的 ChatMessageToolCall.tool_call_id。
+    :param tool_calls: assistant 发起的工具调用列表。
+    :param function_call: 旧版单函数调用字段，新路径用 tool_calls。
+    :param reasoning_content: 思考链正文，部分模型会回。
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    role: str
+    content: str | None = None
+    name: str | None = None
+    tool_call_id: str | None = None
+    tool_calls: list[ChatMessageToolCall] | None = None
+    function_call: FunctionCall | None = None
+    reasoning_content: str | None = None
+
+
+class ChatCompletionRequest(BaseModel):
+    """POST /chat/completions 请求体（aidev_llm_gateway_chat_completion）。
+
+    网关 extra="allow"，未列字段原样转发。本期不用流式：流式由 pydantic-ai
+    的 OpenAI 客户端走同一地址。
+
+    :param model: llm_code，必须与 GET /models 返回的 llm_code 一致。
+    :param messages: 对话消息，含历史与本轮增量。
+    :param temperature: 采样温度，协议默认 0.7。
+    :param top_p: nucleus sampling。
+    :param n: 生成几条 completion。
+    :param max_tokens: 生成上限；不设则走上游默认。
+    :param stop: 停止序列。
+    :param stream: 是否 SSE 流式。ApiClient 默认 False。
+    :param presence_penalty: 话题新鲜度惩罚。
+    :param frequency_penalty: 重复惩罚。
+    :param response_format: 结构化输出约定，字符串或 {"type": ...}。
+    :param user: 调用方用户标识，网关不校验用户认证，此字段仅透传。
+    :param tools: 可供模型调用的函数列表。
+    :param tool_choice: none / auto / required，或指定某个 function。
+    :param parallel_tool_calls: 是否允许并行 tool calls。
+    :param functions: 旧版 functions 字段，优先用 tools。
+    :param function_call: 旧版 function_call 字段，优先用 tool_choice。
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str
+    messages: list[ChatCompletionMessage]
+    temperature: float | None = 0.7
+    top_p: float | None = 1.0
+    n: int | None = 1
+    max_tokens: int | None = None
+    stop: str | list[str] | None = None
+    stream: bool | None = False
+    presence_penalty: float | None = 0.0
+    frequency_penalty: float | None = 0.0
+    response_format: str | dict[str, Any] | None = None
+    user: str | None = None
+    tools: list[FunctionTool] | None = None
+    tool_choice: Literal["none", "auto", "required"] | dict[str, Any] | None = None
+    parallel_tool_calls: bool | None = None
+    functions: list[FunctionDefinition] | None = None
+    function_call: Literal["none", "auto"] | dict[str, Any] | None = None
+
+
+class PromptTokensDetails(BaseModel):
+    """prompt 侧的细项用量，含缓存命中。"""
+
+    audio_tokens: int | None = None
+    cached_tokens: int | None = None
+    cache_write_tokens: int | None = None
+
+
+class UsageInfo(BaseModel):
+    """一次 completion 的 token 用量。
+
+    :param prompt_tokens: 输入 token。
+    :param total_tokens: 输入 + 输出。
+    :param completion_tokens: 输出 token。
+    :param prompt_tokens_details: 缓存等细项。
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    prompt_tokens: int = 0
+    total_tokens: int = 0
+    completion_tokens: int | None = 0
+    prompt_tokens_details: PromptTokensDetails | None = None
+
+
+class ChatCompletionResponseChoice(BaseModel):
+    """非流式响应的一条 choice。
+
+    :param index: 在 choices 中的位置。
+    :param message: 模型回复（文本和/或 tool_calls）。
+    :param finish_reason: stop / length / content_filter /
+        tool_calls / function_call。
+    """
+
+    index: int
+    message: ChatCompletionMessage
+    finish_reason: Literal["stop", "length", "content_filter", "tool_calls", "function_call"]
+
+
+class ChatCompletionResponse(BaseModel):
+    """POST /chat/completions 非流式响应。
+
+    :param completion_id: 网关生成的 completion id，形如 chatcmpl-...。
+    :param object_type: 固定 chat.completion。
+    :param created: Unix 秒。
+    :param model: 实际使用的 llm_code。
+    :param choices: 生成结果；n=1 时通常只有一条。
+    :param usage: token 用量。
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    completion_id: str = _wire("completion_id", "id")
+    object_type: str = _wire("object_type", "object", default="chat.completion")
+    created: int
+    model: str
+    choices: list[ChatCompletionResponseChoice]
+    usage: UsageInfo
+
+
+class ModelPermission(BaseModel):
+    """GET /models 里一张模型卡上的权限描述，OpenAI 兼容字段。"""
+
+    model_config = ConfigDict(extra="allow")
+
+    permission_id: str = _wire("permission_id", "id")
+    object_type: str = _wire("object_type", "object", default="model_permission")
+    created: int
+    allow_create_engine: bool = False
+    allow_sampling: bool = True
+    allow_logprobs: bool = True
+    allow_search_indices: bool = True
+    allow_view: bool = True
+    allow_fine_tuning: bool = False
+    organization: str = "*"
+    group: str | None = None
+    is_blocking: bool = False
+
+
+class ModelCard(BaseModel):
+    """一张可用模型。
+
+    :param llm_code: 应对 MODEL_NAME / 请求里的 model。
+    :param object_type: 固定 model。
+    :param created: Unix 秒。
+    :param owned_by: 协议默认 aidev。
+    :param root: 根模型 id，可空。
+    :param parent: 父模型 id，可空。
+    :param permission: 权限列表。
+    :param extra_properties: 网关扩展属性，JSON 字段仍是 property。
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    llm_code: str = _wire("llm_code", "id")
+    object_type: str = _wire("object_type", "object", default="model")
+    created: int
+    owned_by: str = "aidev"
+    root: str | None = None
+    parent: str | None = None
+    permission: list[ModelPermission] = Field(default_factory=list)
+    extra_properties: dict[str, Any] | None = _wire("extra_properties", "property", default=None)
+
+
+class ModelList(BaseModel):
+    """GET /models 响应（aidev_llm_gateway_models）。
+
+    网关按应用身份过滤；未开通的 llm_code 不会出现在 data 里，
+    直接用也会被拒绝为「该应用无访问该模型的权限」。
+    """
+
+    object_type: str = _wire("object_type", "object", default="list")
+    data: list[ModelCard] = Field(default_factory=list)
+
+
+class ErrorResponseDetail(BaseModel):
+    """OpenAI 风格错误体里的 error 对象。"""
+
+    message: str
+    code: int
+    error_type: str = _wire("error_type", "type", default="invalid_request_error")
+
+
+class ErrorResponse(BaseModel):
+    """网关错误响应。"""
+
+    error: ErrorResponseDetail

--- a/app-spark/agent/app_spark_agent/fake_model.py
+++ b/app-spark/agent/app_spark_agent/fake_model.py
@@ -102,9 +102,7 @@ def build_fake_model(scenario: str) -> Model:
     name = scenario or DEFAULT_SCENARIO
     if name not in SCENARIOS:
         supported = ", ".join(SCENARIOS)
-        raise UnknownFakeScenarioError(
-            f"Unknown fake model scenario: {name!r}. Supported scenarios: {supported}."
-        )
+        raise UnknownFakeScenarioError(f"Unknown fake model scenario: {name!r}. Supported scenarios: {supported}.")
 
     async def stream(
         messages: list[ModelMessage],

--- a/app-spark/agent/app_spark_agent/masking.py
+++ b/app-spark/agent/app_spark_agent/masking.py
@@ -51,7 +51,9 @@ def secret_values() -> tuple[str, ...]:
     """
     return _ordered(
         (
+            settings.AIDEV_ACCESS_TOKEN,
             settings.MODEL_API_KEY,
+            settings.CONTROL_PLANE_TOKEN,
             settings.RUNTIME_TOKEN,
         )
     )

--- a/app-spark/agent/app_spark_agent/masking.py
+++ b/app-spark/agent/app_spark_agent/masking.py
@@ -51,7 +51,7 @@ def secret_values() -> tuple[str, ...]:
     """
     return _ordered(
         (
-            settings.AIDEV_ACCESS_TOKEN,
+            settings.BK_AIDEV_ACCESS_TOKEN,
             settings.MODEL_API_KEY,
             settings.CONTROL_PLANE_TOKEN,
             settings.RUNTIME_TOKEN,

--- a/app-spark/agent/app_spark_agent/replication/client.py
+++ b/app-spark/agent/app_spark_agent/replication/client.py
@@ -117,8 +117,7 @@ class ControlPlaneClient:
 
         if response.status_code != HTTPStatus.OK:
             raise ControlPlaneError(
-                f"the control plane answered {path} with {response.status_code}: "
-                f"{response.text[:200]}"
+                f"the control plane answered {path} with {response.status_code}: {response.text[:200]}"
             )
         try:
             payload = response.json()
@@ -136,6 +135,4 @@ def _read_int(payload: dict[str, Any], key: str) -> int:
     try:
         return int(payload[key])
     except (KeyError, TypeError, ValueError) as exc:
-        raise ControlPlaneError(
-            f"unreadable ingest response, {key} is missing or not an integer: {exc}"
-        ) from exc
+        raise ControlPlaneError(f"unreadable ingest response, {key} is missing or not an integer: {exc}") from exc

--- a/app-spark/agent/app_spark_agent/server/asgi.py
+++ b/app-spark/agent/app_spark_agent/server/asgi.py
@@ -4,8 +4,13 @@ The production entry is `python -m app_spark_agent`, which sets
 `timeout_graceful_shutdown`. If you run `uvicorn app_spark_agent.server.asgi:app`
 directly, pass `--timeout-graceful-shutdown` as well, or SIGTERM waits forever
 for in-flight SSE.
+
+configure_logging is idempotent and must run here too: this module is what
+e2e and any external ASGI server import, and they never go through __main__.
 """
 
+from app_spark_agent.observability import configure_logging
 from app_spark_agent.server.app import create_app_from_settings
 
+configure_logging()
 app = create_app_from_settings()

--- a/app-spark/agent/app_spark_agent/server/runtime.py
+++ b/app-spark/agent/app_spark_agent/server/runtime.py
@@ -237,7 +237,7 @@ class ConversationRuntime:
             )
 
         return cls(
-            agent=agent or create_agent(resolved_workspace),
+            agent=agent or create_agent(resolved_workspace, state_dir=resolved_state_dir),
             context_store=context_store,
             transcript=transcript,
             ui_events=ui_events,

--- a/app-spark/agent/app_spark_agent/settings.py
+++ b/app-spark/agent/app_spark_agent/settings.py
@@ -61,15 +61,18 @@ TENANT_ID = env.str("TENANT_ID", "")
 # 真正启动起来，场景清单见 fake_model.py。
 MODEL = env.str("MODEL", "deepseek:deepseek-v4-flash", validate=Length(min=1))
 
-# 模型密钥。官网 Bearer 路径会用它；本期 bkaidev 优先走下面的用户态 access_token。
-# 未注入 AIDEV_ACCESS_TOKEN 时，它被当作 access_token 回落，以免已入库的
-# SPARK_MODEL_API_KEY 立刻失效。
+# 一把钥匙，两条路，不是两套并行生产配置。
+#
+# 网关：未注入 BK_AIDEV_ACCESS_TOKEN 时，把它当作 bkaidev 的 access_token 回落，
+# 以免已入库的 SPARK_MODEL_API_KEY 立刻失效。
+# 直连：没有网关意图时，交给 pydantic-ai 按 MODEL 的 <provider>:<model> 推断，
+# 走官网 Bearer。/runs 只认网关三件套或 fake；只配这把钥匙走直连时 HTTP 仍 503。
 MODEL_API_KEY = env.str("MODEL_API_KEY", "") or None
 
-# 用户态 access_token。app-spark 在 bkaidev 为该沙箱创建空间和单个智能体后，把这个
-# token 注入 Agent 容器。出站只放进 X-Bkapi-Authorization，禁止带
-# bk_app_code / bk_app_secret。本组件不调创建空间 / 智能体的 API。
-AIDEV_ACCESS_TOKEN = env.str("AIDEV_ACCESS_TOKEN", "") or None
+# 用户态 access_token。app-spark 在 bkaidev 建好该沙箱的空间和单个智能体后注入。
+# 出站只放进 X-Bkapi-Authorization 的 access_token 字段，不带 bk_app_code /
+# bk_app_secret。本组件不调创建空间 / 智能体的 API。
+BK_AIDEV_ACCESS_TOKEN = env.str("BK_AIDEV_ACCESS_TOKEN", "") or None
 
 # 不带 vendor 前缀的模型名（如 deepseek-v4-flash），必须落在 MODEL_PROFILES。
 MODEL_NAME = env.str("MODEL_NAME", "")
@@ -207,20 +210,22 @@ def _stripped(value: str | None) -> str | None:
 def gateway_access_token() -> str | None:
     """bkaidev 出站使用的用户态 access_token。
 
-    优先 AIDEV_ACCESS_TOKEN；未注入时回落到 MODEL_API_KEY。
+    优先 BK_AIDEV_ACCESS_TOKEN；未注入时回落到 MODEL_API_KEY。
     两侧都先 strip，空白值不能挡住回落，也不能把就绪门闩打成真。
     """
-    return _stripped(AIDEV_ACCESS_TOKEN) or _stripped(MODEL_API_KEY)
+    return _stripped(BK_AIDEV_ACCESS_TOKEN) or _stripped(MODEL_API_KEY)
 
 
 def uses_direct_provider() -> bool:
     """没有网关意图时，才允许 MODEL_API_KEY 走官网 provider。
 
-    注入了 AIDEV_ACCESS_TOKEN 或 MODEL_BASE_URL 就表示要走 bkaidev，
+    注入了 BK_AIDEV_ACCESS_TOKEN 或 MODEL_BASE_URL 就表示要走 bkaidev，
     缺项不得回落到公网 api.deepseek.com。
     """
     return (
-        _stripped(AIDEV_ACCESS_TOKEN) is None and not MODEL_BASE_URL.strip() and _stripped(MODEL_API_KEY) is not None
+        _stripped(BK_AIDEV_ACCESS_TOKEN) is None
+        and not MODEL_BASE_URL.strip()
+        and _stripped(MODEL_API_KEY) is not None
     )
 
 

--- a/app-spark/agent/app_spark_agent/settings.py
+++ b/app-spark/agent/app_spark_agent/settings.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import hmac
+from pathlib import Path
 
 from environs import Env, EnvError
 from marshmallow.validate import Length, Range
+from pydantic_ai.profiles.openai import OpenAIModelProfile
 
 # 所有配置项共用的环境变量前缀。接入层与本地开发都只下这一套。
 ENV_PREFIX = "APP_SPARK_AGENT_"
@@ -53,26 +55,60 @@ TENANT_ID = env.str("TENANT_ID", "")
 # 模型
 # -----------------------------------------------------------------------
 
-# 对话使用的模型，格式是 pydantic-ai 的 ``<provider>:<model>``。
+# 对话使用的模型，格式是 pydantic-ai 的 <provider>:<model>。
 #
-# 另外支持 ``fake:<scenario>``：一个不发起任何网络请求的确定性假模型，供集成测试把 Runtime
-# 真正启动起来，场景清单见 ``fake_model.py``。
+# 另外支持 fake:<scenario>：一个不发起任何网络请求的确定性假模型，供集成测试把 Runtime
+# 真正启动起来，场景清单见 fake_model.py。
 MODEL = env.str("MODEL", "deepseek:deepseek-v4-flash", validate=Length(min=1))
 
-# 模型密钥，同时交给 provider。缺失时 health 报 model_ready=false，POST /runs 返回 503。
-# 这是唯一的就绪门闩：模型名或网关地址缺失不让 Runtime 报未就绪。
+# 模型密钥。官网 Bearer 路径会用它；本期 bkaidev 优先走下面的用户态 access_token。
+# 未注入 AIDEV_ACCESS_TOKEN 时，它被当作 access_token 回落，以免已入库的
+# SPARK_MODEL_API_KEY 立刻失效。
 MODEL_API_KEY = env.str("MODEL_API_KEY", "") or None
 
-# 网关目标，读入是为了契约落在同一处。当前还不拿它们去拨号：模型客户端仍由
-# ``MODEL`` 与 ``MODEL_API_KEY`` 构造。
+# 用户态 access_token。app-spark 在 bkaidev 为该沙箱创建空间和单个智能体后，把这个
+# token 注入 Agent 容器。出站只放进 X-Bkapi-Authorization，禁止带
+# bk_app_code / bk_app_secret。本组件不调创建空间 / 智能体的 API。
+AIDEV_ACCESS_TOKEN = env.str("AIDEV_ACCESS_TOKEN", "") or None
+
+# 不带 vendor 前缀的模型名（如 deepseek-v4-flash），必须落在 MODEL_PROFILES。
 MODEL_NAME = env.str("MODEL_NAME", "")
+
+# bkaidev LLM 网关 OpenAI 兼容入口，注入到 v1 这一层，不要带 /chat/completions。
+# prod 示例：https://bkaidev.apigw.example.com/prod/openapi/aidev/gateway/llm/v1。
 MODEL_BASE_URL = env.str("MODEL_BASE_URL", "")
 
-# ``fake:slow`` 场景挂起的秒数。它存在的意义是让「run 正在进行中」成为一个能被外部观察到的
+# MODEL_NAME → 能力档。表外名称不得走「按名字猜测」的保守档，否则工具调用会静默关掉。
+# 值是档位标识，不是拼进请求的 vendor 前缀。
+MODEL_PROFILES: dict[str, str] = {
+    "deepseek-v4-flash": "deepseek",
+}
+
+# 对照表内每一档都必须显式打开工具调用和结构化输出，禁止落到 pydantic-ai 的保守推断。
+_TOOL_AND_STRUCTURED_PROFILE = OpenAIModelProfile(
+    supports_tools=True,
+    supports_json_schema_output=True,
+    supports_json_object_output=True,
+    supports_tool_return_schema=True,
+)
+
+# -----------------------------------------------------------------------
+# 应用日志
+# -----------------------------------------------------------------------
+
+# 本会话约定应用日志。位于 workspace / state 之外；日志工具只读这一条，不接受路径参数。
+# 后续会把用户应用 stdout/stderr 接到同一文件。缺省与容器数据盘对齐。
+DEFAULT_APP_LOG_PATH = "/data/app.log"
+APP_LOG_PATH = env.path("APP_LOG_PATH", Path(DEFAULT_APP_LOG_PATH))
+
+# 单次返回正文的字节上限。按需求锁定，不是部署旋钮。
+APP_LOG_MAX_BYTES = 8192
+
+# fake:slow 场景挂起的秒数。它存在的意义是让「run 正在进行中」成为一个能被外部观察到的
 # 稳定状态，从而可以真实地触发 Runtime 的 409，而不是靠 sleep 去猜时序。
 FAKE_DELAY_SECONDS = env.float("FAKE_DELAY_SECONDS", 2.0, validate=Range(min=0))
 
-# Agent 的系统提示词。它和 ``agent.py`` 里挂载的能力是配套的——提示词里提到的「file 工具」
+# Agent 的系统提示词。它和 agent.py 里挂载的能力是配套的——提示词里提到的「file 工具」
 # 「shell 工具」「AGENTS.md」分别对应 FileSystem、Shell、RepoContext 三个能力。
 #
 # TODO：当前仅做调试功能后，后续再调，以及增加更多 SKILL。
@@ -85,7 +121,8 @@ AGENTS.md instructions. Preserve existing user changes and report what changed, 
 verified, and anything that remains blocked.
 
 Use file tools for reading and editing and shell tools for commands. Treat paths as relative to the
-workspace. Never expose credentials or intentionally inspect secret files.
+workspace. Use read_app_log when diagnosing the running application; it has no path argument.
+Never expose credentials or intentionally inspect secret files.
 """.strip()
 
 # -----------------------------------------------------------------------
@@ -100,7 +137,7 @@ workspace. Never expose credentials or intentionally inspect secret files.
 # 用绝对值而不是窗口比例：这样触发点固定在测试能够到的地方，也不会随计价表变动而漂移。
 COMPACTION_TARGET_TOKENS = env.int("COMPACTION_TARGET_TOKENS", 480_000, validate=Range(min=1))
 
-# 单条消息 part 的 token 上限，超过就截断。跑飞的生成表现为**一个**超大 part 而不是总量
+# 单条消息 part 的 token 上限，超过就截断。跑飞的生成表现为一个超大 part 而不是总量
 # 偏大，所以任何基于总量的策略都碰不到它；把超限的部分截掉才能保证下一次请求还发得出去。
 COMPACTION_MAX_PART_TOKENS = env.int("COMPACTION_MAX_PART_TOKENS", 50_000, validate=Range(min=1))
 
@@ -117,7 +154,7 @@ COMPACTION_KEEP_TOOL_RESULT_PAIRS = env.int("COMPACTION_KEEP_TOOL_RESULT_PAIRS",
 # -----------------------------------------------------------------------
 
 # 控制面的会话级状态写入地址，例如
-# ``http://api/api/internal/conversations/<uuid>/state/``。
+# http://api/api/internal/conversations/<uuid>/state/。
 #
 # 留空即关闭回写：此时 Runtime 完全独立，状态只存在于 STATE_DIR，也就是本地开发和单测的形态。
 # 地址由控制面在拉起 Runtime 时给出，且已经带上会话路径，所以 Runtime 自己不需要知道
@@ -138,7 +175,7 @@ PUSH_BATCH_SIZE = env.int("PUSH_BATCH_SIZE", 50, validate=Range(min=1))
 PUSH_RETRY_BACKOFF_SECONDS = env.float("PUSH_RETRY_BACKOFF_SECONDS", 2.0, validate=Range(min=0))
 
 # 一轮 run 结束时等待推送追平的秒数。超时不会让这一轮失败——数据还在本地文件里、后台任务会继续
-# 重试——但 ``/health`` 的复制游标会显示落后。
+# 重试——但 /health 的复制游标会显示落后。
 PUSH_FLUSH_TIMEOUT_SECONDS = env.float("PUSH_FLUSH_TIMEOUT_SECONDS", 30.0, validate=Range(min=0))
 
 if CONTROL_PLANE_URL and not CONTROL_PLANE_TOKEN:
@@ -148,7 +185,7 @@ if CONTROL_PLANE_URL and not CONTROL_PLANE_TOKEN:
 # HTTP 接口
 # -----------------------------------------------------------------------
 
-# 两条日志游标接口 ``limit`` 参数的默认值和上限。
+# 两条日志游标接口 limit 参数的默认值和上限。
 DEFAULT_DRAIN_LIMIT = env.int("DEFAULT_DRAIN_LIMIT", 200, validate=Range(min=1))
 MAX_DRAIN_LIMIT = env.int("MAX_DRAIN_LIMIT", 1_000, validate=Range(min=1))
 
@@ -159,15 +196,62 @@ if DEFAULT_DRAIN_LIMIT > MAX_DRAIN_LIMIT:
     )
 
 
+def _stripped(value: str | None) -> str | None:
+    """空白和未注入都当成没有。"""
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def gateway_access_token() -> str | None:
+    """bkaidev 出站使用的用户态 access_token。
+
+    优先 AIDEV_ACCESS_TOKEN；未注入时回落到 MODEL_API_KEY。
+    两侧都先 strip，空白值不能挡住回落，也不能把就绪门闩打成真。
+    """
+    return _stripped(AIDEV_ACCESS_TOKEN) or _stripped(MODEL_API_KEY)
+
+
+def uses_direct_provider() -> bool:
+    """没有网关意图时，才允许 MODEL_API_KEY 走官网 provider。
+
+    注入了 AIDEV_ACCESS_TOKEN 或 MODEL_BASE_URL 就表示要走 bkaidev，
+    缺项不得回落到公网 api.deepseek.com。
+    """
+    return (
+        _stripped(AIDEV_ACCESS_TOKEN) is None and not MODEL_BASE_URL.strip() and _stripped(MODEL_API_KEY) is not None
+    )
+
+
+def resolved_model_name() -> str:
+    """去掉首尾空白后的 MODEL_NAME。"""
+    return MODEL_NAME.strip()
+
+
+def model_profile(name: str | None = None) -> str | None:
+    """对照表中的能力档；表外名称返回 None，调用方必须当成未就绪。"""
+    return MODEL_PROFILES.get(name if name is not None else resolved_model_name())
+
+
+def openai_capability_profile(name: str | None = None) -> OpenAIModelProfile | None:
+    """列出模型对应的显式 OpenAI 能力档；表外名称返回 None，不得猜测。"""
+    if model_profile(name) is None:
+        return None
+    return _TOOL_AND_STRUCTURED_PROFILE
+
+
 def is_model_ready() -> bool:
-    """模型是否无需外部凭据，或已注入 ``APP_SPARK_AGENT_MODEL_API_KEY``。"""
-    return MODEL.startswith("fake:") or MODEL_API_KEY is not None
+    """fake: 无需凭据；真实模型要 access_token、网关地址、对照表内模型名。"""
+    if MODEL.startswith("fake:"):
+        return True
+    return gateway_access_token() is not None and bool(MODEL_BASE_URL.strip()) and model_profile() is not None
 
 
 def _tokens_match(expected: str, actual: str) -> bool:
     """恒定时间比较；期望值为空时永不匹配。
 
-    先拒绝长度不一致，避免 ``compare_digest`` 把 401 变成 500。
+    先拒绝长度不一致，避免 compare_digest 把 401 变成 500。
     """
     if not expected or not actual or len(expected) != len(actual):
         return False
@@ -175,12 +259,12 @@ def _tokens_match(expected: str, actual: str) -> bool:
 
 
 def matches_runtime_token(token: str) -> bool:
-    """``token`` 是否等于 ``APP_SPARK_AGENT_RUNTIME_TOKEN``。"""
+    """token 是否等于 APP_SPARK_AGENT_RUNTIME_TOKEN。"""
     return _tokens_match(RUNTIME_TOKEN, token)
 
 
 def matches_bearer(authorization: str | None) -> bool:
-    """Authorization 是否为 ``Bearer <APP_SPARK_AGENT_RUNTIME_TOKEN>``。"""
+    """Authorization 是否为 Bearer <APP_SPARK_AGENT_RUNTIME_TOKEN>。"""
     if not authorization:
         return False
     scheme, _, credential = authorization.partition(" ")

--- a/app-spark/agent/app_spark_agent/state/cursors.py
+++ b/app-spark/agent/app_spark_agent/state/cursors.py
@@ -149,9 +149,7 @@ class CursorStore:
         async with self._lock:
             if version <= self._payload.pushed_context_version:
                 return
-            await self._persist(
-                self._payload.model_copy(update={"pushed_context_version": version})
-            )
+            await self._persist(self._payload.model_copy(update={"pushed_context_version": version}))
 
     async def _persist(self, payload: CursorsPayload) -> None:
         try:

--- a/app-spark/agent/app_spark_agent/state/log.py
+++ b/app-spark/agent/app_spark_agent/state/log.py
@@ -145,8 +145,7 @@ class AppendLog:
             raise AppendLogError("base_seq must be a non-negative integer")
         if not self.is_empty:
             raise AppendLogError(
-                f"{self.path.name} already holds entries up to seq {self._last_seq} "
-                "and cannot be rebased"
+                f"{self.path.name} already holds entries up to seq {self._last_seq} and cannot be rebased"
             )
         self._base_seq = base_seq
         self._last_seq = base_seq

--- a/app-spark/agent/tests/api/conftest.py
+++ b/app-spark/agent/tests/api/conftest.py
@@ -25,7 +25,7 @@ def sandbox_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     """Give API tests the sandbox contract a real injection would provide."""
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", RUNTIME_TOKEN)
     monkeypatch.setattr(settings, "MODEL_API_KEY", MODEL_API_KEY)
-    monkeypatch.setattr(settings, "MODEL_NAME", "test-model")
+    monkeypatch.setattr(settings, "MODEL_NAME", "deepseek-v4-flash")
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "https://model-gateway.test/v1")
     monkeypatch.setattr(settings, "APP_PORT", settings.DEFAULT_APP_PORT)
     # A short idle timeout in a developer .env must not os._exit during TestClient.

--- a/app-spark/agent/tests/api/test_app_log.py
+++ b/app-spark/agent/tests/api/test_app_log.py
@@ -1,0 +1,70 @@
+"""POST /runs 必须能按结构消费 read_app_log 的返回。"""
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from app_spark_agent.app_log import NO_LOG_MESSAGE, AppLogReader, AppLogReadResult
+from tests.api.support import ApiFactory, get_transcript_messages, run_turn
+from tests.support.fake_models import log_calling_model
+
+
+def _read_app_log_tool(path: Path):
+    reader = AppLogReader(path)
+
+    def read_app_log() -> AppLogReadResult:
+        """Read this session's application log. The path is not a parameter."""
+        return reader.read()
+
+    return read_app_log
+
+
+def _tool_return_payloads(api: TestClient) -> list[object]:
+    payloads: list[object] = []
+    for message in get_transcript_messages(api):
+        for part in message["parts"]:
+            if part.get("part_kind") == "tool-return":
+                payloads.append(part.get("content"))
+    return payloads
+
+
+def _as_result(payload: object) -> dict[str, object]:
+    parsed: object = payload
+    if isinstance(parsed, str):
+        parsed = json.loads(parsed)
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_a_run_consumes_a_structured_app_log_result(make_api: ApiFactory, tmp_path: Path) -> None:
+    log_path = tmp_path / "outside" / "app.log"
+    log_path.parent.mkdir()
+    log_path.write_text("preview-5xx")
+    api = make_api(model=log_calling_model(), tools=[_read_app_log_tool(log_path)])
+
+    outcome = run_turn(api, conversation_id=str(uuid4()), prompt="read the app log")
+    returned = _tool_return_payloads(api)
+
+    assert "TOOL_CALL_RESULT" in outcome.event_types
+    assert outcome.reply == "log-consumed"
+    assert returned
+    parsed = _as_result(returned[0])
+    assert parsed["status"] == "ok"
+    assert parsed["content"] == "preview-5xx"
+    assert parsed["truncated"] is False
+
+
+def test_a_run_reports_no_log_without_failing(make_api: ApiFactory, tmp_path: Path) -> None:
+    log_path = tmp_path / "outside" / "app.log"
+    log_path.parent.mkdir()
+    api = make_api(model=log_calling_model(), tools=[_read_app_log_tool(log_path)])
+
+    outcome = run_turn(api, conversation_id=str(uuid4()))
+    returned = _tool_return_payloads(api)
+
+    assert outcome.reply == "log-consumed"
+    parsed = _as_result(returned[0])
+    assert parsed["status"] == "empty"
+    assert parsed["content"] == NO_LOG_MESSAGE

--- a/app-spark/agent/tests/api/test_health.py
+++ b/app-spark/agent/tests/api/test_health.py
@@ -72,7 +72,7 @@ def test_readiness_requires_url_and_listed_model(
 def test_a_missing_token_is_reported_as_unready(api: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     """用户态 token 和兼容回落密钥都空，才算没有 access_token。"""
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
 
     reported: dict[str, Any] = api.get("/health").json()
 
@@ -85,7 +85,7 @@ def test_aidev_access_token_is_enough_when_the_api_key_is_absent(
 ) -> None:
     """用户态 token 是正门；MODEL_API_KEY 只是兼容回落。"""
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-access-token")
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", "user-access-token")
 
     reported: dict[str, Any] = api.get("/health").json()
 
@@ -96,7 +96,7 @@ def test_a_fake_model_is_ready_without_an_api_key(api: TestClient, monkeypatch: 
     """The deterministic fake model never calls a provider and therefore needs no credential."""
     monkeypatch.setattr(settings, "MODEL", "fake:write-file")
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
 
     reported: dict[str, Any] = api.get("/health").json()
 

--- a/app-spark/agent/tests/api/test_health.py
+++ b/app-spark/agent/tests/api/test_health.py
@@ -1,4 +1,4 @@
-"""``GET /health``: the single call a control plane polls the Runtime with.
+"""GET /health: the single call a control plane polls the Runtime with.
 
 Everything it reports is a cursor into something a client can fetch in full elsewhere, so the
 interesting assertion is not the shape of the document but that its numbers agree with the
@@ -47,37 +47,56 @@ def test_every_reported_cursor_matches_the_endpoint_it_points_at(api: TestClient
     assert reported["running"] is False
 
 
-@pytest.mark.parametrize("missing", ["MODEL_NAME", "MODEL_BASE_URL"])
-def test_readiness_is_latched_only_by_the_api_key(
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("MODEL_NAME", ""),
+        ("MODEL_NAME", "not-a-listed-model"),
+        ("MODEL_BASE_URL", ""),
+    ],
+)
+def test_readiness_requires_url_and_listed_model(
     api: TestClient,
     monkeypatch: pytest.MonkeyPatch,
-    missing: str,
+    field: str,
+    value: str,
 ) -> None:
-    """The model name and base URL are carried for a later caller, not gates on serving a run.
-
-    Reporting the Runtime unready for a missing name would stall the sandbox on a condition it
-    cannot fix and that stops nothing it currently does.
-    """
-    monkeypatch.setattr(settings, missing, "")
-
-    reported: dict[str, Any] = api.get("/health").json()
-
-    assert reported["model_ready"] is True
-
-
-def test_a_missing_api_key_is_reported_as_unready(api: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
-    """The one condition that must never be reported as ready."""
-    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    """网关地址和对照表内模型名缺一不可；表外名称不得假装就绪。"""
+    monkeypatch.setattr(settings, field, value)
 
     reported: dict[str, Any] = api.get("/health").json()
 
     assert reported["model_ready"] is False
 
 
+def test_a_missing_token_is_reported_as_unready(api: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """用户态 token 和兼容回落密钥都空，才算没有 access_token。"""
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+
+    reported: dict[str, Any] = api.get("/health").json()
+
+    assert reported["model_ready"] is False
+
+
+def test_aidev_access_token_is_enough_when_the_api_key_is_absent(
+    api: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """用户态 token 是正门；MODEL_API_KEY 只是兼容回落。"""
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-access-token")
+
+    reported: dict[str, Any] = api.get("/health").json()
+
+    assert reported["model_ready"] is True
+
+
 def test_a_fake_model_is_ready_without_an_api_key(api: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     """The deterministic fake model never calls a provider and therefore needs no credential."""
     monkeypatch.setattr(settings, "MODEL", "fake:write-file")
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
 
     reported: dict[str, Any] = api.get("/health").json()
 

--- a/app-spark/agent/tests/api/test_run.py
+++ b/app-spark/agent/tests/api/test_run.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 
 from app_spark_agent import settings
 from tests.api.support import (
+    ApiFactory,
     get_transcript_messages,
     post_run_async,
     run_in_flight,
@@ -21,6 +22,7 @@ from tests.api.support import (
     run_turn,
 )
 from tests.support.ag_ui import SSE_HEADERS, run_body
+from tests.support.fake_models import failing_model
 
 
 def test_a_run_streams_the_reply_as_ag_ui_events(api: TestClient) -> None:
@@ -204,6 +206,7 @@ def test_runs_rejects_bad_token(api: TestClient, headers: dict[str, str]) -> Non
 
 def test_runs_model_not_ready_503(api: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
     resp = api.post(
         "/runs",
         headers=SSE_HEADERS,
@@ -226,3 +229,37 @@ def test_control_plane_without_bearer_is_401(api: TestClient) -> None:
 def test_no_independent_cancel_route(api: TestClient) -> None:
     paths = [getattr(route, "path", "") for route in api.app.routes]
     assert not any("cancel" in path for path in paths)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("MODEL_NAME", "not-a-listed-model"), ("MODEL_BASE_URL", "")],
+)
+def test_runs_rejects_an_unready_listed_model_gate(
+    api: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: str,
+) -> None:
+    monkeypatch.setattr(settings, field, value)
+
+    resp = api.post(
+        "/runs",
+        headers=SSE_HEADERS,
+        json=run_body(conversation_id=str(uuid4()), run_id=str(uuid4()), context_version=0),
+    )
+
+    assert resp.status_code == 503
+    assert api.get("/health").json()["model_ready"] is False
+
+
+def test_a_failed_run_does_not_clear_readiness(make_api: ApiFactory) -> None:
+    """中途模型失败只让该次 run 失败，不得把随后的 model_ready 改成 false。"""
+    api = make_api(model=failing_model())
+
+    resp = run_request(api, conversation_id=str(uuid4()), context_version=0)
+    health = api.get("/health").json()
+
+    assert resp.status_code != 503
+    assert health["model_ready"] is True
+    assert health["running"] is False

--- a/app-spark/agent/tests/api/test_run.py
+++ b/app-spark/agent/tests/api/test_run.py
@@ -206,7 +206,7 @@ def test_runs_rejects_bad_token(api: TestClient, headers: dict[str, str]) -> Non
 
 def test_runs_model_not_ready_503(api: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     resp = api.post(
         "/runs",
         headers=SSE_HEADERS,

--- a/app-spark/agent/tests/api/test_secret_masking.py
+++ b/app-spark/agent/tests/api/test_secret_masking.py
@@ -74,7 +74,7 @@ def test_a_refused_run_names_no_credential(api: TestClient, monkeypatch: pytest.
     conflict = run_request(api, conversation_id=str(uuid4()), context_version=0)
 
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     unready = run_request(api, conversation_id=str(uuid4()), context_version=0)
 
     assert conflict.status_code == 409, conflict.text

--- a/app-spark/agent/tests/api/test_secret_masking.py
+++ b/app-spark/agent/tests/api/test_secret_masking.py
@@ -74,6 +74,7 @@ def test_a_refused_run_names_no_credential(api: TestClient, monkeypatch: pytest.
     conflict = run_request(api, conversation_id=str(uuid4()), context_version=0)
 
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
     unready = run_request(api, conversation_id=str(uuid4()), context_version=0)
 
     assert conflict.status_code == 409, conflict.text

--- a/app-spark/agent/tests/bkaidev/test_auth.py
+++ b/app-spark/agent/tests/bkaidev/test_auth.py
@@ -1,0 +1,49 @@
+"""出站鉴权头只允许 access_token，不能夹带应用凭证。"""
+
+import json
+
+import httpx2
+import pytest
+
+from app_spark_agent.bkaidev.auth import (
+    BKAPI_AUTHORIZATION_HEADER,
+    WithoutAuthorization,
+    authorization_headers,
+    authorization_payload,
+)
+
+
+def test_authorization_payload_contains_only_access_token() -> None:
+    payload = authorization_payload("  user-token  ")
+
+    assert payload == {"access_token": "user-token"}
+    assert set(payload) == {"access_token"}
+
+
+def test_authorization_header_is_compact_json() -> None:
+    headers = authorization_headers("user-token")
+
+    assert headers == {BKAPI_AUTHORIZATION_HEADER: '{"access_token":"user-token"}'}
+    parsed = json.loads(headers[BKAPI_AUTHORIZATION_HEADER])
+    assert "bk_app_code" not in parsed
+    assert "bk_app_secret" not in parsed
+
+
+@pytest.mark.parametrize("token", ["", "   "])
+def test_empty_access_token_is_rejected(token: str) -> None:
+    with pytest.raises(ValueError, match="access_token"):
+        authorization_payload(token)
+
+
+async def test_without_authorization_strips_bearer() -> None:
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        seen.update({key.lower(): value for key, value in request.headers.items()})
+        return httpx2.Response(200, json={"ok": True})
+
+    transport = WithoutAuthorization(httpx2.MockTransport(handler))
+    async with httpx2.AsyncClient(transport=transport) as client:
+        await client.get("https://gw.test/v1/models", headers={"Authorization": "Bearer empty"})
+
+    assert "authorization" not in seen

--- a/app-spark/agent/tests/bkaidev/test_client.py
+++ b/app-spark/agent/tests/bkaidev/test_client.py
@@ -1,0 +1,103 @@
+"""AidevApiClient 打到正确的 OpenAPI 路径，并带上 access_token 头。"""
+
+import json
+
+import httpx
+import pytest
+
+from app_spark_agent.bkaidev.auth import BKAPI_AUTHORIZATION_HEADER
+from app_spark_agent.bkaidev.client import AidevApiClient, AidevApiError
+from app_spark_agent.bkaidev.types import ChatCompletionMessage, ChatCompletionRequest
+
+
+def _router(request: httpx.Request) -> httpx.Response:
+    auth = json.loads(request.headers[BKAPI_AUTHORIZATION_HEADER])
+    assert auth == {"access_token": "user-token"}
+    assert "authorization" not in {key.lower() for key in request.headers}
+    assert "bk_app_secret" not in auth
+
+    if request.method == "GET" and request.url.path.endswith("/models"):
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {
+                        "id": "deepseek-v4-flash",
+                        "object": "model",
+                        "created": 1,
+                        "owned_by": "aidev",
+                    }
+                ],
+            },
+        )
+    if request.method == "POST" and request.url.path.endswith("/chat/completions"):
+        body = json.loads(request.content)
+        assert body["model"] == "deepseek-v4-flash"
+        assert body["messages"][0]["role"] == "user"
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-1",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "deepseek-v4-flash",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+    if request.url.path.endswith("/denied"):
+        return httpx.Response(403, json={"error": {"message": "该应用无访问该模型的权限", "code": 40301}})
+    return httpx.Response(404, text="missing")
+
+
+@pytest.fixture
+def client() -> AidevApiClient:
+    return AidevApiClient(
+        base_url="https://bkaidev.test/prod/openapi/aidev/gateway/llm/v1",
+        access_token="user-token",
+        transport=httpx.MockTransport(_router),
+    )
+
+
+async def test_list_models_uses_openai_compatible_path(client: AidevApiClient) -> None:
+    listed = await client.list_models()
+
+    assert [card.llm_code for card in listed.data] == ["deepseek-v4-flash"]
+    assert listed.object_type == "list"
+    assert listed.data[0].model_dump(by_alias=True)["id"] == "deepseek-v4-flash"
+
+
+async def test_create_chat_completion_round_trips(client: AidevApiClient) -> None:
+    response = await client.create_chat_completion(
+        ChatCompletionRequest(
+            model="deepseek-v4-flash",
+            messages=[ChatCompletionMessage(role="user", content="hello")],
+        )
+    )
+
+    assert response.choices[0].message.content == "ok"
+    assert response.choices[0].finish_reason == "stop"
+
+
+async def test_gateway_error_is_typed() -> None:
+    async def deny(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"error": {"message": "该应用无访问该模型的权限", "code": 40301}})
+
+    client = AidevApiClient(
+        base_url="https://bkaidev.test/v1",
+        access_token="user-token",
+        transport=httpx.MockTransport(deny),
+    )
+
+    with pytest.raises(AidevApiError, match="该应用无访问该模型的权限") as exc_info:
+        await client.list_models()
+
+    assert exc_info.value.status_code == 403
+    assert "user-token" not in str(exc_info.value)

--- a/app-spark/agent/tests/bkaidev/test_messages.py
+++ b/app-spark/agent/tests/bkaidev/test_messages.py
@@ -1,0 +1,72 @@
+"""可信历史到 OpenAI messages 的映射，含工具调用。"""
+
+import pytest
+from pydantic_ai.messages import (
+    InstructionPart,
+    ModelRequest,
+    ModelResponse,
+    RetryPromptPart,
+    SystemPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from app_spark_agent.bkaidev.messages import openai_messages_from_model_messages
+
+
+def test_request_and_response_parts_map_to_openai_roles() -> None:
+    messages = openai_messages_from_model_messages(
+        [
+            ModelRequest(parts=[SystemPromptPart(content="sys"), UserPromptPart(content="hi")]),
+            ModelResponse(
+                parts=[
+                    TextPart(content="call it"),
+                    ToolCallPart(tool_name="read_file", args={"path": "a.py"}, tool_call_id="call_1"),
+                ],
+                model_name="deepseek-v4-flash",
+            ),
+            ModelRequest(parts=[ToolReturnPart(tool_name="read_file", content="print(1)", tool_call_id="call_1")]),
+        ]
+    )
+
+    assert [item.role for item in messages] == ["system", "user", "assistant", "tool"]
+    assert messages[2].tool_calls is not None
+    assert messages[2].tool_calls[0].tool_call_id == "call_1"
+    assert messages[2].tool_calls[0].function.name == "read_file"
+    assert messages[2].tool_calls[0].model_dump(by_alias=True)["id"] == "call_1"
+    assert messages[2].tool_calls[0].model_dump(by_alias=True)["type"] == "function"
+    assert messages[3].tool_call_id == "call_1"
+    assert messages[3].content == "print(1)"
+
+
+def test_retry_prompt_pairs_with_the_tool_call() -> None:
+    messages = openai_messages_from_model_messages(
+        [
+            ModelResponse(
+                parts=[ToolCallPart(tool_name="read_file", args={"path": "a.py"}, tool_call_id="call_1")],
+                model_name="deepseek-v4-flash",
+            ),
+            ModelRequest(
+                parts=[
+                    RetryPromptPart(
+                        content="path is required",
+                        tool_name="read_file",
+                        tool_call_id="call_1",
+                    )
+                ]
+            ),
+        ]
+    )
+
+    assert [item.role for item in messages] == ["assistant", "tool"]
+    assert messages[1].tool_call_id == "call_1"
+    assert messages[1].name == "read_file"
+    assert messages[1].content is not None
+    assert "path is required" in messages[1].content
+
+
+def test_unknown_request_parts_are_rejected() -> None:
+    with pytest.raises(TypeError, match="unsupported model request part"):
+        openai_messages_from_model_messages([ModelRequest(parts=[InstructionPart(content="skill")])])

--- a/app-spark/agent/tests/bkaidev/test_session.py
+++ b/app-spark/agent/tests/bkaidev/test_session.py
@@ -1,0 +1,121 @@
+"""对话中间层从 context.json 取历史，不从 log.jsonl 拼消息。"""
+
+import json
+from uuid import uuid4
+
+import httpx
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+
+from app_spark_agent.bkaidev.client import AidevApiClient
+from app_spark_agent.bkaidev.session import ConversationSession
+from app_spark_agent.bkaidev.types import ChatCompletionMessage
+from app_spark_agent.state import AppendLog, ContextStore, ConversationContext
+
+
+def _stores(tmp_path):
+    context_store = ContextStore(tmp_path / "context.json")
+    transcript = AppendLog(tmp_path / "log.jsonl", payload_key="message")
+    ui_events = AppendLog(tmp_path / "ui_events.jsonl", payload_key="event")
+    return context_store, transcript, ui_events
+
+
+async def test_history_comes_from_context_not_transcript(tmp_path) -> None:
+    conversation_id = str(uuid4())
+    context_store, transcript, ui_events = _stores(tmp_path)
+    await context_store.restore(
+        ConversationContext(
+            conversation_id=conversation_id,
+            context_version=1,
+            messages=[
+                ModelRequest(parts=[UserPromptPart(content="hello")], conversation_id=conversation_id),
+                ModelResponse(
+                    parts=[TextPart(content="world")],
+                    model_name="deepseek-v4-flash",
+                    conversation_id=conversation_id,
+                ),
+            ],
+        )
+    )
+    await transcript.append("run-1", [{"kind": "raw-transcript-must-not-be-sent"}])
+    await ui_events.append("run-1", [{"type": "TEXT_MESSAGE_CONTENT"}])
+
+    session = ConversationSession(
+        client=AidevApiClient(
+            base_url="https://bkaidev.test/v1",
+            access_token="user-token",
+            transport=httpx.MockTransport(lambda request: httpx.Response(500)),
+        ),
+        context_store=context_store,
+        transcript=transcript,
+        ui_events=ui_events,
+    )
+
+    history = session.history()
+    cursors = session.cursors
+
+    assert [message.role for message in history] == ["user", "assistant"]
+    assert [message.content for message in history] == ["hello", "world"]
+    assert cursors.conversation_id == conversation_id
+    assert cursors.context_version == 1
+    assert cursors.log_seq == 1
+    assert cursors.ui_event_seq == 1
+
+
+async def test_create_completion_sends_context_plus_extra(tmp_path) -> None:
+    conversation_id = str(uuid4())
+    context_store, transcript, ui_events = _stores(tmp_path)
+    await context_store.restore(
+        ConversationContext(
+            conversation_id=conversation_id,
+            context_version=2,
+            messages=[
+                ModelRequest(parts=[UserPromptPart(content="prior")], conversation_id=conversation_id),
+            ],
+        )
+    )
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-2",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "deepseek-v4-flash",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "next"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    session = ConversationSession(
+        client=AidevApiClient(
+            base_url="https://bkaidev.test/v1",
+            access_token="user-token",
+            transport=httpx.MockTransport(handler),
+        ),
+        context_store=context_store,
+        transcript=transcript,
+        ui_events=ui_events,
+    )
+
+    response = await session.create_completion(
+        [ChatCompletionMessage(role="user", content="now")],
+        model="deepseek-v4-flash",
+    )
+
+    body = seen["body"]
+    assert isinstance(body, dict)
+    assert [item["content"] for item in body["messages"]] == ["prior", "now"]
+    assert response.choices[0].message.content == "next"
+    assert session.context.context_version == 2
+    assert transcript.last_seq == 0
+    assert (tmp_path / "context.json").exists()
+    assert not (tmp_path / "log.jsonl").exists()

--- a/app-spark/agent/tests/e2e/conftest.py
+++ b/app-spark/agent/tests/e2e/conftest.py
@@ -18,4 +18,4 @@ __all__ = ["StartRuntime", "conversation_id", "require_api_key", "start_runtime"
 def require_api_key() -> None:
     """Skip rather than fail when there is no key: these tests spend real money and time."""
     if settings.MODEL.startswith("fake:") or not settings.is_model_ready():
-        pytest.skip("e2e needs AIDEV_ACCESS_TOKEN or MODEL_API_KEY, plus MODEL_NAME and MODEL_BASE_URL")
+        pytest.skip("e2e needs BK_AIDEV_ACCESS_TOKEN or MODEL_API_KEY, plus MODEL_NAME and MODEL_BASE_URL")

--- a/app-spark/agent/tests/e2e/conftest.py
+++ b/app-spark/agent/tests/e2e/conftest.py
@@ -17,5 +17,5 @@ __all__ = ["StartRuntime", "conversation_id", "require_api_key", "start_runtime"
 @pytest.fixture(autouse=True)
 def require_api_key() -> None:
     """Skip rather than fail when there is no key: these tests spend real money and time."""
-    if not settings.MODEL_API_KEY:
-        pytest.skip("APP_SPARK_AGENT_MODEL_API_KEY is required by the live tests")
+    if settings.MODEL.startswith("fake:") or not settings.is_model_ready():
+        pytest.skip("e2e needs AIDEV_ACCESS_TOKEN or MODEL_API_KEY, plus MODEL_NAME and MODEL_BASE_URL")

--- a/app-spark/agent/tests/live/test_fake_model_session.py
+++ b/app-spark/agent/tests/live/test_fake_model_session.py
@@ -61,9 +61,7 @@ def test_a_fake_model_runs_a_real_session_without_an_api_key(
 
     # A scripted model still has to produce a real conversation shape, or the control plane
     # would be reading a stream no live session ever looks like.
-    assert {"user-prompt", "tool-call", "tool-return", "text"} <= part_kinds(
-        model_messages(transcript)
-    )
+    assert {"user-prompt", "tool-call", "tool-return", "text"} <= part_kinds(model_messages(transcript))
     types = [str(event["type"]) for event in stored_events(ui_events)]
     assert types[0] == "RUN_STARTED"
     assert types[-1] == "RUN_FINISHED"

--- a/app-spark/agent/tests/replication/conftest.py
+++ b/app-spark/agent/tests/replication/conftest.py
@@ -40,9 +40,7 @@ class FakeControlPlane:
         believe over its own version number.
     """
 
-    channels: dict[str, list[dict[str, Any]]] = field(
-        default_factory=dict[str, list[dict[str, Any]]]
-    )
+    channels: dict[str, list[dict[str, Any]]] = field(default_factory=dict[str, list[dict[str, Any]]])
     context: dict[str, Any] | None = None
     calls: list[tuple[str, int]] = field(default_factory=list[tuple[str, int]])
     failures: int = 0

--- a/app-spark/agent/tests/state/test_log.py
+++ b/app-spark/agent/tests/state/test_log.py
@@ -230,9 +230,7 @@ async def test_a_based_channel_reopens_with_the_same_base(tmp_path: Path) -> Non
     assert await reopened.append("run-b", [{"n": 2}]) == 42
     # The base is subtracted before counting lines, so seeking past seq 41 lands on the second
     # entry rather than running off the end of a two-line file.
-    assert [record.seq for record in reopened.read_from(reopened.offset_after(41), 10).records] == [
-        42
-    ]
+    assert [record.seq for record in reopened.read_from(reopened.offset_after(41), 10).records] == [42]
 
 
 def test_reopening_a_based_channel_with_the_wrong_base_is_rejected(tmp_path: Path) -> None:

--- a/app-spark/agent/tests/support/fake_models.py
+++ b/app-spark/agent/tests/support/fake_models.py
@@ -19,8 +19,26 @@ def probe(index: int) -> str:
     return f"probe-payload-{index}-{PROBE_PAYLOAD}"
 
 
+def log_calling_model() -> FunctionModel:
+    """Call read_app_log once, then answer after the structured result comes back."""
+    issued = False
+
+    async def stream(
+        messages: list[ModelMessage],
+        info: AgentInfo,
+    ) -> AsyncIterator[str | DeltaToolCalls]:
+        nonlocal issued
+        if not issued:
+            issued = True
+            yield {0: DeltaToolCall(name="read_app_log", json_args="{}", tool_call_id="app-log-1")}
+            return
+        yield "log-consumed"
+
+    return FunctionModel(stream_function=stream)
+
+
 def tool_calling_model(rounds: int) -> FunctionModel:
-    """Build a model that calls ``probe`` ``rounds`` times and then answers with text.
+    """Build a model that calls probe rounds times and then answers with text.
 
     The remaining rounds are tracked in the closure rather than counted from the history: a
     compaction tier that drops or blanks the earlier turns would otherwise reset the count and
@@ -50,7 +68,7 @@ def tool_calling_model(rounds: int) -> FunctionModel:
 
 
 def text_model(chunks: Sequence[str]) -> FunctionModel:
-    """Build a model that streams ``chunks`` as one assistant message."""
+    """Build a model that streams chunks as one assistant message."""
 
     async def stream(
         messages: list[ModelMessage],
@@ -85,11 +103,11 @@ def failing_model(*, message: str = "synthetic model failure") -> FunctionModel:
 
 
 def tool_then_fail_model(*, tool_rounds: int = 2) -> FunctionModel:
-    """Call ``probe`` ``tool_rounds`` times, then raise so the run ends unsuccessfully.
+    """Call probe tool_rounds times, then raise so the run ends unsuccessfully.
 
     Used to leave a mid-run compaction on disk: the tool rounds succeed and may
     persist a compacted context, then the next request blows up before
-    ``on_complete``.
+    on_complete.
     """
     issued = 0
 
@@ -114,7 +132,7 @@ def tool_then_fail_model(*, tool_rounds: int = 2) -> FunctionModel:
 
 
 def gated_model(gate: asyncio.Event, *, reply: str = "done") -> FunctionModel:
-    """Build a model that holds its response open until ``gate`` is set.
+    """Build a model that holds its response open until gate is set.
 
     A run occupies the Runtime for exactly as long as its model keeps producing output, so this
     is what lets a test send a request *while* a run is in flight rather than after it ended.

--- a/app-spark/agent/tests/support/live.py
+++ b/app-spark/agent/tests/support/live.py
@@ -130,9 +130,7 @@ class LiveRuntime:
         """
         headers = {"If-Match": if_match} if if_match is not None else {}
         params = {
-            name: value
-            for name, value in (("log_seq", log_seq), ("ui_event_seq", ui_event_seq))
-            if value is not None
+            name: value for name, value in (("log_seq", log_seq), ("ui_event_seq", ui_event_seq)) if value is not None
         }
         response = self._client.put("/context", json=context, headers=headers, params=params)
         described = " ".join(

--- a/app-spark/agent/tests/test_agent.py
+++ b/app-spark/agent/tests/test_agent.py
@@ -3,10 +3,12 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, cast
 
+import httpx2
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.models.function import FunctionModel
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai_harness import (
     ClampOversizedMessages,
@@ -22,7 +24,14 @@ from pydantic_ai_harness.shell import LLM_API_KEY_ENV_PATTERNS
 from pytest import MonkeyPatch
 
 from app_spark_agent import settings
-from app_spark_agent.agent import build_compaction, build_model, create_agent, file_read_key
+from app_spark_agent.agent import (
+    _build_gateway_model,
+    build_compaction,
+    build_model,
+    create_agent,
+    file_read_key,
+)
+from app_spark_agent.bkaidev.auth import BKAPI_AUTHORIZATION_HEADER, OPENAI_API_KEY_PLACEHOLDER
 
 
 def test_create_agent_scopes_tools_to_workspace(
@@ -30,6 +39,8 @@ def test_create_agent_scopes_tools_to_workspace(
     monkeypatch: MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(settings, "MODEL_API_KEY", "not-used-by-this-test")
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
 
     agent = create_agent(tmp_path)
 
@@ -56,10 +67,22 @@ def test_create_agent_scopes_tools_to_workspace(
     assert repo_context.nested_traversal is True
     assert tuple(repo_context.filenames) == ("AGENTS.md",)
     assert any(isinstance(item, TieredCompaction) for item in capabilities)
+    log_tool = function_tools(agent)["read_app_log"]
+    assert log_tool.function_schema.json_schema["properties"] == {}
+
+
+def function_tools(agent: Agent[None, str]) -> dict[str, Any]:
+    """Return the function tools registered on agent, keyed by name."""
+    tools: dict[str, Any] = {}
+    for toolset in agent.toolsets:
+        registered = getattr(toolset, "tools", None)
+        if isinstance(registered, dict):
+            tools.update(registered)
+    return tools
 
 
 def denied(name: str, patterns: Sequence[str]) -> bool:
-    """Whether a subprocess would inherit ``name``, decided the way the harness decides it."""
+    """Whether a subprocess would inherit name, decided the way the harness decides it."""
     return any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
 
 
@@ -71,6 +94,7 @@ def shell_of(agent: Agent[None, str]) -> Shell:
     "name",
     [
         "APP_SPARK_AGENT_MODEL_API_KEY",
+        "APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN",
         "APP_SPARK_AGENT_RUNTIME_TOKEN",
     ],
 )
@@ -100,6 +124,8 @@ def provider_key_of(model: Any) -> str:
 def test_the_injected_contract_key_reaches_the_provider(monkeypatch: MonkeyPatch) -> None:
     """`APP_SPARK_AGENT_MODEL_API_KEY` alone must be enough to start the provider."""
     monkeypatch.setattr(settings, "MODEL_API_KEY", "injected-contract-key")
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
 
     assert provider_key_of(build_model()) == "injected-contract-key"
 
@@ -109,12 +135,100 @@ def test_the_settings_key_reaches_the_provider_when_it_is_not_in_the_environment
 ) -> None:
     """A key that only exists in the settings must still authenticate the provider.
 
-    The value never enters ``os.environ``, so a provider left to read the environment
+    The value never enters os.environ, so a provider left to read the environment
     itself would come up empty.
     """
     monkeypatch.setattr(settings, "MODEL_API_KEY", "key-only-in-settings")
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
 
     assert provider_key_of(build_model()) == "key-only-in-settings"
+
+
+def test_gateway_model_uses_access_token_header_not_bearer(monkeypatch: MonkeyPatch) -> None:
+    """bkaidev 过网关靠 X-Bkapi-Authorization；OpenAI api_key 只填占位 empty。"""
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-access-token")
+    monkeypatch.setattr(settings, "MODEL_API_KEY", "must-not-become-bearer")
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "https://bkaidev.test/prod/openapi/aidev/gateway/llm/v1")
+    monkeypatch.setattr(settings, "MODEL_NAME", "deepseek-v4-flash")
+
+    model = build_model()
+    client = cast(Any, model).client
+    headers = {key.lower(): value for key, value in dict(client.default_headers).items()}
+
+    assert isinstance(model, OpenAIChatModel)
+    assert model.model_name == "deepseek-v4-flash"
+    assert model.profile["supports_tools"] is True
+    assert model.profile["supports_json_schema_output"] is True
+    assert client.api_key == OPENAI_API_KEY_PLACEHOLDER
+    assert headers[BKAPI_AUTHORIZATION_HEADER.lower()] == '{"access_token":"user-access-token"}'
+    assert "authorization" not in headers
+    assert "must-not-become-bearer" not in headers[BKAPI_AUTHORIZATION_HEADER.lower()]
+    assert "bk_app_code" not in headers[BKAPI_AUTHORIZATION_HEADER.lower()]
+    assert "bk_app_secret" not in headers[BKAPI_AUTHORIZATION_HEADER.lower()]
+
+
+async def test_gateway_request_omits_bearer_authorization(monkeypatch: MonkeyPatch) -> None:
+    """OpenAI SDK 会自动加 Bearer；出站必须剥掉，只留 X-Bkapi-Authorization。"""
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-access-token")
+    monkeypatch.setattr(settings, "MODEL_API_KEY", "must-not-become-bearer")
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        captured.update({key.lower(): value for key, value in request.headers.items()})
+        return httpx2.Response(
+            200,
+            json={
+                "id": "chatcmpl-1",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "deepseek-v4-flash",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    profile = settings.openai_capability_profile("deepseek-v4-flash")
+    assert profile is not None
+    model = _build_gateway_model(
+        "deepseek-v4-flash",
+        "https://bkaidev.test/v1",
+        "user-access-token",
+        profile=profile,
+        transport=httpx2.MockTransport(handler),
+    )
+    await model.client.chat.completions.create(
+        model="deepseek-v4-flash",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert "authorization" not in captured
+    assert captured[BKAPI_AUTHORIZATION_HEADER.lower()] == '{"access_token":"user-access-token"}'
+    assert "must-not-become-bearer" not in captured[BKAPI_AUTHORIZATION_HEADER.lower()]
+
+
+def test_incomplete_gateway_settings_do_not_infer_a_public_provider(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """AIDEV 已注入但网关地址缺失时，不得回落到官网 DeepSeek。"""
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-access-token")
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
+    monkeypatch.setattr(settings, "MODEL_NAME", "deepseek-v4-flash")
+
+    model = build_model()
+    agent = create_agent(tmp_path)
+
+    assert isinstance(model, FunctionModel)
+    assert model.model_name == "unready"
+    assert isinstance(agent.model, FunctionModel)
 
 
 def test_compaction_escalates_from_cheap_to_expensive() -> None:

--- a/app-spark/agent/tests/test_agent.py
+++ b/app-spark/agent/tests/test_agent.py
@@ -39,7 +39,7 @@ def test_create_agent_scopes_tools_to_workspace(
     monkeypatch: MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(settings, "MODEL_API_KEY", "not-used-by-this-test")
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
 
     agent = create_agent(tmp_path)
@@ -94,7 +94,7 @@ def shell_of(agent: Agent[None, str]) -> Shell:
     "name",
     [
         "APP_SPARK_AGENT_MODEL_API_KEY",
-        "APP_SPARK_AGENT_AIDEV_ACCESS_TOKEN",
+        "APP_SPARK_AGENT_BK_AIDEV_ACCESS_TOKEN",
         "APP_SPARK_AGENT_RUNTIME_TOKEN",
     ],
 )
@@ -124,7 +124,7 @@ def provider_key_of(model: Any) -> str:
 def test_the_injected_contract_key_reaches_the_provider(monkeypatch: MonkeyPatch) -> None:
     """`APP_SPARK_AGENT_MODEL_API_KEY` alone must be enough to start the provider."""
     monkeypatch.setattr(settings, "MODEL_API_KEY", "injected-contract-key")
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
 
     assert provider_key_of(build_model()) == "injected-contract-key"
@@ -139,7 +139,7 @@ def test_the_settings_key_reaches_the_provider_when_it_is_not_in_the_environment
     itself would come up empty.
     """
     monkeypatch.setattr(settings, "MODEL_API_KEY", "key-only-in-settings")
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
 
     assert provider_key_of(build_model()) == "key-only-in-settings"
@@ -147,7 +147,7 @@ def test_the_settings_key_reaches_the_provider_when_it_is_not_in_the_environment
 
 def test_gateway_model_uses_access_token_header_not_bearer(monkeypatch: MonkeyPatch) -> None:
     """bkaidev 过网关靠 X-Bkapi-Authorization；OpenAI api_key 只填占位 empty。"""
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-access-token")
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", "user-access-token")
     monkeypatch.setattr(settings, "MODEL_API_KEY", "must-not-become-bearer")
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "https://bkaidev.test/prod/openapi/aidev/gateway/llm/v1")
     monkeypatch.setattr(settings, "MODEL_NAME", "deepseek-v4-flash")
@@ -170,7 +170,7 @@ def test_gateway_model_uses_access_token_header_not_bearer(monkeypatch: MonkeyPa
 
 async def test_gateway_request_omits_bearer_authorization(monkeypatch: MonkeyPatch) -> None:
     """OpenAI SDK 会自动加 Bearer；出站必须剥掉，只留 X-Bkapi-Authorization。"""
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-access-token")
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", "user-access-token")
     monkeypatch.setattr(settings, "MODEL_API_KEY", "must-not-become-bearer")
     captured: dict[str, str] = {}
 
@@ -217,8 +217,8 @@ def test_incomplete_gateway_settings_do_not_infer_a_public_provider(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """AIDEV 已注入但网关地址缺失时，不得回落到官网 DeepSeek。"""
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-access-token")
+    """BK_AIDEV 已注入但网关地址缺失时，不得回落到官网 DeepSeek。"""
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", "user-access-token")
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
     monkeypatch.setattr(settings, "MODEL_NAME", "deepseek-v4-flash")

--- a/app-spark/agent/tests/test_app_log.py
+++ b/app-spark/agent/tests/test_app_log.py
@@ -1,4 +1,7 @@
-"""受控应用日志：只读约定文件、截尾 8KB、不碰 workspace / state。"""
+"""用户应用日志：只读约定文件、截尾 8KB、不碰 workspace / state。
+
+这里的应用是用户用自然语言编出来、跑在沙箱里的那个服务，不是 Agent 进程。
+"""
 
 from pathlib import Path
 
@@ -103,7 +106,7 @@ def test_log_content_masks_configured_credentials(
     path.write_text(f"crash token={token}")
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", token)
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     monkeypatch.setattr(settings, "CONTROL_PLANE_TOKEN", None)
 
     result = AppLogReader(path).read()
@@ -139,7 +142,7 @@ def test_the_log_tool_cannot_see_state_and_file_tools_cannot_see_the_log(
     log_path.write_text("app-ok")
     monkeypatch.setattr(settings, "APP_LOG_PATH", log_path)
     monkeypatch.setattr(settings, "MODEL_API_KEY", "not-used-by-this-test")
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
 
     agent = create_agent(workspace, state_dir=state)

--- a/app-spark/agent/tests/test_app_log.py
+++ b/app-spark/agent/tests/test_app_log.py
@@ -1,0 +1,158 @@
+"""受控应用日志：只读约定文件、截尾 8KB、不碰 workspace / state。"""
+
+from pathlib import Path
+
+import pytest
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai_harness import FileSystem
+from pytest import MonkeyPatch
+
+from app_spark_agent import settings
+from app_spark_agent.agent import create_agent
+from app_spark_agent.app_log import NO_LOG_MESSAGE, READ_ERROR_PREFIX, AppLogReader
+from app_spark_agent.masking import SECRET_PLACEHOLDER
+from tests.test_agent import function_tools
+
+
+def test_missing_or_empty_file_is_reported_as_no_log(tmp_path: Path) -> None:
+    missing = AppLogReader(tmp_path / "missing.log")
+    empty_path = tmp_path / "empty.log"
+    empty_path.write_bytes(b"")
+
+    assert missing.read().content == NO_LOG_MESSAGE
+    assert missing.read().status == "empty"
+    assert AppLogReader(empty_path).read().status == "empty"
+    assert AppLogReader(empty_path).read().content == NO_LOG_MESSAGE
+
+
+def test_a_short_file_is_returned_in_full(tmp_path: Path) -> None:
+    path = tmp_path / "app.log"
+    path.write_bytes(b"hello-log")
+
+    result = AppLogReader(path).read()
+
+    assert result.status == "ok"
+    assert result.content == "hello-log"
+    assert result.truncated is False
+    assert result.byte_length == 9
+
+
+def test_an_oversized_file_keeps_the_tail(tmp_path: Path) -> None:
+    path = tmp_path / "app.log"
+    body = b"H" * 100 + b"T" * 8192
+    path.write_bytes(body)
+
+    result = AppLogReader(path).read()
+
+    assert result.status == "ok"
+    assert result.truncated is True
+    assert result.byte_length == settings.APP_LOG_MAX_BYTES
+    assert result.content.encode() == body[-8192:]
+    assert result.content.startswith("T")
+    assert "H" not in result.content
+
+
+def test_an_unreadable_file_is_reported_as_read_failure(tmp_path: Path) -> None:
+    path = tmp_path / "app.log"
+    path.write_text("secret")
+    path.chmod(0)
+
+    try:
+        result = AppLogReader(path).read()
+    finally:
+        path.chmod(0o644)
+
+    assert result.status == "error"
+    assert result.content.startswith(READ_ERROR_PREFIX)
+    assert "secret" not in result.content
+
+
+def test_a_directory_is_reported_as_read_failure(tmp_path: Path) -> None:
+    result = AppLogReader(tmp_path).read()
+
+    assert result.status == "error"
+    assert result.content.startswith(READ_ERROR_PREFIX)
+
+
+def test_a_symlink_into_state_is_reported_as_read_failure(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    state = tmp_path / "state"
+    log_path = tmp_path / "app.log"
+    workspace.mkdir()
+    state.mkdir()
+    marker = "STATE-SECRET-7c1a"
+    (state / "context.json").write_text(marker)
+    log_path.write_text("app-ok")
+    reader = AppLogReader(log_path, workspace=workspace, state_dir=state)
+    log_path.unlink()
+    log_path.symlink_to(state / "context.json")
+
+    result = reader.read()
+
+    assert result.status == "error"
+    assert result.content.startswith(READ_ERROR_PREFIX)
+    assert marker not in result.content
+
+
+def test_log_content_masks_configured_credentials(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    path = tmp_path / "app.log"
+    token = "runtime-token-should-not-reach-the-model"
+    path.write_text(f"crash token={token}")
+    monkeypatch.setattr(settings, "RUNTIME_TOKEN", token)
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "CONTROL_PLANE_TOKEN", None)
+
+    result = AppLogReader(path).read()
+
+    assert result.status == "ok"
+    assert token not in result.content
+    assert SECRET_PLACEHOLDER in result.content
+
+
+def test_the_configured_path_cannot_sit_inside_workspace_or_state(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    state = tmp_path / "state"
+    workspace.mkdir()
+    state.mkdir()
+
+    with pytest.raises(ValueError, match="workspace"):
+        AppLogReader(workspace / "app.log", workspace=workspace, state_dir=state)
+    with pytest.raises(ValueError, match="state"):
+        AppLogReader(state / "context.json", workspace=workspace, state_dir=state)
+
+
+def test_the_log_tool_cannot_see_state_and_file_tools_cannot_see_the_log(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    state = tmp_path / "state"
+    log_path = tmp_path / "app.log"
+    workspace.mkdir()
+    state.mkdir()
+    marker = "STATE-MARKER-9f3c"
+    (state / "context.json").write_text(f'{{"secret": "{marker}"}}')
+    log_path.write_text("app-ok")
+    monkeypatch.setattr(settings, "APP_LOG_PATH", log_path)
+    monkeypatch.setattr(settings, "MODEL_API_KEY", "not-used-by-this-test")
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
+
+    agent = create_agent(workspace, state_dir=state)
+    result = function_tools(agent)["read_app_log"].function()
+
+    assert result.content == "app-ok"
+    assert marker not in result.content
+
+    filesystem = next(item for item in agent.root_capability.capabilities if isinstance(item, FileSystem))
+    toolset = filesystem.get_toolset()
+    inner = getattr(toolset, "wrapped", toolset)
+    while hasattr(inner, "wrapped"):
+        inner = inner.wrapped
+    for outside in (f"../{log_path.name}", str(log_path), f"../{state.name}/context.json"):
+        with pytest.raises((PermissionError, ModelRetry), match="outside"):
+            inner._resolve_path(outside)

--- a/app-spark/agent/tests/test_app_log.py
+++ b/app-spark/agent/tests/test_app_log.py
@@ -55,21 +55,6 @@ def test_an_oversized_file_keeps_the_tail(tmp_path: Path) -> None:
     assert "H" not in result.content
 
 
-def test_an_unreadable_file_is_reported_as_read_failure(tmp_path: Path) -> None:
-    path = tmp_path / "app.log"
-    path.write_text("secret")
-    path.chmod(0)
-
-    try:
-        result = AppLogReader(path).read()
-    finally:
-        path.chmod(0o644)
-
-    assert result.status == "error"
-    assert result.content.startswith(READ_ERROR_PREFIX)
-    assert "secret" not in result.content
-
-
 def test_a_directory_is_reported_as_read_failure(tmp_path: Path) -> None:
     result = AppLogReader(tmp_path).read()
 

--- a/app-spark/agent/tests/test_masking.py
+++ b/app-spark/agent/tests/test_masking.py
@@ -9,23 +9,31 @@ from app_spark_agent.masking import SECRET_PLACEHOLDER, mask_payload, mask_text,
 
 RUNTIME_TOKEN = "runtime-token-0123456789"
 MODEL_API_KEY = "model-api-key-0123456789"
+AIDEV_ACCESS_TOKEN = "aidev-access-token-0123456789"
+CONTROL_PLANE_TOKEN = "control-plane-token-0123456789"
 
 
 @pytest.fixture
 def credentials(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Configure both credentials with distinct values."""
+    """Configure every outbound credential with distinct values."""
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", RUNTIME_TOKEN)
     monkeypatch.setattr(settings, "MODEL_API_KEY", MODEL_API_KEY)
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", AIDEV_ACCESS_TOKEN)
+    monkeypatch.setattr(settings, "CONTROL_PLANE_TOKEN", CONTROL_PLANE_TOKEN)
 
 
 def test_every_configured_credential_is_masked(credentials: None) -> None:
-    text = f"token={RUNTIME_TOKEN} key={MODEL_API_KEY}"
+    text = f"token={RUNTIME_TOKEN} key={MODEL_API_KEY} aidev={AIDEV_ACCESS_TOKEN} cp={CONTROL_PLANE_TOKEN}"
 
     masked = mask_text(text)
 
     assert RUNTIME_TOKEN not in masked
     assert MODEL_API_KEY not in masked
-    assert masked == f"token={SECRET_PLACEHOLDER} key={SECRET_PLACEHOLDER}"
+    assert AIDEV_ACCESS_TOKEN not in masked
+    assert CONTROL_PLANE_TOKEN not in masked
+    assert masked == (
+        f"token={SECRET_PLACEHOLDER} key={SECRET_PLACEHOLDER} aidev={SECRET_PLACEHOLDER} cp={SECRET_PLACEHOLDER}"
+    )
 
 
 def test_key_names_survive_masking(credentials: None) -> None:
@@ -39,6 +47,8 @@ def test_an_unset_credential_masks_nothing(monkeypatch: pytest.MonkeyPatch) -> N
     """An empty value must not turn into a match against every string in sight."""
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", "")
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "CONTROL_PLANE_TOKEN", None)
 
     assert secret_values() == ()
     assert mask_text("nothing to hide") == "nothing to hide"
@@ -54,6 +64,8 @@ def test_the_longest_credential_is_masked_first(monkeypatch: pytest.MonkeyPatch)
     long = f"prefix-{short}-suffix"
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", short)
     monkeypatch.setattr(settings, "MODEL_API_KEY", long)
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "CONTROL_PLANE_TOKEN", None)
 
     assert secret_values() == (long, short)
     assert mask_text(f"value={long}") == f"value={SECRET_PLACEHOLDER}"
@@ -63,6 +75,8 @@ def test_credentials_are_read_per_call(monkeypatch: pytest.MonkeyPatch) -> None:
     """A value captured at import would keep masking whatever the environment held back then."""
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", "first")
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "CONTROL_PLANE_TOKEN", None)
     assert mask_text("first") == SECRET_PLACEHOLDER
 
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", "second")

--- a/app-spark/agent/tests/test_masking.py
+++ b/app-spark/agent/tests/test_masking.py
@@ -9,7 +9,7 @@ from app_spark_agent.masking import SECRET_PLACEHOLDER, mask_payload, mask_text,
 
 RUNTIME_TOKEN = "runtime-token-0123456789"
 MODEL_API_KEY = "model-api-key-0123456789"
-AIDEV_ACCESS_TOKEN = "aidev-access-token-0123456789"
+BK_AIDEV_ACCESS_TOKEN = "aidev-access-token-0123456789"
 CONTROL_PLANE_TOKEN = "control-plane-token-0123456789"
 
 
@@ -18,18 +18,18 @@ def credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     """Configure every outbound credential with distinct values."""
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", RUNTIME_TOKEN)
     monkeypatch.setattr(settings, "MODEL_API_KEY", MODEL_API_KEY)
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", AIDEV_ACCESS_TOKEN)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", BK_AIDEV_ACCESS_TOKEN)
     monkeypatch.setattr(settings, "CONTROL_PLANE_TOKEN", CONTROL_PLANE_TOKEN)
 
 
 def test_every_configured_credential_is_masked(credentials: None) -> None:
-    text = f"token={RUNTIME_TOKEN} key={MODEL_API_KEY} aidev={AIDEV_ACCESS_TOKEN} cp={CONTROL_PLANE_TOKEN}"
+    text = f"token={RUNTIME_TOKEN} key={MODEL_API_KEY} aidev={BK_AIDEV_ACCESS_TOKEN} cp={CONTROL_PLANE_TOKEN}"
 
     masked = mask_text(text)
 
     assert RUNTIME_TOKEN not in masked
     assert MODEL_API_KEY not in masked
-    assert AIDEV_ACCESS_TOKEN not in masked
+    assert BK_AIDEV_ACCESS_TOKEN not in masked
     assert CONTROL_PLANE_TOKEN not in masked
     assert masked == (
         f"token={SECRET_PLACEHOLDER} key={SECRET_PLACEHOLDER} aidev={SECRET_PLACEHOLDER} cp={SECRET_PLACEHOLDER}"
@@ -47,7 +47,7 @@ def test_an_unset_credential_masks_nothing(monkeypatch: pytest.MonkeyPatch) -> N
     """An empty value must not turn into a match against every string in sight."""
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", "")
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     monkeypatch.setattr(settings, "CONTROL_PLANE_TOKEN", None)
 
     assert secret_values() == ()
@@ -64,7 +64,7 @@ def test_the_longest_credential_is_masked_first(monkeypatch: pytest.MonkeyPatch)
     long = f"prefix-{short}-suffix"
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", short)
     monkeypatch.setattr(settings, "MODEL_API_KEY", long)
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     monkeypatch.setattr(settings, "CONTROL_PLANE_TOKEN", None)
 
     assert secret_values() == (long, short)
@@ -75,7 +75,7 @@ def test_credentials_are_read_per_call(monkeypatch: pytest.MonkeyPatch) -> None:
     """A value captured at import would keep masking whatever the environment held back then."""
     monkeypatch.setattr(settings, "RUNTIME_TOKEN", "first")
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     monkeypatch.setattr(settings, "CONTROL_PLANE_TOKEN", None)
     assert mask_text("first") == SECRET_PLACEHOLDER
 

--- a/app-spark/agent/tests/test_settings.py
+++ b/app-spark/agent/tests/test_settings.py
@@ -1,0 +1,84 @@
+"""就绪门闩：token + 网关地址 + 对照表内模型名。"""
+
+import pytest
+from pytest import MonkeyPatch
+
+from app_spark_agent import settings
+
+
+@pytest.fixture
+def ready(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-token")
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    monkeypatch.setattr(settings, "MODEL_NAME", "deepseek-v4-flash")
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "https://bkaidev.test/v1")
+
+
+def test_listed_model_has_an_explicit_profile(ready: None) -> None:
+    profile = settings.openai_capability_profile()
+
+    assert settings.model_profile() == "deepseek"
+    assert settings.is_model_ready() is True
+    assert profile is not None
+    assert profile["supports_tools"] is True
+    assert profile["supports_json_schema_output"] is True
+
+
+def test_unknown_model_has_no_capability_profile(ready: None, monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "MODEL_NAME", "not-a-listed-model")
+
+    assert settings.openai_capability_profile() is None
+
+
+def test_unknown_model_is_not_inferred(ready: None, monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "MODEL_NAME", "some-new-vendor-model")
+
+    assert settings.model_profile() is None
+    assert settings.is_model_ready() is False
+
+
+def test_a_fake_model_is_ready_without_gateway_settings(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "MODEL", "fake:write-file")
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+    monkeypatch.setattr(settings, "MODEL_NAME", "")
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
+
+    assert settings.is_model_ready() is True
+
+
+def test_api_key_is_a_fallback_token(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "MODEL_API_KEY", "legacy-key")
+    monkeypatch.setattr(settings, "MODEL_NAME", "deepseek-v4-flash")
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "https://bkaidev.test/v1")
+
+    assert settings.gateway_access_token() == "legacy-key"
+    assert settings.is_model_ready() is True
+
+
+def test_whitespace_token_falls_back_or_is_unready(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "   ")
+    monkeypatch.setattr(settings, "MODEL_API_KEY", "legacy-key")
+    monkeypatch.setattr(settings, "MODEL_NAME", "deepseek-v4-flash")
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "https://bkaidev.test/v1")
+
+    assert settings.gateway_access_token() == "legacy-key"
+    assert settings.is_model_ready() is True
+
+    monkeypatch.setattr(settings, "MODEL_API_KEY", None)
+
+    assert settings.gateway_access_token() is None
+    assert settings.is_model_ready() is False
+
+
+def test_direct_provider_is_only_for_api_key_without_gateway(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "MODEL_API_KEY", "legacy-key")
+    monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
+
+    assert settings.uses_direct_provider() is True
+
+    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-token")
+
+    assert settings.uses_direct_provider() is False

--- a/app-spark/agent/tests/test_settings.py
+++ b/app-spark/agent/tests/test_settings.py
@@ -8,7 +8,7 @@ from app_spark_agent import settings
 
 @pytest.fixture
 def ready(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-token")
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", "user-token")
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
     monkeypatch.setattr(settings, "MODEL_NAME", "deepseek-v4-flash")
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "https://bkaidev.test/v1")
@@ -39,7 +39,7 @@ def test_unknown_model_is_not_inferred(ready: None, monkeypatch: MonkeyPatch) ->
 
 def test_a_fake_model_is_ready_without_gateway_settings(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "MODEL", "fake:write-file")
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     monkeypatch.setattr(settings, "MODEL_API_KEY", None)
     monkeypatch.setattr(settings, "MODEL_NAME", "")
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
@@ -48,7 +48,7 @@ def test_a_fake_model_is_ready_without_gateway_settings(monkeypatch: MonkeyPatch
 
 
 def test_api_key_is_a_fallback_token(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     monkeypatch.setattr(settings, "MODEL_API_KEY", "legacy-key")
     monkeypatch.setattr(settings, "MODEL_NAME", "deepseek-v4-flash")
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "https://bkaidev.test/v1")
@@ -58,7 +58,7 @@ def test_api_key_is_a_fallback_token(monkeypatch: MonkeyPatch) -> None:
 
 
 def test_whitespace_token_falls_back_or_is_unready(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "   ")
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", "   ")
     monkeypatch.setattr(settings, "MODEL_API_KEY", "legacy-key")
     monkeypatch.setattr(settings, "MODEL_NAME", "deepseek-v4-flash")
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "https://bkaidev.test/v1")
@@ -73,12 +73,12 @@ def test_whitespace_token_falls_back_or_is_unready(monkeypatch: MonkeyPatch) -> 
 
 
 def test_direct_provider_is_only_for_api_key_without_gateway(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", None)
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", None)
     monkeypatch.setattr(settings, "MODEL_API_KEY", "legacy-key")
     monkeypatch.setattr(settings, "MODEL_BASE_URL", "")
 
     assert settings.uses_direct_provider() is True
 
-    monkeypatch.setattr(settings, "AIDEV_ACCESS_TOKEN", "user-token")
+    monkeypatch.setattr(settings, "BK_AIDEV_ACCESS_TOKEN", "user-token")
 
     assert settings.uses_direct_provider() is False


### PR DESCRIPTION
沙箱 Agent 对接 bkaidev 网关：

- 支持用 AIDEV_ACCESS_TOKEN 调模型（没有就回落 MODEL_API_KEY）
- 对照表内模型显式打开 tools / JSON，避免被库按名字关掉
- 配置不齐时进程和 /health 仍能起来，真正跑对话返回 503
- 对话中间层只读现有 context / 游标，不改历史
- 新增 read_app_log，只读约定应用日志尾部