### PR TITLE
feat: 开放 cloudapi-v2 网关资源权限申请接口 --story=138114028

### DIFF
--- a/apiserver/paasng/support-files/apigw/api_doc/en/apply_gateway_resource_permission.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/en/apply_gateway_resource_permission.md
@@ -1,0 +1,47 @@
+### Function Description
+Apply for resource permissions of a gateway. Cross-gateway apply is not supported. The response contains an apply record ID; use `list_resource_permission_apply_records` or `retrieve_resource_permission_apply_record` to check approval status.
+
+Recommended flow:
+1. Call `list_gateways` to confirm the gateway
+2. Call `list_gateway_permission_resources` to get resource `id`s
+3. Call `check_is_allowed_apply_by_gateway` to decide `grant_dimension`
+4. Call this API to submit the apply
+
+Apply by resource: `grant_dimension=resource` with `resource_ids`. Apply by gateway: `grant_dimension=api` with an empty `resource_ids` array, and only after the gateway allows it.
+
+### Request Parameters
+
+#### 1. Path Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| app_code | string | Yes | Application ID, e.g. "appid1" |
+| gateway_name | string | Yes | Gateway name, e.g. "paasv3" |
+
+#### 2. Body Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| grant_dimension | string | Yes | Grant dimension: resource / api |
+| expire_days | int | Yes | Validity: 0=permanent, 180=6 months, 360=12 months |
+| resource_ids | array[int] | No | Resource IDs from `list_gateway_permission_resources`. Pass an empty array when applying by gateway |
+| reason | string | No | Apply reason, max 512 characters |
+
+### Request Example
+```bash
+curl -X POST -H 'Content-Type: application/json' -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' -d '{"grant_dimension":"resource","expire_days":180,"resource_ids":[123,456],"reason":"Need paasv3 APIs for deployment"}' --insecure https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/paasv3/permissions/apply/
+```
+
+### Response Example
+```json
+{
+    "record_id": 1001
+}
+```
+
+### Response Fields
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| record_id | int | Apply record ID |
+
+**Status Code Explanation:**
+- **200**: Submitted successfully
+- **400**: Invalid parameters, e.g. applying by gateway is not allowed, or `expire_days` / `grant_dimension` is invalid

--- a/apiserver/paasng/support-files/apigw/api_doc/en/check_is_allowed_apply_by_gateway.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/en/check_is_allowed_apply_by_gateway.md
@@ -1,0 +1,37 @@
+### Function Description
+Check whether applying permission by the whole gateway is allowed.
+
+When `allow_apply_by_gateway=true`, call `apply_gateway_resource_permission` with `grant_dimension=api` and an empty `resource_ids` array. Otherwise apply by resource (`grant_dimension=resource`).
+
+### Request Parameters
+
+#### 1. Path Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| app_code | string | Yes | Application ID, e.g. "appid1" |
+| gateway_name | string | Yes | Gateway name, e.g. "paasv3" |
+
+#### 2. Query Parameters:
+None.
+
+### Request Example
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/paasv3/permissions/allow-apply-by-gateway/
+```
+
+### Response Example
+```json
+{
+    "allow_apply_by_gateway": true,
+    "reason": ""
+}
+```
+
+### Response Fields
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| allow_apply_by_gateway | boolean | Whether applying by the whole gateway is allowed |
+| reason | string | Reason when it is not allowed |
+
+**Status Code Explanation:**
+- **200**: Success

--- a/apiserver/paasng/support-files/apigw/api_doc/en/list_app_resource_permissions.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/en/list_app_resource_permissions.md
@@ -1,0 +1,54 @@
+### Function Description
+List gateway resource permissions already granted to the current application. Use it to avoid duplicate applies, or to find resources that need renewal.
+
+### Request Parameters
+
+#### 1. Path Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| app_code | string | Yes | Application ID, e.g. "appid1" |
+
+#### 2. Query Parameters:
+None.
+
+### Request Example
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/permissions/app-permissions/
+```
+
+### Response Example
+```json
+[
+    {
+        "id": 123,
+        "name": "deploy_with_module",
+        "gateway_name": "paasv3",
+        "gateway_id": 1,
+        "description": "Deploy an app with module",
+        "description_en": "Deploy an app with module",
+        "expires_in": 15552000,
+        "permission_level": "normal",
+        "permission_status": "owned",
+        "permission_action": "renew",
+        "doc_link": ""
+    }
+]
+```
+
+### Response Fields
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| id | int | Resource ID |
+| name | string | Resource name |
+| gateway_name | string | Gateway name |
+| gateway_id | int | Gateway ID |
+| description | string | Resource description |
+| description_en | string | Resource description in English |
+| expires_in | int | Remaining seconds; may be null for permanent grants |
+| permission_level | string | Permission level: unlimited / normal / sensitive / special |
+| permission_status | string | Status: owned / need_apply / pending / expired / rejected |
+| permission_action | string | Next action: apply / renew |
+| doc_link | string | Documentation link |
+
+**Status Code Explanation:**
+- **200**: Success

--- a/apiserver/paasng/support-files/apigw/api_doc/en/list_gateway_permission_resources.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/en/list_gateway_permission_resources.md
@@ -1,0 +1,59 @@
+### Function Description
+List resources of a gateway and the current application's permission status for each resource.
+
+`permission_status` is `owned` / `need_apply` / `pending` / `expired` / `rejected`. `permission_action` is `apply` / `renew`. Filter `need_apply` before applying, or `permission_action=renew` before renewing.
+
+### Request Parameters
+
+#### 1. Path Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| app_code | string | Yes | Application ID, e.g. "appid1" |
+| gateway_name | string | Yes | Gateway name, e.g. "paasv3", from `list_gateways` |
+
+#### 2. Query Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| keyword | string | No | Resource name keyword |
+
+### Request Example
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure 'https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/paasv3/permissions/resources/?keyword=deploy'
+```
+
+### Response Example
+```json
+[
+    {
+        "id": 123,
+        "name": "deploy_with_module",
+        "gateway_name": "paasv3",
+        "gateway_id": 1,
+        "description": "Deploy an app with module",
+        "description_en": "Deploy an app with module",
+        "expires_in": null,
+        "permission_level": "normal",
+        "permission_status": "need_apply",
+        "permission_action": "apply",
+        "doc_link": ""
+    }
+]
+```
+
+### Response Fields
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| id | int | Resource ID, used as `resource_ids` when applying or renewing |
+| name | string | Resource name |
+| gateway_name | string | Gateway name |
+| gateway_id | int | Gateway ID |
+| description | string | Resource description |
+| description_en | string | Resource description in English |
+| expires_in | int | Remaining seconds; may be null when not owned or granted permanently |
+| permission_level | string | Permission level: unlimited / normal / sensitive / special |
+| permission_status | string | Status: owned / need_apply / pending / expired / rejected |
+| permission_action | string | Next action: apply / renew |
+| doc_link | string | Documentation link |
+
+**Status Code Explanation:**
+- **200**: Success

--- a/apiserver/paasng/support-files/apigw/api_doc/en/list_gateways.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/en/list_gateways.md
@@ -1,0 +1,47 @@
+### Function Description
+List available API gateways for permission apply. Use `name` to search by gateway name.
+
+Recommended flow: call this API to get the target gateway `name`, then call `list_gateway_permission_resources` to inspect resources and current permission status.
+
+### Request Parameters
+
+#### 1. Path Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| app_code | string | Yes | Application ID, e.g. "appid1" |
+
+#### 2. Query Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| name | string | No | Gateway name, e.g. "paasv3" |
+| fuzzy | boolean | No | Fuzzy match by name, default true |
+
+### Request Example
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure 'https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/?name=paasv3&fuzzy=true'
+```
+
+### Response Example
+```json
+[
+    {
+        "id": 1,
+        "name": "paasv3",
+        "description": "PaaS 3.0 Developer Center API Gateway",
+        "maintainers": ["admin"],
+        "doc_maintainers": {}
+    }
+]
+```
+
+### Response Fields
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| id | int | Gateway ID |
+| name | string | Gateway name |
+| description | string | Gateway description |
+| maintainers | array | Gateway maintainers |
+| doc_maintainers | object | Document maintainer info |
+
+**Status Code Explanation:**
+- **200**: Success

--- a/apiserver/paasng/support-files/apigw/api_doc/en/list_resource_permission_apply_records.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/en/list_resource_permission_apply_records.md
@@ -1,0 +1,71 @@
+### Function Description
+List gateway resource permission apply records. Use it to check whether an apply is approved. The `record_id` from `apply_gateway_resource_permission` can be passed to `retrieve_resource_permission_apply_record` for details.
+
+### Request Parameters
+
+#### 1. Path Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| app_code | string | Yes | Application ID, e.g. "appid1" |
+
+#### 2. Query Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| applied_by | string | No | Applicant |
+| applied_time_start | int | No | Apply start time, Unix timestamp |
+| applied_time_end | int | No | Apply end time, Unix timestamp |
+| apply_status | string | No | Apply status: pending / approved / rejected / partial_approved |
+| query | string | No | Search keyword |
+| limit | int | No | Page size, default 10 |
+| offset | int | No | Page offset, default 0 |
+
+### Request Example
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure 'https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/permissions/apply-records/?apply_status=pending&limit=10&offset=0'
+```
+
+### Response Example
+```json
+{
+    "count": 1,
+    "results": [
+        {
+            "id": 1001,
+            "bk_app_code": "appid1",
+            "applied_by": "admin",
+            "applied_time": "2026-09-10 12:00:00",
+            "handled_by": [],
+            "handled_time": null,
+            "apply_status": "pending",
+            "apply_status_display": "Pending",
+            "grant_dimension": "resource",
+            "comment": "",
+            "reason": "Need paasv3 APIs for deployment",
+            "expire_days": 180,
+            "gateway_name": "paasv3"
+        }
+    ]
+}
+```
+
+### Response Fields
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| count | int | Total record count |
+| results | array | Apply records |
+| results[].id | int | Apply record ID |
+| results[].bk_app_code | string | Applicant application ID |
+| results[].applied_by | string | Applicant |
+| results[].applied_time | string | Apply time |
+| results[].handled_by | array | Approvers |
+| results[].handled_time | string | Handle time |
+| results[].apply_status | string | Status: pending / approved / rejected / partial_approved |
+| results[].apply_status_display | string | Status display text |
+| results[].grant_dimension | string | Grant dimension: resource / api |
+| results[].comment | string | Approval comment |
+| results[].reason | string | Apply reason |
+| results[].expire_days | int | Requested validity in days |
+| results[].gateway_name | string | Gateway name |
+
+**Status Code Explanation:**
+- **200**: Success

--- a/apiserver/paasng/support-files/apigw/api_doc/en/list_resource_permission_apply_records.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/en/list_resource_permission_apply_records.md
@@ -33,7 +33,7 @@ curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app
             "id": 1001,
             "bk_app_code": "appid1",
             "applied_by": "admin",
-            "applied_time": "2026-09-10 12:00:00",
+            "applied_time": "2024-03-15 12:00:00",
             "handled_by": [],
             "handled_time": null,
             "apply_status": "pending",
@@ -58,7 +58,7 @@ curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app
 | results[].applied_by | string | Applicant |
 | results[].applied_time | string | Apply time |
 | results[].handled_by | array | Approvers |
-| results[].handled_time | string | Handle time |
+| results[].handled_time | string / null | Handle time; null when still pending |
 | results[].apply_status | string | Status: pending / approved / rejected / partial_approved |
 | results[].apply_status_display | string | Status display text |
 | results[].grant_dimension | string | Grant dimension: resource / api |

--- a/apiserver/paasng/support-files/apigw/api_doc/en/renew_resource_permission.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/en/renew_resource_permission.md
@@ -1,0 +1,26 @@
+### Function Description
+Renew granted gateway resource permissions. Resources from different gateways can be renewed in one request. Take `resource_ids` from `list_app_resource_permissions` or from `list_gateway_permission_resources` items whose `permission_action` is `renew`.
+
+### Request Parameters
+
+#### 1. Path Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| app_code | string | Yes | Application ID, e.g. "appid1" |
+
+#### 2. Body Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| resource_ids | array[int] | Yes | Resource IDs to renew, max 100 |
+| expire_days | int | Yes | Renewed validity: 0=permanent, 180=6 months, 360=12 months |
+
+### Request Example
+```bash
+curl -X POST -H 'Content-Type: application/json' -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' -d '{"resource_ids":[123,456],"expire_days":180}' --insecure https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/permissions/renew/
+```
+
+### Response Example
+
+**Status Code Explanation:**
+- **200** / **204**: Renewed successfully (response body may be empty)
+- **400**: Invalid parameters, e.g. the resource cannot be renewed or `expire_days` is invalid

--- a/apiserver/paasng/support-files/apigw/api_doc/en/retrieve_resource_permission_apply_record.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/en/retrieve_resource_permission_apply_record.md
@@ -23,9 +23,9 @@ curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app
     "id": 1001,
     "bk_app_code": "appid1",
     "applied_by": "admin",
-    "applied_time": "2026-09-10 12:00:00",
+    "applied_time": "2024-03-15 12:00:00",
     "handled_by": ["admin"],
-    "handled_time": "2026-09-10 12:10:00",
+    "handled_time": "2024-03-15 12:10:00",
     "apply_status": "approved",
     "apply_status_display": "Approved",
     "grant_dimension": "resource",
@@ -50,7 +50,7 @@ curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app
 | applied_by | string | Applicant |
 | applied_time | string | Apply time |
 | handled_by | array | Approvers |
-| handled_time | string | Handle time |
+| handled_time | string / null | Handle time; null when still pending |
 | apply_status | string | Status: pending / approved / rejected / partial_approved |
 | apply_status_display | string | Status display text |
 | grant_dimension | string | Grant dimension: resource / api |

--- a/apiserver/paasng/support-files/apigw/api_doc/en/retrieve_resource_permission_apply_record.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/en/retrieve_resource_permission_apply_record.md
@@ -1,0 +1,67 @@
+### Function Description
+Get details of a gateway resource permission apply record, including the requested resources and each resource's approval result. `record_id` comes from `apply_gateway_resource_permission` or `list_resource_permission_apply_records`.
+
+### Request Parameters
+
+#### 1. Path Parameters:
+| Parameter Name | Parameter Type | Required | Description |
+| -------------- | -------------- | -------- | ----------- |
+| app_code | string | Yes | Application ID, e.g. "appid1" |
+| record_id | int | Yes | Apply record ID |
+
+#### 2. Query Parameters:
+None.
+
+### Request Example
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/permissions/apply-records/1001/
+```
+
+### Response Example
+```json
+{
+    "id": 1001,
+    "bk_app_code": "appid1",
+    "applied_by": "admin",
+    "applied_time": "2026-09-10 12:00:00",
+    "handled_by": ["admin"],
+    "handled_time": "2026-09-10 12:10:00",
+    "apply_status": "approved",
+    "apply_status_display": "Approved",
+    "grant_dimension": "resource",
+    "comment": "",
+    "reason": "Need paasv3 APIs for deployment",
+    "expire_days": 180,
+    "gateway_name": "paasv3",
+    "resources": [
+        {
+            "name": "deploy_with_module",
+            "apply_status": "approved"
+        }
+    ]
+}
+```
+
+### Response Fields
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| id | int | Apply record ID |
+| bk_app_code | string | Applicant application ID |
+| applied_by | string | Applicant |
+| applied_time | string | Apply time |
+| handled_by | array | Approvers |
+| handled_time | string | Handle time |
+| apply_status | string | Status: pending / approved / rejected / partial_approved |
+| apply_status_display | string | Status display text |
+| grant_dimension | string | Grant dimension: resource / api |
+| comment | string | Approval comment |
+| reason | string | Apply reason |
+| expire_days | int | Requested validity in days |
+| gateway_name | string | Gateway name |
+| resources | array | Resources in this apply |
+| resources[].name | string | Resource name |
+| resources[].apply_status | string | Approval status of this resource |
+
+**Status Code Explanation:**
+- **200**: Success
+- **404**: Apply record not found

--- a/apiserver/paasng/support-files/apigw/api_doc/zh/apply_gateway_resource_permission.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/zh/apply_gateway_resource_permission.md
@@ -1,0 +1,47 @@
+### 功能描述
+申请指定网关的资源权限，不支持跨网关。提交后返回申请记录 ID，可用 `list_resource_permission_apply_records` 或 `retrieve_resource_permission_apply_record` 查询审批结果。
+
+推荐流程：
+1. `list_gateways` 确认网关
+2. `list_gateway_permission_resources` 拿到待申请资源的 `id`
+3. `check_is_allowed_apply_by_gateway` 决定 `grant_dimension`
+4. 调用本接口提交申请
+
+按资源申请：`grant_dimension=resource`，并传入 `resource_ids`。按网关申请：`grant_dimension=api`，`resource_ids` 传空数组，且必须先确认允许按网关申请。
+
+### 请求参数
+
+#### 1、路径参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| app_code | string | 是 | 应用 ID，如 "appid1" |
+| gateway_name | string | 是 | 网关名称，如 "paasv3" |
+
+#### 2、接口参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| grant_dimension | string | 是 | 授权维度：resource=按资源，api=按整个网关 |
+| expire_days | int | 是 | 有效期：0=永久，180=6个月，360=12个月 |
+| resource_ids | array[int] | 否 | 资源 ID 列表，来自 `list_gateway_permission_resources`。按网关申请时传空数组 |
+| reason | string | 否 | 申请原因，最长 512 字符 |
+
+### 请求示例
+```bash
+curl -X POST -H 'Content-Type: application/json' -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' -d '{"grant_dimension":"resource","expire_days":180,"resource_ids":[123,456],"reason":"部署时需要调用 paasv3 接口"}' --insecure https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/paasv3/permissions/apply/
+```
+
+### 返回结果示例
+```json
+{
+    "record_id": 1001
+}
+```
+
+### 返回结果参数说明
+| 字段 | 类型 | 描述 |
+| ---- | ---- | ---- |
+| record_id | int | 申请记录 ID |
+
+**状态码说明：**
+- **200**：提交成功
+- **400**：参数不合法，例如按网关申请但该网关不允许，或 `expire_days` / `grant_dimension` 取值错误

--- a/apiserver/paasng/support-files/apigw/api_doc/zh/check_is_allowed_apply_by_gateway.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/zh/check_is_allowed_apply_by_gateway.md
@@ -1,0 +1,37 @@
+### 功能描述
+检查是否允许按整个网关申请资源权限。
+
+`allow_apply_by_gateway=true` 时，调用 `apply_gateway_resource_permission` 可将 `grant_dimension` 设为 `api`，且 `resource_ids` 传空数组。否则只能按资源申请（`grant_dimension=resource`）。
+
+### 请求参数
+
+#### 1、路径参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| app_code | string | 是 | 应用 ID，如 "appid1" |
+| gateway_name | string | 是 | 网关名称，如 "paasv3" |
+
+#### 2、接口参数：
+暂无。
+
+### 请求示例
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/paasv3/permissions/allow-apply-by-gateway/
+```
+
+### 返回结果示例
+```json
+{
+    "allow_apply_by_gateway": true,
+    "reason": ""
+}
+```
+
+### 返回结果参数说明
+| 字段 | 类型 | 描述 |
+| ---- | ---- | ---- |
+| allow_apply_by_gateway | boolean | 是否允许按整个网关申请 |
+| reason | string | 不允许时的原因 |
+
+**状态码说明：**
+- **200**：查询成功

--- a/apiserver/paasng/support-files/apigw/api_doc/zh/list_app_resource_permissions.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/zh/list_app_resource_permissions.md
@@ -1,0 +1,54 @@
+### 功能描述
+获取当前应用已申请的网关资源权限列表，可用于申请前避免重复提交，或筛选需要续期的资源。
+
+### 请求参数
+
+#### 1、路径参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| app_code | string | 是 | 应用 ID，如 "appid1" |
+
+#### 2、接口参数：
+暂无。
+
+### 请求示例
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/permissions/app-permissions/
+```
+
+### 返回结果示例
+```json
+[
+    {
+        "id": 123,
+        "name": "deploy_with_module",
+        "gateway_name": "paasv3",
+        "gateway_id": 1,
+        "description": "App 部署（支持多模块）",
+        "description_en": "Deploy an app with module",
+        "expires_in": 15552000,
+        "permission_level": "normal",
+        "permission_status": "owned",
+        "permission_action": "renew",
+        "doc_link": ""
+    }
+]
+```
+
+### 返回结果参数说明
+| 字段 | 类型 | 描述 |
+| ---- | ---- | ---- |
+| id | int | 资源 ID |
+| name | string | 资源名称 |
+| gateway_name | string | 所属网关名称 |
+| gateway_id | int | 所属网关 ID |
+| description | string | 资源描述 |
+| description_en | string | 资源英文描述 |
+| expires_in | int | 剩余有效秒数，永久授权时可能为 null |
+| permission_level | string | 权限级别：unlimited / normal / sensitive / special |
+| permission_status | string | 权限状态：owned / need_apply / pending / expired / rejected |
+| permission_action | string | 可执行操作：apply / renew |
+| doc_link | string | 文档链接 |
+
+**状态码说明：**
+- **200**：查询成功

--- a/apiserver/paasng/support-files/apigw/api_doc/zh/list_gateway_permission_resources.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/zh/list_gateway_permission_resources.md
@@ -1,0 +1,59 @@
+### 功能描述
+获取指定网关下的资源列表，以及当前应用对这些资源的权限状态。
+
+`permission_status` 为 `owned` / `need_apply` / `pending` / `expired` / `rejected`；`permission_action` 为 `apply` / `renew`。申请前先筛出 `need_apply` 的资源，续期则筛 `permission_action=renew` 的资源。
+
+### 请求参数
+
+#### 1、路径参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| app_code | string | 是 | 应用 ID，如 "appid1" |
+| gateway_name | string | 是 | 网关名称，如 "paasv3"，来自 `list_gateways` |
+
+#### 2、接口参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| keyword | string | 否 | 资源名称关键字 |
+
+### 请求示例
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure 'https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/paasv3/permissions/resources/?keyword=deploy'
+```
+
+### 返回结果示例
+```json
+[
+    {
+        "id": 123,
+        "name": "deploy_with_module",
+        "gateway_name": "paasv3",
+        "gateway_id": 1,
+        "description": "App 部署（支持多模块）",
+        "description_en": "Deploy an app with module",
+        "expires_in": null,
+        "permission_level": "normal",
+        "permission_status": "need_apply",
+        "permission_action": "apply",
+        "doc_link": ""
+    }
+]
+```
+
+### 返回结果参数说明
+| 字段 | 类型 | 描述 |
+| ---- | ---- | ---- |
+| id | int | 资源 ID，申请/续期时作为 `resource_ids` 传入 |
+| name | string | 资源名称 |
+| gateway_name | string | 所属网关名称 |
+| gateway_id | int | 所属网关 ID |
+| description | string | 资源描述 |
+| description_en | string | 资源英文描述 |
+| expires_in | int | 剩余有效秒数，未拥有或永久授权时可能为 null |
+| permission_level | string | 权限级别：unlimited / normal / sensitive / special |
+| permission_status | string | 权限状态：owned=已拥有，need_apply=未申请，pending=申请中，expired=已过期，rejected=已拒绝 |
+| permission_action | string | 可执行操作：apply=申请，renew=续期 |
+| doc_link | string | 文档链接 |
+
+**状态码说明：**
+- **200**：查询成功

--- a/apiserver/paasng/support-files/apigw/api_doc/zh/list_gateways.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/zh/list_gateways.md
@@ -1,0 +1,47 @@
+### 功能描述
+获取可申请权限的网关列表，可用 `name` 按网关名搜索。
+
+推荐流程：先调用本接口拿到目标网关 `name`，再调用 `list_gateway_permission_resources` 查看该网关下的资源及当前权限状态。
+
+### 请求参数
+
+#### 1、路径参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| app_code | string | 是 | 应用 ID，如 "appid1" |
+
+#### 2、接口参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| name | string | 否 | 网关名称，如 "paasv3" |
+| fuzzy | boolean | 否 | 是否按名称模糊匹配，默认 true |
+
+### 请求示例
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure 'https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/?name=paasv3&fuzzy=true'
+```
+
+### 返回结果示例
+```json
+[
+    {
+        "id": 1,
+        "name": "paasv3",
+        "description": "PaaS3.0 开发者中心 API 网关",
+        "maintainers": ["admin"],
+        "doc_maintainers": {}
+    }
+]
+```
+
+### 返回结果参数说明
+| 字段 | 类型 | 描述 |
+| ---- | ---- | ---- |
+| id | int | 网关 ID |
+| name | string | 网关名称 |
+| description | string | 网关描述 |
+| maintainers | array | 网关维护人 |
+| doc_maintainers | object | 文档维护人信息 |
+
+**状态码说明：**
+- **200**：查询成功

--- a/apiserver/paasng/support-files/apigw/api_doc/zh/list_resource_permission_apply_records.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/zh/list_resource_permission_apply_records.md
@@ -33,7 +33,7 @@ curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app
             "id": 1001,
             "bk_app_code": "appid1",
             "applied_by": "admin",
-            "applied_time": "2026-09-10 12:00:00",
+            "applied_time": "2024-03-15 12:00:00",
             "handled_by": [],
             "handled_time": null,
             "apply_status": "pending",
@@ -58,7 +58,7 @@ curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app
 | results[].applied_by | string | 申请人 |
 | results[].applied_time | string | 申请时间 |
 | results[].handled_by | array | 审批人 |
-| results[].handled_time | string | 处理时间 |
+| results[].handled_time | string / null | 处理时间，待审批时为 null |
 | results[].apply_status | string | 申请状态：pending / approved / rejected / partial_approved |
 | results[].apply_status_display | string | 申请状态展示文案 |
 | results[].grant_dimension | string | 授权维度：resource / api |

--- a/apiserver/paasng/support-files/apigw/api_doc/zh/list_resource_permission_apply_records.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/zh/list_resource_permission_apply_records.md
@@ -1,0 +1,71 @@
+### 功能描述
+获取网关资源权限申请记录，可用于查询申请单是否通过。`apply_gateway_resource_permission` 返回的 `record_id` 可再配合 `retrieve_resource_permission_apply_record` 查看详情。
+
+### 请求参数
+
+#### 1、路径参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| app_code | string | 是 | 应用 ID，如 "appid1" |
+
+#### 2、接口参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| applied_by | string | 否 | 申请人 |
+| applied_time_start | int | 否 | 申请开始时间，Unix 时间戳 |
+| applied_time_end | int | 否 | 申请结束时间，Unix 时间戳 |
+| apply_status | string | 否 | 申请状态：pending / approved / rejected / partial_approved |
+| query | string | 否 | 搜索关键字 |
+| limit | int | 否 | 分页大小，默认 10 |
+| offset | int | 否 | 分页偏移，默认 0 |
+
+### 请求示例
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure 'https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/permissions/apply-records/?apply_status=pending&limit=10&offset=0'
+```
+
+### 返回结果示例
+```json
+{
+    "count": 1,
+    "results": [
+        {
+            "id": 1001,
+            "bk_app_code": "appid1",
+            "applied_by": "admin",
+            "applied_time": "2026-09-10 12:00:00",
+            "handled_by": [],
+            "handled_time": null,
+            "apply_status": "pending",
+            "apply_status_display": "待审批",
+            "grant_dimension": "resource",
+            "comment": "",
+            "reason": "部署时需要调用 paasv3 接口",
+            "expire_days": 180,
+            "gateway_name": "paasv3"
+        }
+    ]
+}
+```
+
+### 返回结果参数说明
+| 字段 | 类型 | 描述 |
+| ---- | ---- | ---- |
+| count | int | 总记录数 |
+| results | array | 申请记录列表 |
+| results[].id | int | 申请记录 ID |
+| results[].bk_app_code | string | 申请的应用 ID |
+| results[].applied_by | string | 申请人 |
+| results[].applied_time | string | 申请时间 |
+| results[].handled_by | array | 审批人 |
+| results[].handled_time | string | 处理时间 |
+| results[].apply_status | string | 申请状态：pending / approved / rejected / partial_approved |
+| results[].apply_status_display | string | 申请状态展示文案 |
+| results[].grant_dimension | string | 授权维度：resource / api |
+| results[].comment | string | 审批意见 |
+| results[].reason | string | 申请原因 |
+| results[].expire_days | int | 申请的有效期天数 |
+| results[].gateway_name | string | 网关名称 |
+
+**状态码说明：**
+- **200**：查询成功

--- a/apiserver/paasng/support-files/apigw/api_doc/zh/renew_resource_permission.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/zh/renew_resource_permission.md
@@ -1,0 +1,26 @@
+### 功能描述
+续期已有网关资源权限，支持跨网关一次续期多个资源。`resource_ids` 来自 `list_app_resource_permissions` 或 `list_gateway_permission_resources` 中 `permission_action=renew` 的资源。
+
+### 请求参数
+
+#### 1、路径参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| app_code | string | 是 | 应用 ID，如 "appid1" |
+
+#### 2、接口参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| resource_ids | array[int] | 是 | 需要续期的资源 ID 列表，最多 100 个 |
+| expire_days | int | 是 | 续期有效期：0=永久，180=6个月，360=12个月 |
+
+### 请求示例
+```bash
+curl -X POST -H 'Content-Type: application/json' -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' -d '{"resource_ids":[123,456],"expire_days":180}' --insecure https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/permissions/renew/
+```
+
+### 返回结果示例
+
+**状态码说明：**
+- **200** / **204**：续期成功（可能无响应体）
+- **400**：参数不合法，例如资源不可续期或 `expire_days` 取值错误

--- a/apiserver/paasng/support-files/apigw/api_doc/zh/retrieve_resource_permission_apply_record.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/zh/retrieve_resource_permission_apply_record.md
@@ -1,0 +1,67 @@
+### 功能描述
+获取网关资源权限申请记录详情，含本次申请的资源及各资源审批结果。`record_id` 来自 `apply_gateway_resource_permission` 或 `list_resource_permission_apply_records`。
+
+### 请求参数
+
+#### 1、路径参数：
+| 参数名称 | 参数类型 | 必须 | 参数说明 |
+| -------- | -------- | ---- | -------- |
+| app_code | string | 是 | 应用 ID，如 "appid1" |
+| record_id | int | 是 | 申请记录 ID |
+
+#### 2、接口参数：
+暂无。
+
+### 请求示例
+```bash
+curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app_secret": "***", "bk_token": "***"}' --insecure https://bkapi.example.com/api/bkpaas3/prod/cloudapi-v2/apps/appid1/inner/gateways/permissions/apply-records/1001/
+```
+
+### 返回结果示例
+```json
+{
+    "id": 1001,
+    "bk_app_code": "appid1",
+    "applied_by": "admin",
+    "applied_time": "2026-09-10 12:00:00",
+    "handled_by": ["admin"],
+    "handled_time": "2026-09-10 12:10:00",
+    "apply_status": "approved",
+    "apply_status_display": "通过",
+    "grant_dimension": "resource",
+    "comment": "",
+    "reason": "部署时需要调用 paasv3 接口",
+    "expire_days": 180,
+    "gateway_name": "paasv3",
+    "resources": [
+        {
+            "name": "deploy_with_module",
+            "apply_status": "approved"
+        }
+    ]
+}
+```
+
+### 返回结果参数说明
+| 字段 | 类型 | 描述 |
+| ---- | ---- | ---- |
+| id | int | 申请记录 ID |
+| bk_app_code | string | 申请的应用 ID |
+| applied_by | string | 申请人 |
+| applied_time | string | 申请时间 |
+| handled_by | array | 审批人 |
+| handled_time | string | 处理时间 |
+| apply_status | string | 申请状态：pending / approved / rejected / partial_approved |
+| apply_status_display | string | 申请状态展示文案 |
+| grant_dimension | string | 授权维度：resource / api |
+| comment | string | 审批意见 |
+| reason | string | 申请原因 |
+| expire_days | int | 申请的有效期天数 |
+| gateway_name | string | 网关名称 |
+| resources | array | 本次申请的资源列表 |
+| resources[].name | string | 资源名称 |
+| resources[].apply_status | string | 该资源的审批状态 |
+
+**状态码说明：**
+- **200**：查询成功
+- **404**：申请记录不存在

--- a/apiserver/paasng/support-files/apigw/api_doc/zh/retrieve_resource_permission_apply_record.md
+++ b/apiserver/paasng/support-files/apigw/api_doc/zh/retrieve_resource_permission_apply_record.md
@@ -23,9 +23,9 @@ curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app
     "id": 1001,
     "bk_app_code": "appid1",
     "applied_by": "admin",
-    "applied_time": "2026-09-10 12:00:00",
+    "applied_time": "2024-03-15 12:00:00",
     "handled_by": ["admin"],
-    "handled_time": "2026-09-10 12:10:00",
+    "handled_time": "2024-03-15 12:10:00",
     "apply_status": "approved",
     "apply_status_display": "通过",
     "grant_dimension": "resource",
@@ -50,7 +50,7 @@ curl -X GET -H 'X-Bkapi-Authorization: {"bk_app_code": "apigw-api-test", "bk_app
 | applied_by | string | 申请人 |
 | applied_time | string | 申请时间 |
 | handled_by | array | 审批人 |
-| handled_time | string | 处理时间 |
+| handled_time | string / null | 处理时间，待审批时为 null |
 | apply_status | string | 申请状态：pending / approved / rejected / partial_approved |
 | apply_status_display | string | 申请状态展示文案 |
 | grant_dimension | string | 授权维度：resource / api |

--- a/apiserver/paasng/support-files/apigw/resources.yaml
+++ b/apiserver/paasng/support-files/apigw/resources.yaml
@@ -2651,3 +2651,390 @@ paths:
           resourcePermissionRequired: true
         descriptionEn:
         noneSchema: true
+  /cloudapi-v2/apps/{app_code}/inner/gateways/:
+    get:
+      operationId: list_gateways
+      description: 获取可申请权限的网关列表，可用 name 按网关名搜索
+      tags:
+      - 云API权限
+      parameters:
+      - in: path
+        name: app_code
+        schema:
+          type: string
+        required: true
+        description: 应用 ID
+      - in: query
+        name: name
+        schema:
+          type: string
+        required: false
+        description: 网关名称，如 paasv3
+      - in: query
+        name: fuzzy
+        schema:
+          type: boolean
+          default: true
+        required: false
+        description: 是否按名称模糊匹配，默认 true
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /{env.BKPAAS_SUB_PATH}backend/api/cloudapi-v2/apps/{app_code}/inner/gateways/
+          matchSubpath: false
+          timeout: 30
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: true
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        descriptionEn: List available API gateways for permission apply
+  /cloudapi-v2/apps/{app_code}/inner/gateways/{gateway_name}/permissions/resources/:
+    get:
+      operationId: list_gateway_permission_resources
+      description: 获取指定网关下的资源列表及当前应用的权限状态。permission_status 为 owned/need_apply/pending/expired/rejected，permission_action 为 apply/renew
+      tags:
+      - 云API权限
+      parameters:
+      - in: path
+        name: app_code
+        schema:
+          type: string
+        required: true
+        description: 应用 ID
+      - in: path
+        name: gateway_name
+        schema:
+          type: string
+        required: true
+        description: 网关名称，如 paasv3
+      - in: query
+        name: keyword
+        schema:
+          type: string
+        required: false
+        description: 资源名称关键字
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /{env.BKPAAS_SUB_PATH}backend/api/cloudapi-v2/apps/{app_code}/inner/gateways/{gateway_name}/permissions/resources/
+          matchSubpath: false
+          timeout: 30
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: true
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        descriptionEn: List gateway resources and current permission status
+  /cloudapi-v2/apps/{app_code}/inner/gateways/{gateway_name}/permissions/allow-apply-by-gateway/:
+    get:
+      operationId: check_is_allowed_apply_by_gateway
+      description: 检查是否允许按整个网关申请权限。allow_apply_by_gateway=true 时，申请接口 grant_dimension 可传 api
+      tags:
+      - 云API权限
+      parameters:
+      - in: path
+        name: app_code
+        schema:
+          type: string
+        required: true
+        description: 应用 ID
+      - in: path
+        name: gateway_name
+        schema:
+          type: string
+        required: true
+        description: 网关名称，如 paasv3
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /{env.BKPAAS_SUB_PATH}backend/api/cloudapi-v2/apps/{app_code}/inner/gateways/{gateway_name}/permissions/allow-apply-by-gateway/
+          matchSubpath: false
+          timeout: 30
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: true
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        descriptionEn: Check whether applying permission by whole gateway is allowed
+  /cloudapi-v2/apps/{app_code}/inner/gateways/{gateway_name}/permissions/apply/:
+    post:
+      operationId: apply_gateway_resource_permission
+      description: 申请网关资源权限。按资源申请时 grant_dimension=resource 并传 resource_ids；按网关申请时 grant_dimension=api 且 resource_ids 传空数组
+      tags:
+      - 云API权限
+      parameters:
+      - in: path
+        name: app_code
+        schema:
+          type: string
+        required: true
+        description: 应用 ID
+      - in: path
+        name: gateway_name
+        schema:
+          type: string
+        required: true
+        description: 网关名称，如 paasv3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - expire_days
+              - grant_dimension
+              properties:
+                resource_ids:
+                  type: array
+                  items:
+                    type: integer
+                  description: 资源 ID 列表，来自 list_gateway_permission_resources。按网关申请时传空数组
+                reason:
+                  type: string
+                  description: 申请原因
+                expire_days:
+                  type: integer
+                  enum:
+                  - 0
+                  - 180
+                  - 360
+                  description: 有效期，0=永久，180=6个月，360=12个月
+                grant_dimension:
+                  type: string
+                  enum:
+                  - resource
+                  - api
+                  description: 授权维度。resource=按资源，api=按整个网关
+        required: true
+        description: ''
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: post
+          path: /{env.BKPAAS_SUB_PATH}backend/api/cloudapi-v2/apps/{app_code}/inner/gateways/{gateway_name}/permissions/apply/
+          matchSubpath: false
+          timeout: 30
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: true
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        descriptionEn: Apply for gateway resource permissions
+  /cloudapi-v2/apps/{app_code}/inner/gateways/permissions/app-permissions/:
+    get:
+      operationId: list_app_resource_permissions
+      description: 获取当前应用已申请的网关资源权限列表
+      tags:
+      - 云API权限
+      parameters:
+      - in: path
+        name: app_code
+        schema:
+          type: string
+        required: true
+        description: 应用 ID
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /{env.BKPAAS_SUB_PATH}backend/api/cloudapi-v2/apps/{app_code}/inner/gateways/permissions/app-permissions/
+          matchSubpath: false
+          timeout: 30
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: true
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        descriptionEn: List granted gateway resource permissions of the app
+  /cloudapi-v2/apps/{app_code}/inner/gateways/permissions/renew/:
+    post:
+      operationId: renew_resource_permission
+      description: 续期已有网关资源权限。resource_ids 来自 list_app_resource_permissions 或 list_gateway_permission_resources 中 permission_action=renew 的资源
+      tags:
+      - 云API权限
+      parameters:
+      - in: path
+        name: app_code
+        schema:
+          type: string
+        required: true
+        description: 应用 ID
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - resource_ids
+              - expire_days
+              properties:
+                resource_ids:
+                  type: array
+                  items:
+                    type: integer
+                  description: 需要续期的资源 ID 列表，最多 100 个
+                expire_days:
+                  type: integer
+                  enum:
+                  - 0
+                  - 180
+                  - 360
+                  description: 续期有效期，0=永久，180=6个月，360=12个月
+        required: true
+        description: ''
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: post
+          path: /{env.BKPAAS_SUB_PATH}backend/api/cloudapi-v2/apps/{app_code}/inner/gateways/permissions/renew/
+          matchSubpath: false
+          timeout: 30
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: true
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        descriptionEn: Renew granted gateway resource permissions
+  /cloudapi-v2/apps/{app_code}/inner/gateways/permissions/apply-records/:
+    get:
+      operationId: list_resource_permission_apply_records
+      description: 获取网关资源权限申请记录，可用于查询申请单是否通过
+      tags:
+      - 云API权限
+      parameters:
+      - in: path
+        name: app_code
+        schema:
+          type: string
+        required: true
+        description: 应用 ID
+      - in: query
+        name: applied_by
+        schema:
+          type: string
+        required: false
+        description: 申请人
+      - in: query
+        name: applied_time_start
+        schema:
+          type: integer
+        required: false
+        description: 申请开始时间，Unix 时间戳
+      - in: query
+        name: applied_time_end
+        schema:
+          type: integer
+        required: false
+        description: 申请结束时间，Unix 时间戳
+      - in: query
+        name: apply_status
+        schema:
+          type: string
+          enum:
+          - pending
+          - approved
+          - rejected
+          - partial_approved
+        required: false
+        description: 申请状态
+      - in: query
+        name: query
+        schema:
+          type: string
+        required: false
+        description: 搜索关键字
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          default: 10
+        required: false
+        description: 分页大小，默认 10
+      - in: query
+        name: offset
+        schema:
+          type: integer
+          default: 0
+        required: false
+        description: 分页偏移，默认 0
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /{env.BKPAAS_SUB_PATH}backend/api/cloudapi-v2/apps/{app_code}/inner/gateways/permissions/apply-records/
+          matchSubpath: false
+          timeout: 30
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: true
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        descriptionEn: List gateway resource permission apply records
+  /cloudapi-v2/apps/{app_code}/inner/gateways/permissions/apply-records/{record_id}/:
+    get:
+      operationId: retrieve_resource_permission_apply_record
+      description: 获取网关资源权限申请记录详情，含本次申请的资源及审批结果
+      tags:
+      - 云API权限
+      parameters:
+      - in: path
+        name: app_code
+        schema:
+          type: string
+        required: true
+        description: 应用 ID
+      - in: path
+        name: record_id
+        schema:
+          type: integer
+        required: true
+        description: 申请记录 ID，来自 apply_gateway_resource_permission 或 list_resource_permission_apply_records
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: false
+        matchSubpath: false
+        enableWebsocket: false
+        backend:
+          name: default
+          method: get
+          path: /{env.BKPAAS_SUB_PATH}backend/api/cloudapi-v2/apps/{app_code}/inner/gateways/permissions/apply-records/{record_id}/
+          matchSubpath: false
+          timeout: 30
+        pluginConfigs: []
+        authConfig:
+          userVerifiedRequired: true
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        descriptionEn: Get gateway resource permission apply record detail


### PR DESCRIPTION
### WHY

把这些接口做成 MCP, 提高申请权限便利性

NOTE: 这些接口设置了无需申请权限，但仍需用户态权限