### PR TITLE
fix: 修复 except 分支引用未赋值变量 application 导致 UnboundLocalError

### DIFF
--- a/apiserver/paasng/paasng/platform/smart_app/views.py
+++ b/apiserver/paasng/paasng/platform/smart_app/views.py
@@ -181,7 +181,7 @@ class SMartPackageCreatorViewSet(viewsets.ViewSet):
                     application = handler.handle_app(request.user)
                 except (ControllerError, DescriptionValidationError, BindServicePlanError) as e:
                     # 清理 v2 中创建的应用
-                    cascade_delete_legacy_app("code", application.code, False)
+                    cascade_delete_legacy_app("code", validated_data["code"], False)
                     logger.exception("Create app error !")
                     raise error_codes.FAILED_TO_HANDLE_APP_DESC.f(e.message)
                 else:


### PR DESCRIPTION
### WHY

创建应用失败触发清理时，application 可能尚未赋值（在 handle_app 抛出异常的情况下），直接访问 application.code 会引发 UnboundLocalError，掩盖原始异常。

### HOW
改为使用请求中已解析的 validated_data["code"] 作为待清理应用的标识，避免依赖未绑定变量。