### PR TITLE
fix(paasng): 创建 smart 应用时将 oauth2 client 创建移到事务末尾

### DIFF
--- a/apiserver/paasng/paasng/platform/declarative/application/controller.py
+++ b/apiserver/paasng/paasng/platform/declarative/application/controller.py
@@ -109,7 +109,6 @@ class AppDeclarativeController:
         self.sync_modules(application, desc.modules)
         default_module = application.get_default_module()
 
-        post_create_application.send(sender=self.__class__, application=application)
         # Create market related data after application created, to avoid overwriting market related data
         MarketConfig.objects.create(
             application=application,
@@ -126,12 +125,14 @@ class AppDeclarativeController:
         self.save_description(desc, application, is_creation=True)
 
         # The oauth2 client is created in an external system and cannot be rolled back
-        # toghther with the DB transaction, so create it at the end
+        # together with the DB transaction, so create it at the end
         try:
             create_oauth2_client(application.code, application.app_tenant_mode, application.app_tenant_id)
         except BkOauthClientCodeConflictError:
             logger.warning(f"OAuth2 client code conflict for application {application.code}")
             raise error_codes.CANNOT_CREATE_APP_BKAUTH_CONFLICT.f(code=application.code)
+
+        post_create_application.send(sender=self.__class__, application=application)
         return application
 
     @atomic

--- a/apiserver/paasng/paasng/platform/declarative/application/controller.py
+++ b/apiserver/paasng/paasng/platform/declarative/application/controller.py
@@ -106,12 +106,6 @@ class AppDeclarativeController:
             tenant_id=self.app_tenant_conf.tenant_id,
         )
 
-        try:
-            create_oauth2_client(application.code, application.app_tenant_mode, application.app_tenant_id)
-        except BkOauthClientCodeConflictError:
-            logger.warning(f"OAuth2 client code conflict for application {application.code}")
-            raise error_codes.CANNOT_CREATE_APP_BKAUTH_CONFLICT.f(code=application.code)
-
         self.sync_modules(application, desc.modules)
         default_module = application.get_default_module()
 
@@ -130,6 +124,14 @@ class AppDeclarativeController:
         self.sync_market_fields(application, desc.market)
         self.sync_services_fields(application, desc.modules)
         self.save_description(desc, application, is_creation=True)
+
+        # The oauth2 client is created in an external system and cannot be rolled back
+        # toghther with the DB transaction, so create it at the end
+        try:
+            create_oauth2_client(application.code, application.app_tenant_mode, application.app_tenant_id)
+        except BkOauthClientCodeConflictError:
+            logger.warning(f"OAuth2 client code conflict for application {application.code}")
+            raise error_codes.CANNOT_CREATE_APP_BKAUTH_CONFLICT.f(code=application.code)
         return application
 
     @atomic


### PR DESCRIPTION
### WHY

当租户没有可用集群时，`self.sync_modules` 会报错“无可用集群”，但此时外部 oauth 客户端已建立且没有回滚，该 app_code 变成孤儿 code。

### HOW

将 `create_oauth2_client` 调整到 `perform_create` 事务内的最后一步：所有 DB 写入以及 `post_create_application` 信号处理完成后再触发外部调用。这样 `sync_modules`（无可用集群）或 IAM 初始化失败时，事务回滚且不会留下孤儿 oauth2 client。

说明：`post_create_application` 的触发时机相对旧逻辑后移，现在会在 MarketConfig / 服务绑定 / ApplicationDescription 写入之后发出。当前接收器不依赖“早期空状态”。